### PR TITLE
update: iced & some deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ name = "cosmic"
 [features]
 default = ["wayland"]
 debug = ["iced/debug"]
-wayland = ["iced/wayland"]
-wgpu = ["iced/wgpu"]
+wayland = ["iced/wayland", "iced_glow"]
+wgpu = ["iced/wgpu", "iced_wgpu"]
+tokio = ["iced/tokio"]
 winit = ["iced/winit", "iced_winit"]
 applet = ["cosmic-panel-config", "sctk"]
 
@@ -49,6 +50,11 @@ optional = true
 
 [dependencies.iced_wgpu]
 path = "iced/wgpu"
+optional = true
+
+[dependencies.iced_glow]
+path = "iced/glow"
+optional = true
 
 [workspace]
 members = [
@@ -57,3 +63,4 @@ members = [
 exclude = [
   "iced",
 ]
+

--- a/examples/cosmic-sctk/Cargo.toml
+++ b/examples/cosmic-sctk/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libcosmic = { path = "../..", default-features = false, features = ["debug", "wayland"] }
+libcosmic = { path = "../.." }


### PR DESCRIPTION
This updates iced to the latest version that moves iced_sctk back into pop-os/iced. It also tweaks the features and dependencies a bit