### PR TITLE
Improvements to the Segmented Button widget

### DIFF
--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -274,28 +274,16 @@ impl Application for Window {
         window.spin_button.max = 10;
 
         // Configures the demo view switcher.
-        let key = window
-            .demo_view_switcher
-            .insert(String::from("Tab A"), DemoView::TabA);
-
+        let key = window.demo_view_switcher.insert("Tab A", DemoView::TabA);
         window.demo_view_switcher.activate(key);
-
-        window
-            .demo_view_switcher
-            .insert(String::from("Tab B"), DemoView::TabB);
-
-        window
-            .demo_view_switcher
-            .insert(String::from("Tab C"), DemoView::TabC);
+        window.demo_view_switcher.insert("Tab B", DemoView::TabB);
+        window.demo_view_switcher.insert("Tab C", DemoView::TabC);
 
         // Configures the demo selection button.
-        let key = window.
-            demo_selection
-            .insert(String::from("Choice A"), ());
-
+        let key = window.demo_selection.insert("Choice A", ());
         window.demo_selection.activate(key);
-        window.demo_selection.insert(String::from("Choice B"), ());
-        window.demo_selection.insert(String::from("Choice C"), ());
+        window.demo_selection.insert("Choice B", ());
+        window.demo_selection.insert("Choice C", ());
 
         (window, Command::none())
     }

--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -129,7 +129,8 @@ pub struct Window {
     debug: bool,
     theme: Theme,
     slider_value: f32,
-    demo_tab_state: segmented_button::State<DemoView>,
+    demo_view_switcher: segmented_button::State<DemoView>,
+    demo_selection: segmented_button::State<()>,
     spin_button: SpinButtonModel<i32>,
     checkbox_value: bool,
     toggler_value: bool,
@@ -166,6 +167,7 @@ pub enum Message {
     CondensedViewToggle(()),
     Debug(bool),
     DemoTabActivate(segmented_button::Key),
+    DemoSelectionActivate(segmented_button::Key),
     Drag,
     InputChanged,
     Maximize,
@@ -271,19 +273,29 @@ impl Application for Window {
         window.spin_button.min = -10;
         window.spin_button.max = 10;
 
+        // Configures the demo view switcher.
         let key = window
-            .demo_tab_state
+            .demo_view_switcher
             .insert(String::from("Tab A"), DemoView::TabA);
 
-        window.demo_tab_state.activate(key);
+        window.demo_view_switcher.activate(key);
 
         window
-            .demo_tab_state
+            .demo_view_switcher
             .insert(String::from("Tab B"), DemoView::TabB);
 
         window
-            .demo_tab_state
+            .demo_view_switcher
             .insert(String::from("Tab C"), DemoView::TabC);
+
+        // Configures the demo selection button.
+        let key = window.
+            demo_selection
+            .insert(String::from("Choice A"), ());
+
+        window.demo_selection.activate(key);
+        window.demo_selection.insert(String::from("Choice B"), ());
+        window.demo_selection.insert(String::from("Choice C"), ());
 
         (window, Command::none())
     }
@@ -341,7 +353,8 @@ impl Application for Window {
             Message::InputChanged => {}
             Message::SpinButton(msg) => self.spin_button.update(msg),
             Message::CondensedViewToggle(_) => {}
-            Message::DemoTabActivate(key) => self.demo_tab_state.activate(key),
+            Message::DemoTabActivate(key) => self.demo_view_switcher.activate(key),
+            Message::DemoSelectionActivate(key) => self.demo_selection.activate(key),
         }
 
         Command::none()

--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -2,7 +2,7 @@ use cosmic::{
     iced::widget::{checkbox, pick_list, progress_bar, radio, row, slider},
     iced::{Alignment, Length},
     theme::{self, Button as ButtonTheme, Theme},
-    widget::{button, segmented_button, settings, toggler},
+    widget::{button, segmented_button::cosmic::{view_switcher, segmented_selection}, settings, toggler},
     Element,
 };
 
@@ -30,8 +30,7 @@ impl Window {
 
         settings::view_column(vec![
             self.page_title(Page::Demo),
-            segmented_button(&self.demo_view_switcher)
-                .height(Length::Units(48))
+            view_switcher(&self.demo_view_switcher)
                 .on_activate(Message::DemoTabActivate)
                 .into(),
             match self.demo_view_switcher.active_data() {
@@ -122,8 +121,7 @@ impl Window {
                         cosmic::iced::widget::text("SegmentedButton::Selection")
                             .font(cosmic::font::FONT_SEMIBOLD)
                             .into(),
-                        segmented_button(&self.demo_selection)
-                            .style(theme::SegmentedButton::Selection)
+                        segmented_selection(&self.demo_selection)
                             .on_activate(Message::DemoSelectionActivate)
                             .into()
                     ])

--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -1,7 +1,7 @@
 use cosmic::{
     iced::widget::{checkbox, pick_list, progress_bar, radio, row, slider},
     iced::{Alignment, Length},
-    theme::{Button as ButtonTheme, Theme},
+    theme::{self, Button as ButtonTheme, Theme},
     widget::{button, segmented_button, settings, toggler},
     Element,
 };
@@ -30,10 +30,11 @@ impl Window {
 
         settings::view_column(vec![
             self.page_title(Page::Demo),
-            segmented_button(&self.demo_tab_state)
+            segmented_button(&self.demo_view_switcher)
+                .height(Length::Units(48))
                 .on_activate(Message::DemoTabActivate)
                 .into(),
-            match self.demo_tab_state.active_data() {
+            match self.demo_view_switcher.active_data() {
                 None => panic!("no tab is active"),
                 Some(DemoView::TabA) => settings::view_column(vec![
                     settings::view_section("Debug")
@@ -117,9 +118,15 @@ impl Window {
                 .padding(0)
                 .into(),
                 Some(DemoView::TabB) => {
-                    settings::view_column(vec![settings::view_section("Tab B")
-                        .add(cosmic::iced::widget::text("Nothing here yet").width(Length::Fill))
-                        .into()])
+                    settings::view_column(vec![
+                        cosmic::iced::widget::text("SegmentedButton::Selection")
+                            .font(cosmic::font::FONT_SEMIBOLD)
+                            .into(),
+                        segmented_button(&self.demo_selection)
+                            .style(theme::SegmentedButton::Selection)
+                            .on_activate(Message::DemoSelectionActivate)
+                            .into()
+                    ])
                     .padding(0)
                     .into()
                 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -868,8 +868,10 @@ impl text_input::StyleSheet for Theme {
 
 #[derive(Clone, Copy, Default)]
 pub enum SegmentedButton {
+    /// A tabbed widget for switching between views in an interface.
     #[default]
-    Default,
+    ViewSwitcher,
+    /// Or implement any custom theme of your liking.
     Custom(fn(&Theme) -> segmented_button::Appearance)
 }
 
@@ -877,25 +879,41 @@ impl segmented_button::StyleSheet for Theme {
     type Style = SegmentedButton;
 
     fn appearance(&self, style: &Self::Style) -> segmented_button::Appearance {
-        if let SegmentedButton::Custom(func) = style {
-            return func(self);
-        }
-
-        let cosmic = self.cosmic();
-
-        segmented_button::Appearance {
-            button_active: segmented_button::ButtonAppearance {
-                background: Some(Background::Color(cosmic.primary.component.base.into())),
-                border_bottom: Some((4.0, cosmic.accent.base.into())),
-                border_radius: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
-                text_color: cosmic.accent.base.into(),
-            },
-            button_inactive: segmented_button::ButtonAppearance {
-                background: None,
-                border_bottom: Some((2.0, cosmic.accent.base.into())),
-                text_color: cosmic.primary.on.into(),
-                border_radius: BorderRadius::from(0.0),
+        match style {
+            SegmentedButton::ViewSwitcher => {
+                let cosmic = self.cosmic();
+                segmented_button::Appearance {
+                    background: None,
+                    border_color: Color::TRANSPARENT,
+                    border_radius: BorderRadius::from(0.0),
+                    border_width: 0.0,
+                    button_active: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.primary.component.base.into())),
+                        border_bottom: Some((4.0, cosmic.accent.base.into())),
+                        border_radius_first: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        border_radius_last: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        border_radius_middle: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        text_color: cosmic.accent.base.into(),
+                    },
+                    button_inactive: segmented_button::ButtonAppearance {
+                        background: None,
+                        border_bottom: Some((1.0, cosmic.accent.base.into())),
+                        border_radius_first: BorderRadius::from(0.0),
+                        border_radius_last: BorderRadius::from(0.0),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.primary.on.into(),
+                    },
+                    button_hover: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.primary.component.hover.into())),
+                        border_bottom: Some((1.0, cosmic.accent.base.into())),
+                        border_radius_first: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        border_radius_last: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        border_radius_middle: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        text_color: cosmic.accent.base.into(),
+                    }
+                }
             }
+            SegmentedButton::Custom(func) => func(self)
         }
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -871,6 +871,8 @@ pub enum SegmentedButton {
     /// A tabbed widget for switching between views in an interface.
     #[default]
     ViewSwitcher,
+    /// A widget for multiple choice selection.
+    Selection,
     /// Or implement any custom theme of your liking.
     Custom(fn(&Theme) -> segmented_button::Appearance)
 }
@@ -909,6 +911,39 @@ impl segmented_button::StyleSheet for Theme {
                         border_radius_first: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
                         border_radius_last: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
                         border_radius_middle: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
+                        text_color: cosmic.accent.base.into(),
+                    }
+                }
+            }
+            SegmentedButton::Selection => {
+                let cosmic = self.cosmic();
+                segmented_button::Appearance {
+                    background: None,
+                    border_color: Color::TRANSPARENT,
+                    border_radius: BorderRadius::from(0.0),
+                    border_width: 0.0,
+                    button_active: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.secondary.component.divider.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 0.0, 0.0, 24.0]),
+                        border_radius_last: BorderRadius::from([0.0, 24.0, 24.0, 0.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.accent.base.into(),
+                    },
+                    button_inactive: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.secondary.component.base.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 0.0, 0.0, 24.0]),
+                        border_radius_last: BorderRadius::from([0.0, 24.0, 24.0, 0.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.primary.on.into(),
+                    },
+                    button_hover: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.primary.component.hover.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 0.0, 0.0, 24.0]),
+                        border_radius_last: BorderRadius::from([0.0, 24.0, 24.0, 0.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
                         text_color: cosmic.accent.base.into(),
                     }
                 }

--- a/src/widget/segmented_button/cosmic.rs
+++ b/src/widget/segmented_button/cosmic.rs
@@ -1,0 +1,29 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{SegmentedButton, State};
+use iced_core::Length;
+
+/// Appears as a collection of tabs for developing a tabbed interface.
+///
+/// The data for the widget comes from a [`State`] that is maintained the application.
+#[must_use]
+pub fn view_switcher<Message, Data>(
+    state: &State<Data>,
+) -> SegmentedButton<Message, crate::Renderer> {
+    SegmentedButton::new(&state.inner)
+        .height(Length::Units(48))
+        .style(crate::theme::SegmentedButton::ViewSwitcher)
+}
+
+/// Appears as a selection of choices for choosing between.
+///
+/// The data for the widget comes from a [`State`] that is maintained the application.
+#[must_use]
+pub fn segmented_selection<Message, Data>(
+    state: &State<Data>,
+) -> SegmentedButton<Message, crate::Renderer> {
+    SegmentedButton::new(&state.inner)
+        .height(Length::Units(32))
+        .style(crate::theme::SegmentedButton::Selection)
+}

--- a/src/widget/segmented_button/cosmic.rs
+++ b/src/widget/segmented_button/cosmic.rs
@@ -14,6 +14,7 @@ pub fn view_switcher<Message, Data>(
     SegmentedButton::new(&state.inner)
         .height(Length::Units(48))
         .style(crate::theme::SegmentedButton::ViewSwitcher)
+        .font_active(crate::font::FONT_SEMIBOLD)
 }
 
 /// Appears as a selection of choices for choosing between.
@@ -26,4 +27,5 @@ pub fn segmented_selection<Message, Data>(
     SegmentedButton::new(&state.inner)
         .height(Length::Units(32))
         .style(crate::theme::SegmentedButton::Selection)
+        .font_active(crate::font::FONT_SEMIBOLD)
 }

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -1,6 +1,5 @@
 /// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
-
 mod state;
 mod style;
 
@@ -49,7 +48,7 @@ where
     pub fn new(state: &'a WidgetState) -> Self {
         Self {
             state,
-            height: Length::Units(48),
+            height: Length::Units(32),
             width: Length::Fill,
             spacing: 0,
             style: <Renderer::Theme as StyleSheet>::Style::default(),

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -1,5 +1,49 @@
-/// Copyright 2022 System76 <info@system76.com>
+// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
+
+//! A widget providing a conjoined set of linear buttons for choosing between.
+//!
+//! ## Example
+//!
+//! Add the state and a message variant in your application for handling selections.
+//!
+//! ```no_run
+//! use iced_core::Length;
+//! use cosmic::theme;
+//! use cosmic::widget::segmented_button;
+//!
+//! enum AppMessage {
+//!     Selected(segmented_button::Key)
+//! }
+//!
+//! struct App {
+//!     ...
+//!     state: segmented_button::State<u16>(),
+//!     ...
+//! }
+//! ```
+//!
+//! Then add choices to the state, while activating the first.
+//!
+//! ```no_run
+//! let first_key = application.state.insert("Choice A", 0);
+//! application.state.insert("Choice B", 1);
+//! application.state.insert("Choice C", 2);
+//! application.state.activate(first_key);
+//! ```
+//!
+//! Then use it in the view method to create segmented button widgets.
+//!
+//! ```no_run
+//! let widget = segmentend_button(&application.state)
+//!     .style(theme::SegmentedButton::Selection)
+//!     .height(Length::Units(32))
+//!     .on_activate(AppMessage::Selected);
+//! ```
+
+/// COSMIC configurations of [`SegmentedButton`].
+pub mod cosmic;
+
 mod state;
 mod style;
 
@@ -22,19 +66,28 @@ struct PrivateWidgetState {
     hovered: Key,
 }
 
-/// A linear set of options for choosing between.
+/// A widget providing a conjoined set of linear buttons for choosing between.
+///
+/// The data for the widget comes from a [`State`] that is maintained the application.
 #[derive(Setters)]
 pub struct SegmentedButton<'a, Message, Renderer>
 where
     Renderer: iced_native::Renderer,
     Renderer::Theme: StyleSheet,
 {
+    /// Contains application state also used for drawing.
+    #[setters(skip)]
     state: &'a WidgetState,
+    /// The desired width of the widget.
     width: Length,
+    /// The desired height of the widget.
     height: Length,
+    /// The desired spacing between widgets.
     spacing: u16,
+    /// The style to draw the widget in.
     #[setters(into)]
     style: <Renderer::Theme as StyleSheet>::Style,
+    /// Emits the ID of the activated widget on selection.
     #[setters(skip)]
     on_activate: Option<Box<dyn Fn(Key) -> Message>>,
 }
@@ -56,6 +109,7 @@ where
         }
     }
 
+    /// Emits the ID of the activated widget on selection.
     #[must_use]
     pub fn on_activate(mut self, on_activate: impl Fn(Key) -> Message + 'static) -> Self {
         self.on_activate = Some(Box::from(on_activate));
@@ -63,6 +117,7 @@ where
     }
 }
 
+/// Creates a widget that presents multiple conjoined buttons.
 #[must_use]
 pub fn segmented_button<Message, Renderer, Data>(
     state: &State<Data>,

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -13,7 +13,15 @@ use iced::{
     event, mouse, touch, Background, Color, Element, Event, Length, Point, Rectangle, Size,
 };
 use iced_core::BorderRadius;
+use iced_native::widget::tree;
 use iced_native::{layout, renderer, widget::Tree, Clipboard, Layout, Shell, Widget};
+
+/// State that is maintained by the widget internally.
+#[derive(Default)]
+struct PrivateWidgetState {
+    /// The ID of the button that is being hovered. Defaults to null.
+    hovered: Key,
+}
 
 /// A linear set of options for choosing between.
 #[derive(Setters)]
@@ -73,6 +81,14 @@ where
     Renderer::Theme: StyleSheet,
     Message: 'static + Clone,
 {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<PrivateWidgetState>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(PrivateWidgetState::default())
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -101,7 +117,7 @@ where
 
     fn on_event(
         &mut self,
-        _tree: &mut Tree,
+        tree: &mut Tree,
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
@@ -110,6 +126,7 @@ where
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let bounds = layout.bounds();
+        let state = tree.state.downcast_mut::<PrivateWidgetState>();
 
         if bounds.contains(cursor_position) {
             let button_width = bounds.width / self.state.buttons.len() as f32;
@@ -119,6 +136,9 @@ where
                 bounds.x += num as f32 * button_width;
 
                 if bounds.contains(cursor_position) {
+                    // Record that the mouse is hovering over this button.
+                    state.hovered = key;
+
                     if let Some(on_activate) = self.on_activate.as_ref() {
                         if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
                         | Event::Touch(touch::Event::FingerLifted { .. }) = event
@@ -129,6 +149,8 @@ where
                     }
                 }
             }
+        } else {
+            state.hovered = Key::default();
         }
 
         event::Status::Ignored
@@ -151,7 +173,7 @@ where
 
     fn draw(
         &self,
-        _tree: &Tree,
+        tree: &Tree,
         renderer: &mut Renderer,
         theme: &<Renderer as iced_native::Renderer>::Theme,
         _style: &renderer::Style,
@@ -159,9 +181,23 @@ where
         _cursor_position: iced::Point,
         _viewport: &iced::Rectangle,
     ) {
+        let state = tree.state.downcast_ref::<PrivateWidgetState>();
         let appearance = theme.appearance(&self.style);
         let bounds = layout.bounds();
-        let button_width = bounds.width / self.state.buttons.len() as f32;
+        let button_amount = self.state.buttons.len();
+        let button_width = bounds.width / button_amount as f32;
+
+        if let Some(background) = appearance.background {
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds,
+                    border_radius: appearance.border_radius,
+                    border_width: appearance.border_width,
+                    border_color: appearance.border_color,
+                },
+                background,
+            );
+        }
 
         for (num, (key, content)) in self.state.buttons.iter().enumerate() {
             let mut bounds = bounds;
@@ -170,6 +206,8 @@ where
 
             let button_appearance = if self.state.active == key {
                 appearance.button_active
+            } else if state.hovered == key {
+                appearance.button_hover
             } else {
                 appearance.button_inactive
             };
@@ -182,7 +220,13 @@ where
                 renderer.fill_quad(
                     renderer::Quad {
                         bounds,
-                        border_radius: button_appearance.border_radius,
+                        border_radius: if num == 0 {
+                            button_appearance.border_radius_first
+                        } else if num + 1 == button_amount {
+                            button_appearance.border_radius_last
+                        } else {
+                            button_appearance.border_radius_middle
+                        },
                         border_width: 0.0,
                         border_color: Color::TRANSPARENT,
                     },

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -72,12 +72,18 @@ struct PrivateWidgetState {
 #[derive(Setters)]
 pub struct SegmentedButton<'a, Message, Renderer>
 where
-    Renderer: iced_native::Renderer,
+    Renderer: iced_native::Renderer + iced_native::text::Renderer,
     Renderer::Theme: StyleSheet,
 {
     /// Contains application state also used for drawing.
     #[setters(skip)]
     state: &'a WidgetState,
+    /// The desired font for active tabs.
+    font_active: Renderer::Font,
+    /// The desired font for hovered tabs.
+    font_hovered: Renderer::Font,
+    /// The desired font for inactive tabs.
+    font_inactive: Renderer::Font,
     /// The desired width of the widget.
     width: Length,
     /// The desired height of the widget.
@@ -94,13 +100,16 @@ where
 
 impl<'a, Message, Renderer> SegmentedButton<'a, Message, Renderer>
 where
-    Renderer: iced_native::Renderer,
+    Renderer: iced_native::Renderer + iced_native::text::Renderer,
     Renderer::Theme: StyleSheet,
 {
     #[must_use]
     pub fn new(state: &'a WidgetState) -> Self {
         Self {
             state,
+            font_active: Renderer::Font::default(),
+            font_hovered: Renderer::Font::default(),
+            font_inactive: Renderer::Font::default(),
             height: Length::Units(32),
             width: Length::Fill,
             spacing: 0,
@@ -123,7 +132,7 @@ pub fn segmented_button<Message, Renderer, Data>(
     state: &State<Data>,
 ) -> SegmentedButton<Message, Renderer>
 where
-    Renderer: iced_native::Renderer,
+    Renderer: iced_native::Renderer + iced_native::text::Renderer,
     Renderer::Theme: StyleSheet,
 {
     SegmentedButton::new(&state.inner)
@@ -258,12 +267,12 @@ where
             bounds.width = button_width;
             bounds.x += num as f32 * button_width;
 
-            let button_appearance = if self.state.active == key {
-                appearance.button_active
+            let (button_appearance, font) = if self.state.active == key {
+                (appearance.button_active, &self.font_active)
             } else if state.hovered == key {
-                appearance.button_hover
+                (appearance.button_hover, &self.font_hovered)
             } else {
-                appearance.button_inactive
+                (appearance.button_inactive, &self.font_inactive)
             };
 
             let x = bounds.center_x();
@@ -313,7 +322,7 @@ where
                 size: f32::from(renderer.default_size()),
                 bounds: Rectangle { x, y, ..bounds },
                 color: button_appearance.text_color,
-                font: Default::default(),
+                font: font.clone(),
                 horizontal_alignment: Horizontal::Center,
                 vertical_alignment: Vertical::Center,
             });

--- a/src/widget/segmented_button/state.rs
+++ b/src/widget/segmented_button/state.rs
@@ -1,17 +1,20 @@
-/// Copyright 2022 System76 <info@system76.com>
+// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
+
 use slotmap::{SecondaryMap, SlotMap};
 use std::borrow::Cow;
 
-use crate::theme::Button;
-
 slotmap::new_key_type! {
+    /// An ID for a segmented button
     pub struct Key;
 }
 
-/// Contains all state for interacting with a [`SegmentedButton`].
+/// Contains all state for interacting with a segmented button.
 pub struct State<Data> {
+    /// State that is shared with widget drawing.
     pub inner: WidgetState,
+
+    /// State unique to the application.
     pub data: SecondaryState<Data>,
 }
 
@@ -27,7 +30,10 @@ impl<Data> Default for State<Data> {
 /// State which is most useful to the widget.
 #[derive(Default)]
 pub struct WidgetState {
+    /// The content used for drawing segmented buttons.
     pub buttons: SlotMap<Key, ButtonContent>,
+
+    /// The actively-selected segmented button.
     pub active: Key,
 }
 
@@ -72,7 +78,7 @@ impl<Data> State<Data> {
     }
 }
 
-/// Data to be drawn in a [`SegmentedButton`] button.
+/// Data to be drawn in a segmented button.
 pub struct ButtonContent {
     pub text: Cow<'static, str>,
 }

--- a/src/widget/segmented_button/state.rs
+++ b/src/widget/segmented_button/state.rs
@@ -1,6 +1,9 @@
 /// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 use slotmap::{SecondaryMap, SlotMap};
+use std::borrow::Cow;
+
+use crate::theme::Button;
 
 slotmap::new_key_type! {
     pub struct Key;
@@ -71,11 +74,27 @@ impl<Data> State<Data> {
 
 /// Data to be drawn in a [`SegmentedButton`] button.
 pub struct ButtonContent {
-    pub text: String,
+    pub text: Cow<'static, str>,
 }
 
 impl From<String> for ButtonContent {
     fn from(text: String) -> Self {
+        ButtonContent {
+            text: Cow::Owned(text),
+        }
+    }
+}
+
+impl From<&'static str> for ButtonContent {
+    fn from(text: &'static str) -> Self {
+        ButtonContent {
+            text: Cow::Borrowed(text),
+        }
+    }
+}
+
+impl From<Cow<'static, str>> for ButtonContent {
+    fn from(text: Cow<'static, str>) -> Self {
         ButtonContent { text }
     }
 }

--- a/src/widget/segmented_button/state.rs
+++ b/src/widget/segmented_button/state.rs
@@ -1,6 +1,5 @@
 /// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
-
 use slotmap::{SecondaryMap, SlotMap};
 
 slotmap::new_key_type! {

--- a/src/widget/segmented_button/style.rs
+++ b/src/widget/segmented_button/style.rs
@@ -1,6 +1,5 @@
 /// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
-
 use iced_core::{Background, BorderRadius, Color};
 
 /// The appearance of a [`SegmentedButton`].

--- a/src/widget/segmented_button/style.rs
+++ b/src/widget/segmented_button/style.rs
@@ -6,16 +6,23 @@ use iced_core::{Background, BorderRadius, Color};
 /// The appearance of a [`SegmentedButton`].
 #[derive(Clone, Copy)]
 pub struct Appearance {
+    pub background: Option<Background>,
+    pub border_color: Color,
+    pub border_radius: BorderRadius,
+    pub border_width: f32,
     pub button_active: ButtonAppearance,
     pub button_inactive: ButtonAppearance,
+    pub button_hover: ButtonAppearance,
 }
 
 /// The appearance of a button in the [`SegmentedButton`]
 #[derive(Clone, Copy)]
 pub struct ButtonAppearance {
     pub background: Option<Background>,
-    pub border_radius: BorderRadius,
     pub border_bottom: Option<(f32, Color)>,
+    pub border_radius_first: BorderRadius,
+    pub border_radius_middle: BorderRadius,
+    pub border_radius_last: BorderRadius,
     pub text_color: Color,
 }
 

--- a/src/widget/segmented_button/style.rs
+++ b/src/widget/segmented_button/style.rs
@@ -1,8 +1,9 @@
-/// Copyright 2022 System76 <info@system76.com>
+// Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
+
 use iced_core::{Background, BorderRadius, Color};
 
-/// The appearance of a [`SegmentedButton`].
+/// The appearance of a segmented button.
 #[derive(Clone, Copy)]
 pub struct Appearance {
     pub background: Option<Background>,
@@ -14,7 +15,7 @@ pub struct Appearance {
     pub button_hover: ButtonAppearance,
 }
 
-/// The appearance of a button in the [`SegmentedButton`]
+/// The appearance of a button in the segmented button
 #[derive(Clone, Copy)]
 pub struct ButtonAppearance {
     pub background: Option<Background>,
@@ -25,11 +26,11 @@ pub struct ButtonAppearance {
     pub text_color: Color,
 }
 
-/// Defines the [`Appearance`] of a [`SegmentedButton`].
+/// Defines the [`Appearance`] of a segmented button.
 pub trait StyleSheet {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 
-    /// The [`Appearance`] of the [`SegmentedButton`].
+    /// The [`Appearance`] of the segmented button.
     fn appearance(&self, style: &Self::Style) -> Appearance;
 }


### PR DESCRIPTION
- Adds support for tracking the hover state to apply a hover style to hovered tabs.
- Renames the default style to `ViewSwitcher` to make room for an alternative `Selection` style.
- Border radius style now configurable based on position of widget in the view.
- The background and border of the entire widget is now also themable.
- Adds `font_active`, `font_hovered`, and `font_inactive` methods to `SegmentedButton` for configuring the fonts.
- Adds cosmic-specific functions for constructing a `view_switcher` and `segmented_selection` with ideal COSMIC theming and setup. Such as specifying a semi-bold font for active buttons or preferred default heights.

[SegmentedButton.webm](https://user-images.githubusercontent.com/4143535/209882257-2b1421da-7f04-44f2-a17d-edf09505649f.webm)
