### PR TITLE
Vertical layout for segmented buttons, and cosmic example improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ palette = "0.6.1"
 cosmic-panel-config = {git = "https://github.com/pop-os/cosmic-panel", optional = true, branch = "master_jammy" }
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", optional = true, rev = "73346019952f82ec7e4d4d15f5d66841b54e8b61" }
 slotmap = "1.0.6"
+stack_dst = "0.7.2"
 
 [dependencies.cosmic-theme]
 git = "https://github.com/pop-os/cosmic-theme.git"

--- a/examples/cosmic/Cargo.toml
+++ b/examples/cosmic/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+apply = "0.3.0"
 libcosmic = { path = "../..", default-features = false, features = ["debug", "wgpu", "winit"] }

--- a/examples/cosmic/src/window/bluetooth.rs
+++ b/examples/cosmic/src/window/bluetooth.rs
@@ -3,16 +3,32 @@ use cosmic::{
     iced::widget::{column, text},
     widget::{list_column, settings, toggler},
 };
-use super::{Message, Page, Window};
+use super::{Page, Window};
 
-impl Window {
-    pub(super) fn view_bluetooth(&self) -> Element<Message> {
+#[derive(Clone, Copy, Debug)]
+pub enum Message {
+    Enable(bool)
+}
+
+#[derive(Default)]
+pub struct State {
+    enabled: bool
+}
+
+impl State {
+    pub(super) fn update(&mut self, message: Message) {
+        match message {
+            Message::Enable(value) => self.enabled = value,
+        }
+    }
+
+    pub(super) fn view<'a>(&'a self, window: &'a Window) -> Element<'a, Message> {
         settings::view_column(vec![
-            self.page_title(Page::Bluetooth),
+            window.page_title(Page::Bluetooth),
 
             column!(
                 list_column()
-                    .add(settings::item("Bluetooth", toggler(None, self.toggler_value, Message::TogglerToggled))),
+                    .add(settings::item("Bluetooth", toggler(None, self.enabled, Message::Enable))),
                 text("Now visible as \"TODO\", just kidding")
             ).spacing(8).into(),
 

--- a/examples/cosmic/src/window/system_and_accounts.rs
+++ b/examples/cosmic/src/window/system_and_accounts.rs
@@ -7,6 +7,9 @@ use cosmic::{
 
 use super::{Message, Page, SubPage, Window};
 
+#[derive(Default)]
+pub struct State {}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SystemAndAccountsPage {
     Users,
@@ -53,10 +56,10 @@ impl SubPage for SystemAndAccountsPage {
     }
 }
 
-impl Window {
-    pub(super) fn view_system_and_accounts_about(&self) -> Element<Message> {
+impl State {
+    pub(super) fn view<'a>(&'a self, window: &'a Window) -> Element<'a, Message> {
         settings::view_column(vec![
-            self.parent_page_button(SystemAndAccountsPage::About),
+            window.parent_page_button(SystemAndAccountsPage::About),
 
             row!(
                 horizontal_space(Length::Fill),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -27,6 +27,7 @@ use iced_style::svg;
 use iced_style::text;
 use iced_style::text_input;
 use iced_style::toggler;
+use crate::widget::Orientation;
 use crate::widget::segmented_button;
 
 use iced_core::{Background, Color};
@@ -880,7 +881,7 @@ pub enum SegmentedButton {
 impl segmented_button::StyleSheet for Theme {
     type Style = SegmentedButton;
 
-    fn appearance(&self, style: &Self::Style) -> segmented_button::Appearance {
+    fn appearance(&self, style: &Self::Style, orientation: Orientation) -> segmented_button::Appearance {
         match style {
             SegmentedButton::ViewSwitcher => {
                 let cosmic = self.cosmic();
@@ -915,7 +916,7 @@ impl segmented_button::StyleSheet for Theme {
                     }
                 }
             }
-            SegmentedButton::Selection => {
+            SegmentedButton::Selection if orientation == Orientation::Horizontal => {
                 let cosmic = self.cosmic();
                 segmented_button::Appearance {
                     background: None,
@@ -943,6 +944,39 @@ impl segmented_button::StyleSheet for Theme {
                         border_bottom: None,
                         border_radius_first: BorderRadius::from([24.0, 0.0, 0.0, 24.0]),
                         border_radius_last: BorderRadius::from([0.0, 24.0, 24.0, 0.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.accent.base.into(),
+                    }
+                }
+            }
+            SegmentedButton::Selection => {
+                let cosmic = self.cosmic();
+                segmented_button::Appearance {
+                    background: None,
+                    border_color: Color::TRANSPARENT,
+                    border_radius: BorderRadius::from(0.0),
+                    border_width: 0.0,
+                    button_active: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.secondary.component.divider.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 24.0, 0.0, 0.0]),
+                        border_radius_last: BorderRadius::from([0.0, 0.0, 24.0, 24.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.accent.base.into(),
+                    },
+                    button_inactive: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.secondary.component.base.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 24.0, 0.0, 0.0]),
+                        border_radius_last: BorderRadius::from([0.0, 0.0, 24.0, 24.0]),
+                        border_radius_middle: BorderRadius::from(0.0),
+                        text_color: cosmic.primary.on.into(),
+                    },
+                    button_hover: segmented_button::ButtonAppearance {
+                        background: Some(Background::Color(cosmic.primary.component.hover.into())),
+                        border_bottom: None,
+                        border_radius_first: BorderRadius::from([24.0, 24.0, 0.0, 0.0]),
+                        border_radius_last: BorderRadius::from([0.0, 0.0, 24.0, 24.0]),
                         border_radius_middle: BorderRadius::from(0.0),
                         text_color: cosmic.accent.base.into(),
                     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -39,3 +39,10 @@ pub use spin_button::{SpinButton, spin_button};
 pub mod rectangle_tracker;
 
 pub mod aspect_ratio;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Orientation {
+    #[default]
+    Horizontal,
+    Vertical
+}

--- a/src/widget/segmented_button/cosmic.rs
+++ b/src/widget/segmented_button/cosmic.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::{SegmentedButton, State};
-use iced_core::Length;
 
 /// Appears as a collection of tabs for developing a tabbed interface.
 ///
@@ -12,7 +11,8 @@ pub fn view_switcher<Message, Data>(
     state: &State<Data>,
 ) -> SegmentedButton<Message, crate::Renderer> {
     SegmentedButton::new(&state.inner)
-        .height(Length::Units(48))
+        .button_padding([16, 0, 16, 0])
+        .button_height(48)
         .style(crate::theme::SegmentedButton::ViewSwitcher)
         .font_active(crate::font::FONT_SEMIBOLD)
 }
@@ -25,7 +25,8 @@ pub fn segmented_selection<Message, Data>(
     state: &State<Data>,
 ) -> SegmentedButton<Message, crate::Renderer> {
     SegmentedButton::new(&state.inner)
-        .height(Length::Units(32))
+        .button_padding([16, 0, 16, 0])
+        .button_height(32)
         .style(crate::theme::SegmentedButton::Selection)
         .font_active(crate::font::FONT_SEMIBOLD)
 }

--- a/src/widget/segmented_button/state.rs
+++ b/src/widget/segmented_button/state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use slotmap::{SecondaryMap, SlotMap};
-use std::borrow::Cow;
+use std::{borrow::Cow, cell::Cell};
 
 slotmap::new_key_type! {
     /// An ID for a segmented button
@@ -35,6 +35,9 @@ pub struct WidgetState {
 
     /// The actively-selected segmented button.
     pub active: Key,
+
+    /// The button currently hovered.
+    pub hovered: Cell<Key>,
 }
 
 /// State which is most useful to the application.

--- a/src/widget/segmented_button/style.rs
+++ b/src/widget/segmented_button/style.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::widget::Orientation;
 use iced_core::{Background, BorderRadius, Color};
 
 /// The appearance of a segmented button.
@@ -32,5 +33,5 @@ pub trait StyleSheet {
     type Style: Default;
 
     /// The [`Appearance`] of the segmented button.
-    fn appearance(&self, style: &Self::Style) -> Appearance;
+    fn appearance(&self, style: &Self::Style, orientation: Orientation) -> Appearance;
 }


### PR DESCRIPTION
![Screenshot from 2022-12-30 17-42-13](https://user-images.githubusercontent.com/4143535/210093350-caa9faaa-03df-4734-a1fb-795be4235a4b.png)

- Adds `Orientation` enum for defining the vertical or horizontal layout of a widget.
- Implements vertical orientation for the segmented button widget and its cosmic styles.
- cosmic pages now have their own states and messages, and all controls are now mapped to unique states