### PR TITLE
feat: implement SegmentedButton widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4.0"
 palette = "0.6.1"
 cosmic-panel-config = {git = "https://github.com/pop-os/cosmic-panel", optional = true, branch = "master_jammy" }
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", optional = true, rev = "73346019952f82ec7e4d4d15f5d66841b54e8b61" }
+slotmap = "1.0.6"
 
 [dependencies.cosmic-theme]
 git = "https://github.com/pop-os/cosmic-theme.git"

--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -1,12 +1,18 @@
 use cosmic::{
-    Element,
-    iced::{Alignment, Length},
     iced::widget::{checkbox, pick_list, progress_bar, radio, row, slider},
-    widget::{button, settings, toggler},
+    iced::{Alignment, Length},
     theme::{Button as ButtonTheme, Theme},
+    widget::{button, segmented_button, settings, toggler},
+    Element,
 };
 
 use super::{Message, Page, Window};
+
+pub enum DemoView {
+    TabA,
+    TabB,
+    TabC,
+}
 
 impl Window {
     pub(super) fn view_demo(&self) -> Element<Message> {
@@ -24,77 +30,107 @@ impl Window {
 
         settings::view_column(vec![
             self.page_title(Page::Demo),
-
-            settings::view_section("Debug")
-                .add(settings::item("Debug theme", choose_theme))
-                .add(settings::item(
-                    "Debug layout",
-                    toggler(None, self.debug, Message::Debug)
-                ))
+            segmented_button(&self.demo_tab_state)
+                .on_activate(Message::DemoTabActivate)
                 .into(),
-
-            settings::view_section("Buttons")
-                .add(settings::item_row(vec![
-                    button(ButtonTheme::Primary)
-                        .text("Primary")
-                        .on_press(Message::ButtonPressed)
+            match self.demo_tab_state.active_data() {
+                None => panic!("no tab is active"),
+                Some(DemoView::TabA) => settings::view_column(vec![
+                    settings::view_section("Debug")
+                        .add(settings::item("Debug theme", choose_theme))
+                        .add(settings::item(
+                            "Debug layout",
+                            toggler(None, self.debug, Message::Debug),
+                        ))
                         .into(),
-                    button(ButtonTheme::Secondary)
-                        .text("Secondary")
-                        .on_press(Message::ButtonPressed)
+                    settings::view_section("Buttons")
+                        .add(settings::item_row(vec![
+                            button(ButtonTheme::Primary)
+                                .text("Primary")
+                                .on_press(Message::ButtonPressed)
+                                .into(),
+                            button(ButtonTheme::Secondary)
+                                .text("Secondary")
+                                .on_press(Message::ButtonPressed)
+                                .into(),
+                            button(ButtonTheme::Positive)
+                                .text("Positive")
+                                .on_press(Message::ButtonPressed)
+                                .into(),
+                            button(ButtonTheme::Destructive)
+                                .text("Destructive")
+                                .on_press(Message::ButtonPressed)
+                                .into(),
+                            button(ButtonTheme::Text)
+                                .text("Text")
+                                .on_press(Message::ButtonPressed)
+                                .into(),
+                        ]))
+                        .add(settings::item_row(vec![
+                            button(ButtonTheme::Primary).text("Primary").into(),
+                            button(ButtonTheme::Secondary).text("Secondary").into(),
+                            button(ButtonTheme::Positive).text("Positive").into(),
+                            button(ButtonTheme::Destructive).text("Destructive").into(),
+                            button(ButtonTheme::Text).text("Text").into(),
+                        ]))
                         .into(),
-                    button(ButtonTheme::Positive)
-                        .text("Positive")
-                        .on_press(Message::ButtonPressed)
+                    settings::view_section("Controls")
+                        .add(settings::item(
+                            "Toggler",
+                            toggler(None, self.toggler_value, Message::TogglerToggled),
+                        ))
+                        .add(settings::item(
+                            "Pick List (TODO)",
+                            pick_list(
+                                vec!["Option 1", "Option 2", "Option 3", "Option 4"],
+                                self.pick_list_selected,
+                                Message::PickListSelected,
+                            )
+                            .padding([8, 0, 8, 16]),
+                        ))
+                        .add(settings::item(
+                            "Slider",
+                            slider(0.0..=100.0, self.slider_value, Message::SliderChanged)
+                                .width(Length::Units(250)),
+                        ))
+                        .add(settings::item(
+                            "Progress",
+                            progress_bar(0.0..=100.0, self.slider_value)
+                                .width(Length::Units(250))
+                                .height(Length::Units(4)),
+                        ))
+                        .add(settings::item_row(vec![checkbox(
+                            "Checkbox",
+                            self.checkbox_value,
+                            Message::CheckboxToggled,
+                        )
+                        .into()]))
+                        .add(settings::item(
+                            format!(
+                                "Spin Button (Range {}:{})",
+                                self.spin_button.min, self.spin_button.max
+                            ),
+                            self.spin_button.view(Message::SpinButton),
+                        ))
                         .into(),
-                    button(ButtonTheme::Destructive)
-                        .text("Destructive")
-                        .on_press(Message::ButtonPressed)
-                        .into(),
-                    button(ButtonTheme::Text)
-                        .text("Text")
-                        .on_press(Message::ButtonPressed)
-                        .into()
-                ]))
-                .add(settings::item_row(vec![
-                    button(ButtonTheme::Primary).text("Primary").into(),
-                    button(ButtonTheme::Secondary).text("Secondary").into(),
-                    button(ButtonTheme::Positive).text("Positive").into(),
-                    button(ButtonTheme::Destructive).text("Destructive").into(),
-                    button(ButtonTheme::Text).text("Text").into(),
-                ]))
+                ])
+                .padding(0)
                 .into(),
-
-            settings::view_section("Controls")
-                .add(settings::item("Toggler", toggler(None, self.toggler_value, Message::TogglerToggled)))
-                .add(settings::item(
-                    "Pick List (TODO)",
-                    pick_list(
-                        vec!["Option 1", "Option 2", "Option 3", "Option 4",],
-                        self.pick_list_selected,
-                        Message::PickListSelected
-                    )
-                    .padding([8, 0, 8, 16])
-                ))
-                .add(settings::item(
-                    "Slider",
-                    slider(0.0..=100.0, self.slider_value, Message::SliderChanged)
-                        .width(Length::Units(250))
-                ))
-                .add(settings::item(
-                    "Progress",
-                    progress_bar(0.0..=100.0, self.slider_value)
-                        .width(Length::Units(250))
-                        .height(Length::Units(4))
-                ))
-                .add(settings::item_row(vec![
-                    checkbox("Checkbox", self.checkbox_value, Message::CheckboxToggled).into()
-                ]))
-                .add(settings::item(
-                    format!("Spin Button (Range {}:{})", self.spin_button.min, self.spin_button.max),
-                    self.spin_button.view(Message::SpinButton),
-                ))
-                .into()
+                Some(DemoView::TabB) => {
+                    settings::view_column(vec![settings::view_section("Tab B")
+                        .add(cosmic::iced::widget::text("Nothing here yet").width(Length::Fill))
+                        .into()])
+                    .padding(0)
+                    .into()
+                }
+                Some(DemoView::TabC) => {
+                    settings::view_column(vec![settings::view_section("Tab C")
+                        .add(cosmic::iced::widget::text("Nothing here yet").width(Length::Fill))
+                        .into()])
+                    .padding(0)
+                    .into()
+                }
+            },
         ])
         .into()
     }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -27,6 +27,7 @@ use iced_style::svg;
 use iced_style::text;
 use iced_style::text_input;
 use iced_style::toggler;
+use crate::widget::segmented_button;
 
 use iced_core::{Background, Color};
 
@@ -862,5 +863,39 @@ impl text_input::StyleSheet for Theme {
         let palette = self.extended_palette();
 
         palette.primary.weak.color
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub enum SegmentedButton {
+    #[default]
+    Default,
+    Custom(fn(&Theme) -> segmented_button::Appearance)
+}
+
+impl segmented_button::StyleSheet for Theme {
+    type Style = SegmentedButton;
+
+    fn appearance(&self, style: &Self::Style) -> segmented_button::Appearance {
+        if let SegmentedButton::Custom(func) = style {
+            return func(self);
+        }
+
+        let cosmic = self.cosmic();
+
+        segmented_button::Appearance {
+            button_active: segmented_button::ButtonAppearance {
+                background: Some(Background::Color(cosmic.primary.component.base.into())),
+                border_bottom: Some((4.0, cosmic.accent.base.into())),
+                border_radius: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                text_color: cosmic.accent.base.into(),
+            },
+            button_inactive: segmented_button::ButtonAppearance {
+                background: None,
+                border_bottom: Some((2.0, cosmic.accent.base.into())),
+                text_color: cosmic.primary.on.into(),
+                border_radius: BorderRadius::from(0.0),
+            }
+        }
     }
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -22,6 +22,9 @@ pub use navigation::*;
 mod toggler;
 pub use toggler::toggler;
 
+pub mod segmented_button;
+pub use segmented_button::{SegmentedButton, segmented_button};
+
 pub mod settings;
 
 mod scrollable;

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -1,0 +1,245 @@
+/// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+mod state;
+mod style;
+
+pub use self::state::{ButtonContent, Key, SecondaryState, State, WidgetState};
+pub use self::style::{Appearance, ButtonAppearance, StyleSheet};
+
+use derive_setters::Setters;
+use iced::{
+    alignment::{Horizontal, Vertical},
+    event, mouse, touch, Background, Color, Element, Event, Length, Point, Rectangle, Size,
+};
+use iced_core::BorderRadius;
+use iced_native::{layout, renderer, widget::Tree, Clipboard, Layout, Shell, Widget};
+
+/// A linear set of options for choosing between.
+#[derive(Setters)]
+pub struct SegmentedButton<'a, Message, Renderer>
+where
+    Renderer: iced_native::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    state: &'a WidgetState,
+    width: Length,
+    height: Length,
+    spacing: u16,
+    #[setters(into)]
+    style: <Renderer::Theme as StyleSheet>::Style,
+    #[setters(skip)]
+    on_activate: Option<Box<dyn Fn(Key) -> Message>>,
+}
+
+impl<'a, Message, Renderer> SegmentedButton<'a, Message, Renderer>
+where
+    Renderer: iced_native::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    #[must_use]
+    pub fn new(state: &'a WidgetState) -> Self {
+        Self {
+            state,
+            height: Length::Units(48),
+            width: Length::Fill,
+            spacing: 0,
+            style: <Renderer::Theme as StyleSheet>::Style::default(),
+            on_activate: None,
+        }
+    }
+
+    #[must_use]
+    pub fn on_activate(mut self, on_activate: impl Fn(Key) -> Message + 'static) -> Self {
+        self.on_activate = Some(Box::from(on_activate));
+        self
+    }
+}
+
+#[must_use]
+pub fn segmented_button<Message, Renderer, Data>(
+    state: &State<Data>,
+) -> SegmentedButton<Message, Renderer>
+where
+    Renderer: iced_native::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    SegmentedButton::new(&state.inner)
+}
+
+impl<'a, Message, Renderer> Widget<Message, Renderer> for SegmentedButton<'a, Message, Renderer>
+where
+    Renderer: iced_native::Renderer + iced_native::text::Renderer,
+    Renderer::Theme: StyleSheet,
+    Message: 'static + Clone,
+{
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
+    fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
+        let limits = limits.width(self.width).height(self.height);
+
+        let bounds = limits.max();
+
+        let size = renderer.default_size();
+
+        let mut width = 0.0;
+        let height = bounds.height;
+
+        for (_, content) in self.state.buttons.iter() {
+            let (w, _) = renderer.measure(&content.text, size, Default::default(), bounds);
+            width += w + f32::from(self.spacing * 2);
+        }
+
+        layout::Node::new(limits.resolve(Size::new(width, height)))
+    }
+
+    fn on_event(
+        &mut self,
+        _tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        _renderer: &Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        let bounds = layout.bounds();
+
+        if bounds.contains(cursor_position) {
+            let button_width = bounds.width / self.state.buttons.len() as f32;
+            for (num, (key, _)) in self.state.buttons.iter().enumerate() {
+                let mut bounds = bounds;
+                bounds.width = button_width;
+                bounds.x += num as f32 * button_width;
+
+                if bounds.contains(cursor_position) {
+                    if let Some(on_activate) = self.on_activate.as_ref() {
+                        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+                        | Event::Touch(touch::Event::FingerLifted { .. }) = event
+                        {
+                            shell.publish(on_activate(key));
+                            return event::Status::Captured;
+                        }
+                    }
+                }
+            }
+        }
+
+        event::Status::Ignored
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        layout: Layout<'_>,
+        cursor_position: iced::Point,
+        _viewport: &iced::Rectangle,
+        _renderer: &Renderer,
+    ) -> iced_native::mouse::Interaction {
+        if layout.bounds().contains(cursor_position) {
+            iced_native::mouse::Interaction::Pointer
+        } else {
+            iced_native::mouse::Interaction::Idle
+        }
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &<Renderer as iced_native::Renderer>::Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor_position: iced::Point,
+        _viewport: &iced::Rectangle,
+    ) {
+        let appearance = theme.appearance(&self.style);
+        let bounds = layout.bounds();
+        let button_width = bounds.width / self.state.buttons.len() as f32;
+
+        for (num, (key, content)) in self.state.buttons.iter().enumerate() {
+            let mut bounds = bounds;
+            bounds.width = button_width;
+            bounds.x += num as f32 * button_width;
+
+            let button_appearance = if self.state.active == key {
+                appearance.button_active
+            } else {
+                appearance.button_inactive
+            };
+
+            let x = bounds.center_x();
+            let y = bounds.center_y();
+
+            // Render the background of the button.
+            if button_appearance.background.is_some() {
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds,
+                        border_radius: button_appearance.border_radius,
+                        border_width: 0.0,
+                        border_color: Color::TRANSPARENT,
+                    },
+                    button_appearance
+                        .background
+                        .unwrap_or(Background::Color(Color::TRANSPARENT)),
+                );
+            }
+
+            // Render the bottom border.
+            if let Some((width, background)) = button_appearance.border_bottom {
+                let mut bounds = bounds;
+                bounds.y = bounds.y + bounds.height - width;
+                bounds.height = width;
+
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds,
+                        border_radius: BorderRadius::from(0.0),
+                        border_width: 0.0,
+                        border_color: Color::TRANSPARENT,
+                    },
+                    background,
+                );
+            }
+
+            // Render the text.
+            renderer.fill_text(iced_native::text::Text {
+                content: &content.text,
+                size: f32::from(renderer.default_size()),
+                bounds: Rectangle { x, y, ..bounds },
+                color: button_appearance.text_color,
+                font: Default::default(),
+                horizontal_alignment: Horizontal::Center,
+                vertical_alignment: Vertical::Center,
+            });
+        }
+    }
+
+    fn overlay<'b>(
+        &'b self,
+        _tree: &'b mut Tree,
+        _layout: iced_native::Layout<'_>,
+        _renderer: &Renderer,
+    ) -> Option<iced_native::overlay::Element<'b, Message, Renderer>> {
+        None
+    }
+}
+
+impl<'a, Message, Renderer> From<SegmentedButton<'a, Message, Renderer>>
+    for Element<'a, Message, Renderer>
+where
+    Renderer: iced_native::Renderer + iced_native::text::Renderer + 'a,
+    Renderer::Theme: StyleSheet,
+    Message: 'static + Clone,
+{
+    fn from(widget: SegmentedButton<'a, Message, Renderer>) -> Self {
+        Self::new(widget)
+    }
+}

--- a/src/widget/segmented_button/state.rs
+++ b/src/widget/segmented_button/state.rs
@@ -1,0 +1,82 @@
+/// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use slotmap::{SecondaryMap, SlotMap};
+
+slotmap::new_key_type! {
+    pub struct Key;
+}
+
+/// Contains all state for interacting with a [`SegmentedButton`].
+pub struct State<Data> {
+    pub inner: WidgetState,
+    pub data: SecondaryState<Data>,
+}
+
+impl<Data> Default for State<Data> {
+    fn default() -> Self {
+        Self {
+            inner: WidgetState::default(),
+            data: SecondaryState::default(),
+        }
+    }
+}
+
+/// State which is most useful to the widget.
+#[derive(Default)]
+pub struct WidgetState {
+    pub buttons: SlotMap<Key, ButtonContent>,
+    pub active: Key,
+}
+
+/// State which is most useful to the application.
+pub type SecondaryState<Data> = SecondaryMap<Key, Data>;
+
+impl<Data> State<Data> {
+    /// The ID of the active button.
+    #[must_use]
+    pub fn active(&self) -> Key {
+        self.inner.active
+    }
+
+    /// Get the application data for the active button.
+    #[must_use]
+    pub fn active_data(&self) -> Option<&Data> {
+        self.data(self.active())
+    }
+
+    /// Get the application data for a button.
+    #[must_use]
+    pub fn data(&self, key: Key) -> Option<&Data> {
+        self.data.get(key)
+    }
+
+    /// Insert a new button.
+    pub fn insert(&mut self, content: impl Into<ButtonContent>, data: Data) -> Key {
+        let key = self.inner.buttons.insert(content.into());
+        self.data.insert(key, data);
+        key
+    }
+
+    /// Removes a button.
+    pub fn remove(&mut self, key: Key) -> Option<Data> {
+        self.inner.buttons.remove(key);
+        self.data.remove(key)
+    }
+
+    /// Activates this button.
+    pub fn activate(&mut self, key: Key) {
+        self.inner.active = key;
+    }
+}
+
+/// Data to be drawn in a [`SegmentedButton`] button.
+pub struct ButtonContent {
+    pub text: String,
+}
+
+impl From<String> for ButtonContent {
+    fn from(text: String) -> Self {
+        ButtonContent { text }
+    }
+}

--- a/src/widget/segmented_button/style.rs
+++ b/src/widget/segmented_button/style.rs
@@ -1,0 +1,29 @@
+/// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use iced_core::{Background, BorderRadius, Color};
+
+/// The appearance of a [`SegmentedButton`].
+#[derive(Clone, Copy)]
+pub struct Appearance {
+    pub button_active: ButtonAppearance,
+    pub button_inactive: ButtonAppearance,
+}
+
+/// The appearance of a button in the [`SegmentedButton`]
+#[derive(Clone, Copy)]
+pub struct ButtonAppearance {
+    pub background: Option<Background>,
+    pub border_radius: BorderRadius,
+    pub border_bottom: Option<(f32, Color)>,
+    pub text_color: Color,
+}
+
+/// Defines the [`Appearance`] of a [`SegmentedButton`].
+pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
+    /// The [`Appearance`] of the [`SegmentedButton`].
+    fn appearance(&self, style: &Self::Style) -> Appearance;
+}


### PR DESCRIPTION
We may now implement tabbed interfaces, complete with a stylesheet implementation.

![Screenshot from 2022-12-28 12-43-42](https://user-images.githubusercontent.com/4143535/209807120-5481e94a-73cf-4f16-bf33-384d6b473285.png)

Based on

![Screenshot from 2022-12-28 12-47-58](https://user-images.githubusercontent.com/4143535/209807495-80942923-4ceb-48ef-be4d-8fc371c7e3d7.png)

Improvement still to come to style the mouse hover over a button, implementing different style variants, and a multi-select mode.