### PR TITLE
Add tokio-based `SingleThreadExecutor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ debug = ["iced/debug"]
 softbuffer = ["iced/softbuffer", "iced_softbuffer"]
 wayland = ["iced/wayland", "iced/glow"]
 wgpu = ["iced/wgpu", "iced_wgpu"]
-tokio = ["iced/tokio"]
+tokio = ["dep:tokio", "iced/tokio"]
 winit = ["iced/winit", "iced_winit"]
 applet = ["cosmic-panel-config", "sctk", "wayland"]
 winit_softbuffer = ["winit", "softbuffer"]
@@ -23,6 +23,7 @@ apply = "0.3.0"
 derive_setters = "0.1.5"
 lazy_static = "1.4.0"
 palette = "0.6.1"
+tokio = { version = "1.24.2", optional = true }
 cosmic-panel-config = {git = "https://github.com/pop-os/cosmic-panel", optional = true }
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", optional = true, rev = "3776d4a" }
 slotmap = "1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "cosmic"
 default = ["softbuffer", "winit", "tokio"]
 debug = ["iced/debug"]
 softbuffer = ["iced/softbuffer", "iced_softbuffer"]
-wayland = ["iced/wayland", "iced/glow"]
+wayland = ["iced/wayland", "iced/glow", "iced_sctk"]
 wgpu = ["iced/wgpu", "iced_wgpu"]
 tokio = ["dep:tokio", "iced/tokio"]
 winit = ["iced/winit", "iced_winit"]
@@ -51,6 +51,10 @@ optional = true
 
 [dependencies.iced_style]
 path = "iced/style"
+
+[dependencies.iced_sctk]
+path = "iced/sctk"
+optional = true
 
 [dependencies.iced_winit]
 path = "iced/winit"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,11 @@ pub mod keyboard_nav;
 pub mod theme;
 pub mod widget;
 
+#[cfg(feature = "tokio")]
+mod single_thread_executor;
+#[cfg(feature = "tokio")]
+pub use single_thread_executor::SingleThreadExecutor;
+
 pub mod settings;
 pub use settings::settings;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 pub use iced;
 pub use iced_lazy;
 pub use iced_native;
+#[cfg(feature = "wayland")]
+pub use iced_sctk;
 pub use iced_style;
 #[cfg(feature = "winit")]
 pub use iced_winit;

--- a/src/single_thread_executor.rs
+++ b/src/single_thread_executor.rs
@@ -1,0 +1,28 @@
+use std::{future::Future, thread};
+
+#[cfg(feature = "tokio")]
+pub struct SingleThreadExecutor(tokio::runtime::Runtime);
+
+#[cfg(feature = "tokio")]
+impl iced_native::Executor for SingleThreadExecutor {
+    fn new() -> Result<Self, iced::futures::io::Error> {
+        // Current thread executor requires calling `block_on` to actually run
+        // futures. Main thread is busy with things other than running futures,
+        // so spawn a single worker thread.
+        Ok(Self(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()?,
+        ))
+    }
+
+    fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
+        let _ = self.0.spawn(future);
+    }
+
+    fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _guard = self.0.enter();
+        f()
+    }
+}


### PR DESCRIPTION
At least for applets, this is probably better than spawning a tokio worker thread per CPU thread.