### PR TITLE
ci: Test variant without shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         - 'winit_softbuffer tokio'
         - winit_softbuffer
         - winit_wgpu
+        - softbuffer
         - wayland
         - applet
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This adds the feature set cosmic-comp uses for libcosmic to the CI feature matrix, to avoid breaking compiling without a shell feature enabled.

Recently the keyboard_nav-widget broke this, which is why this also updates iced to include https://github.com/pop-os/iced/pull/25.