### PR TITLE
Renamed custom scrollable widget

### DIFF
--- a/examples/cosmic/src/main.rs
+++ b/examples/cosmic/src/main.rs
@@ -22,12 +22,12 @@ use cosmic::{
         radio,
         row,
         slider,
-        text,
-        scrollable
+        text
     },
     iced_lazy::responsive,
     iced_winit::window::drag,
-    WindowMsg
+    WindowMsg,
+    scrollable
 };
 
 pub fn main() -> cosmic::iced::Result {
@@ -259,13 +259,11 @@ impl Application for Window {
             }
 
             widgets.push(
-                scrollable(row![
+                scrollable!(row![
                     horizontal_space(Length::Fill),
                     if self.debug { content.explain(Color::WHITE) } else { content },
                     horizontal_space(Length::Fill),
                 ])
-                .scrollbar_width(8)
-                .scroller_width(8)
                 .into()
             );
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -16,5 +16,5 @@ pub use nav::*;
 mod toggler;
 pub use toggler::*;
 
-mod scrollbar;
-pub use scrollbar::*;
+mod scrollable;
+pub use scrollable::*;

--- a/src/widget/nav.rs
+++ b/src/widget/nav.rs
@@ -9,7 +9,7 @@ use iced::{
 macro_rules! nav_bar {
     ($($x:expr),+ $(,)?) => (
         $crate::iced::widget::Container::new(
-            $crate::scrollbar!(
+            $crate::scrollable!(
                 $crate::iced::widget::row![
                     $crate::iced::widget::Column::with_children(
                         vec![$($crate::iced::Element::from($x)),+]

--- a/src/widget/scrollable.rs
+++ b/src/widget/scrollable.rs
@@ -1,5 +1,5 @@
 #[macro_export]
-macro_rules! scrollbar {
+macro_rules! scrollable {
     ($x:expr) => (
         $crate::iced::widget::scrollable($x)
             .scrollbar_width(8)


### PR DESCRIPTION
- Swapped `iced::widget::scrollable` with `cosmic::scrollable` in existing widgets.
- Renamed macro from `scrollbar` to `scrollable`