### PR TITLE
Global setting for default icon theme

### DIFF
--- a/examples/cosmic-sctk/src/main.rs
+++ b/examples/cosmic-sctk/src/main.rs
@@ -7,6 +7,7 @@ mod window;
 pub use window::Window;
 
 pub fn main() -> cosmic::iced::Result {
+    settings::set_default_icon_theme("Pop");
     let mut settings = settings();
     settings.initial_surface = InitialSurface::XdgWindow(Default::default());
     Window::run(settings)

--- a/examples/cosmic/src/main.rs
+++ b/examples/cosmic/src/main.rs
@@ -7,9 +7,8 @@ mod window;
 pub use window::*;
 
 pub fn main() -> cosmic::iced::Result {
+    settings::set_default_icon_theme("Pop");
     let mut settings = settings();
     settings.window.min_size = Some((600, 300));
-    // TODO: Window resize handles not functioning yet
-    settings.window.decorations = false;
     Window::run(settings)
 }

--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -19,7 +19,7 @@ mod bluetooth;
 
 mod demo;
 
-use self::{demo::DemoView, desktop::DesktopPage};
+use self::desktop::DesktopPage;
 mod desktop;
 
 use self::input_devices::InputDevicesPage;
@@ -272,28 +272,8 @@ impl Application for Window {
             .sidebar_toggled(true)
             .show_maximize(true)
             .show_minimize(true);
-        window.demo.slider_value = 50.0;
-        //        window.theme = Theme::Light;
-        window.demo.pick_list_selected = Some("Option 1");
+
         window.title = String::from("COSMIC Design System - Iced");
-        window.demo.spin_button.min = -10;
-        window.demo.spin_button.max = 10;
-
-        // Configures the demo view switcher.
-        let key = window.demo.view_switcher.insert("Controls", DemoView::TabA);
-        window.demo.view_switcher.activate(key);
-        window
-            .demo
-            .view_switcher
-            .insert("Segmented Button", DemoView::TabB);
-        window.demo.view_switcher.insert("Tab C", DemoView::TabC);
-
-        // Configures the demo selection button.
-        let key = window.demo.selection.insert("Choice A", ());
-        window.demo.selection.activate(key);
-        window.demo.selection.insert("Choice B", ());
-        window.demo.selection.insert("Choice C", ());
-
         (window, Command::none())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,21 +16,12 @@ pub mod font;
 pub mod theme;
 pub mod widget;
 
+pub mod settings;
+pub use settings::settings;
+
 mod ext;
 pub use ext::ElementExt;
 
 pub use theme::Theme;
 pub type Renderer = iced::Renderer<Theme>;
 pub type Element<'a, Message> = iced::Element<'a, Message, Renderer>;
-
-#[must_use]
-pub fn settings<Flags: Default>() -> iced::Settings<Flags> {
-    iced::Settings {
-        default_font: match font::FONT {
-            iced::Font::Default => None,
-            iced::Font::External { bytes, .. } => Some(bytes),
-        },
-        default_text_size: 18,
-        ..iced::Settings::default()
-    }
-}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,31 @@
+use crate::font;
+use std::cell::RefCell;
+
+thread_local! {
+    /// The fallback icon theme to search if no icon theme was specified.
+    pub(crate) static DEFAULT_ICON_THEME: RefCell<String> = RefCell::new(String::from("Pop"));
+}
+
+/// The fallback icon theme to search if no icon theme was specified.
+#[must_use]
+pub fn default_icon_theme() -> String {
+    DEFAULT_ICON_THEME.with(|f| f.borrow().clone())
+}
+
+/// Set the fallback icon theme to search when loading system icons.
+pub fn set_default_icon_theme(name: impl Into<String>) {
+    DEFAULT_ICON_THEME.with(|f| *f.borrow_mut() = name.into());
+}
+
+/// Default iced settings for COSMIC applications.
+#[must_use]
+pub fn settings<Flags: Default>() -> iced::Settings<Flags> {
+    iced::Settings {
+        default_font: match font::FONT {
+            iced::Font::Default => None,
+            iced::Font::External { bytes, .. } => Some(bytes),
+        },
+        default_text_size: 18,
+        ..iced::Settings::default()
+    }
+}

--- a/src/widget/spin_button/mod.rs
+++ b/src/widget/spin_button/mod.rs
@@ -45,7 +45,7 @@ impl<T: 'static + Copy + Hash + ToString, Message: 'static> SpinButton<T, Messag
         let Self { on_change, value } = self;
 
         Element::from(iced_lazy::lazy(
-            value,
+            (value, crate::settings::default_icon_theme()),
             move || -> Element<'static, SpinMessage> {
                 container(
                     row![


### PR DESCRIPTION
Applications may now override the default icon theme application-wide using a new convenience function. Typically called before running the application.

```rs
cosmic::settings::set_default_icon_theme("Pop");
```

It can be applied at any moment during the lifetime of the application. The cosmic example has been updated to demonstrate the ability to dynamically switch between loading icons from the Pop and Adwaita themes. Ideally we'll want to support loading this setting from a configuration file of some kind, too.

Closes #61 