### PR TITLE
feat: autosized surface support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "iced"]
 	path = iced
 	url = https://github.com/pop-os/iced.git
-	branch = sctk-cosmic
+	branch = master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ winit = ["iced/winit", "iced_winit"]
 applet = ["cosmic-panel-config", "sctk"]
 
 [dependencies]
-freedesktop-icons = {git = "https://github.com/wash2/freedestkop-icons"}
+freedesktop-icons = "0.2.2"
 apply = "0.3.0"
 derive_setters = "0.1.5"
 lazy_static = "1.4.0"


### PR DESCRIPTION
update freedesktop-icons & change iced submodule branch to master.

Auto-sized surfaces are currently only auto-sized on creation but I have a plan to make them resize whenever necessary within the provided limits.