### PR TITLE
Add tokio fieature to iced import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ git = "https://github.com/pop-os/cosmic-theme.git"
 [dependencies.iced]
 path = "iced"
 default-features = false
-features = ["image", "svg"]
+features = ["image", "svg", "tokio"]
 
 [dependencies.iced_core]
 path = "iced/core"


### PR DESCRIPTION
This allows applets to use the `time::every` subscription

I need it for the cosmic time applet.