### PR TITLE
Configurable close icons for view switching

### DIFF
--- a/examples/cosmic/Cargo.toml
+++ b/examples/cosmic/Cargo.toml
@@ -10,3 +10,4 @@ apply = "0.3.0"
 fraction = "0.13.0"
 libcosmic = { path = "../..", default-features = false, features = ["debug", "winit_softbuffer"] }
 once_cell = "1.15"
+slotmap = "1.0.6"

--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -28,6 +28,8 @@ mod demo;
 use self::desktop::DesktopPage;
 mod desktop;
 
+mod editor;
+
 use self::input_devices::InputDevicesPage;
 mod input_devices;
 
@@ -51,6 +53,7 @@ pub trait SubPage {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Page {
     Demo,
+    Editor,
     WiFi,
     Networking(Option<NetworkingPage>),
     Bluetooth,
@@ -74,6 +77,7 @@ impl Page {
         use Page::*;
         match self {
             Demo => "Demo",
+            Editor => "Editor",
             WiFi => "Wi-Fi",
             Networking(_) => "Networking",
             Bluetooth => "Bluetooth",
@@ -96,6 +100,7 @@ impl Page {
         use Page::*;
         match self {
             Demo => "document-properties-symbolic",
+            Editor => "text-editor-symbolic",
             WiFi => "network-wireless-symbolic",
             Networking(_) => "network-workgroup-symbolic",
             Bluetooth => "bluetooth-active-symbolic",
@@ -130,6 +135,7 @@ pub struct Window {
     bluetooth: bluetooth::State,
     debug: bool,
     demo: demo::State,
+    editor: editor::State,
     desktop: desktop::State,
     nav_bar: segmented_button::SingleSelectModel,
     nav_id_to_page: segmented_button::SecondaryMap<Page>,
@@ -178,6 +184,7 @@ pub enum Message {
     Demo(demo::Message),
     Desktop(desktop::Message),
     Drag,
+    Editor(editor::Message),
     InputChanged,
     KeyboardNav(keyboard_nav::Message),
     Maximize,
@@ -318,6 +325,7 @@ impl Application for Window {
         window.warning_message = String::from("You were not supposed to touch that.");
 
         window.insert_page(Page::Demo);
+        window.insert_page(Page::Editor);
         window.insert_page(Page::WiFi);
         window.insert_page(Page::Networking(None));
         window.insert_page(Page::Bluetooth);
@@ -386,6 +394,7 @@ impl Application for Window {
                 Some(demo::Output::ToggleWarning) => self.toggle_warning(),
                 None => (),
             },
+            Message::Editor(message) => self.editor.update(message),
             Message::Desktop(message) => match self.desktop.update(message) {
                 Some(desktop::Output::Page(page)) => self.page(page),
                 None => (),
@@ -460,6 +469,7 @@ impl Application for Window {
         if !(self.is_condensed() && nav_bar_toggled) {
             let content: Element<_> = match self.page {
                 Page::Demo => self.demo.view(self).map(Message::Demo),
+                Page::Editor => self.editor.view(self).map(Message::Editor),
                 Page::Networking(None) => settings::view_column(vec![
                     self.page_title(self.page),
                     column!(

--- a/examples/cosmic/src/window/editor.rs
+++ b/examples/cosmic/src/window/editor.rs
@@ -1,0 +1,78 @@
+use cosmic::iced::widget::row;
+use cosmic::iced::Length;
+use cosmic::iced_winit::Alignment;
+use cosmic::widget::{button, segmented_button, view_switcher};
+use cosmic::{theme, Element};
+use slotmap::Key;
+
+#[derive(Clone, Copy, Debug)]
+pub enum Message {
+    Activate(segmented_button::Entity),
+    AddNew,
+    Close(segmented_button::Entity),
+}
+
+pub struct State {
+    pub pages: segmented_button::SingleSelectModel,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        let mut state = Self {
+            pages: segmented_button::Model::default(),
+        };
+
+        let id = state.tab_add_new();
+        state.pages.activate(id);
+
+        state
+    }
+}
+
+impl State {
+    pub(super) fn update(&mut self, message: Message) {
+        match message {
+            Message::Activate(id) => self.pages.activate(id),
+            Message::AddNew => {
+                self.tab_add_new();
+            }
+            Message::Close(id) => self.tab_close(id),
+        }
+    }
+
+    pub fn tab_add_new(&mut self) -> segmented_button::Entity {
+        let id = self.pages.insert().closable().id();
+
+        self.pages
+            .text_set(id, format!("Tab {}", id.data().as_ffi() & 0xffff_ffff));
+
+        id
+    }
+
+    pub fn tab_close(&mut self, id: segmented_button::Entity) {
+        if self.pages.is_active(id) {
+            if let Some(pos) = self.pages.position(id) {
+                let next = if pos == 0 { pos + 1 } else { pos - 1 };
+                self.pages.activate_position(next);
+            }
+        }
+
+        self.pages.remove(id);
+    }
+
+    pub(super) fn view<'a>(&'a self, window: &'a super::Window) -> Element<'a, Message> {
+        let tabs = view_switcher::horizontal(&self.pages)
+            .show_close_icon_on_hover(true)
+            .on_activate(Message::Activate)
+            .on_close(Message::Close)
+            .width(Length::Fill);
+
+        let new_tab_button = button(theme::Button::Text)
+            .icon(theme::Svg::Symbolic, "tab-new-symbolic", 20)
+            .on_press(Message::AddNew);
+
+        row!(tabs, new_tab_button)
+            .align_items(Alignment::Center)
+            .into()
+    }
+}

--- a/examples/cosmic/src/window/editor.rs
+++ b/examples/cosmic/src/window/editor.rs
@@ -1,4 +1,5 @@
-use cosmic::iced::widget::row;
+use apply::Apply;
+use cosmic::iced::widget::{horizontal_space, row, scrollable};
 use cosmic::iced::Length;
 use cosmic::iced_winit::Alignment;
 use cosmic::widget::{button, segmented_button, view_switcher};
@@ -65,14 +66,14 @@ impl State {
             .show_close_icon_on_hover(true)
             .on_activate(Message::Activate)
             .on_close(Message::Close)
-            .width(Length::Fill);
+            .width(Length::Shrink);
 
         let new_tab_button = button(theme::Button::Text)
             .icon(theme::Svg::Symbolic, "tab-new-symbolic", 20)
             .on_press(Message::AddNew);
 
-        row!(tabs, new_tab_button)
-            .align_items(Alignment::Center)
-            .into()
+        let tab_header = row!(tabs, new_tab_button).align_items(Alignment::Center);
+
+        row!(tab_header, horizontal_space(Length::Fill)).into()
     }
 }

--- a/src/widget/nav_bar.rs
+++ b/src/widget/nav_bar.rs
@@ -19,7 +19,7 @@ use crate::{theme, widget::segmented_button, Theme};
 /// For details on the model, see the [`segmented_button`] module for more details.
 pub fn nav_bar<Message>(
     model: &segmented_button::SingleSelectModel,
-    on_activate: impl Fn(segmented_button::Entity) -> Message + 'static,
+    on_activate: fn(segmented_button::Entity) -> Message,
 ) -> iced::widget::Container<Message, crate::Renderer>
 where
     Message: Clone + 'static,

--- a/src/widget/segmented_button/mod.rs
+++ b/src/widget/segmented_button/mod.rs
@@ -97,3 +97,11 @@ pub type SecondaryMap<T> = slotmap::SecondaryMap<Entity, T>;
 ///
 /// Sparse maps internally use a `HashMap`, for data that is sparsely associated.
 pub type SparseSecondaryMap<T> = slotmap::SparseSecondaryMap<Entity, T>;
+
+/// Defines the color of the icon for a segmented item.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+enum IconColor {
+    #[default]
+    None,
+    Color(crate::iced::Color),
+}

--- a/src/widget/segmented_button/model/builder.rs
+++ b/src/widget/segmented_button/model/builder.rs
@@ -48,6 +48,13 @@ where
         self
     }
 
+    /// Defines that the close button should appear
+    #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
+    pub fn closable(mut self) -> Self {
+        self.model.0.closable_set(self.id, true);
+        self
+    }
+
     /// Associates extra data with an external secondary map.
     ///
     /// The secondary map internally uses a `Vec`, so should only be used for data that

--- a/src/widget/segmented_button/model/builder.rs
+++ b/src/widget/segmented_button/model/builder.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use iced::Color;
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 
 use super::{Entity, Model, Selectable};
@@ -105,6 +106,13 @@ where
     #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
     pub fn icon(mut self, icon: impl Into<IconSource<'static>>) -> Self {
         self.model.0.icon_set(self.id, icon);
+        self
+    }
+
+    /// Defines the color of an icon.
+    #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
+    pub fn icon_color(mut self, icon: Option<Color>) -> Self {
+        self.model.0.icon_color_set(self.id, icon);
         self
     }
 

--- a/src/widget/segmented_button/model/entity.rs
+++ b/src/widget/segmented_button/model/entity.rs
@@ -63,6 +63,13 @@ where
         self
     }
 
+    /// Shows a close button for this item.
+    #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
+    pub fn closable(self) -> Self {
+        self.model.closable_set(self.id, true);
+        self
+    }
+
     /// Associates data with the item.
     ///
     /// There may only be one data component per Rust type.

--- a/src/widget/segmented_button/model/entity.rs
+++ b/src/widget/segmented_button/model/entity.rs
@@ -3,6 +3,7 @@
 
 use std::borrow::Cow;
 
+use iced::Color;
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 
 use crate::widget::IconSource;
@@ -91,6 +92,13 @@ where
     #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
     pub fn icon(self, icon: impl Into<IconSource<'static>>) -> Self {
         self.model.icon_set(self.id, icon);
+        self
+    }
+
+    /// Define the color for the icon.
+    #[allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
+    pub fn icon_color(self, icon: Option<Color>) -> Self {
+        self.model.icon_color_set(self.id, icon);
         self
     }
 

--- a/src/widget/segmented_button/model/mod.rs
+++ b/src/widget/segmented_button/model/mod.rs
@@ -11,10 +11,13 @@ mod selection;
 pub use self::selection::{MultiSelect, Selectable, SingleSelect};
 
 use crate::widget::IconSource;
+use iced::Color;
 use slotmap::{SecondaryMap, SlotMap};
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
+
+use super::IconColor;
 
 slotmap::new_key_type! {
     /// A unique ID for an item in the [`Model`].
@@ -242,6 +245,24 @@ where
         }
 
         self.icons.insert(id, icon.into())
+    }
+
+    /// Sets the color of the icon. By default, the color matches the text.
+    pub fn icon_color_set(&mut self, id: Entity, color: Option<Color>) {
+        if self.contains_item(id) {
+            self.data_set(
+                id,
+                match color {
+                    Some(color) => IconColor::Color(color),
+                    None => IconColor::None,
+                },
+            );
+        }
+    }
+
+    /// Unsets the defined color of an icon.
+    pub fn icon_color_remove(&mut self, id: Entity) {
+        self.data_remove::<IconColor>(id);
     }
 
     /// Removes the icon from an item.

--- a/src/widget/segmented_button/model/selection.rs
+++ b/src/widget/segmented_button/model/selection.rs
@@ -33,8 +33,10 @@ impl Selectable for Model<SingleSelect> {
         self.selection.active = id;
     }
 
-    fn deactivate(&mut self, _id: Entity) {
-        self.selection.active = Entity::default();
+    fn deactivate(&mut self, id: Entity) {
+        if id == self.selection.active {
+            self.selection.active = Entity::default();
+        }
     }
 
     fn is_active(&self, id: Entity) -> bool {

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -3,6 +3,7 @@
 
 use super::model::{Entity, Model, Selectable};
 use super::style::StyleSheet;
+use super::IconColor;
 use crate::widget::{icon, IconSource};
 use derive_setters::Setters;
 use iced::{
@@ -466,6 +467,12 @@ where
                 status_appearance.middle
             };
 
+            let icon_color = match self.model.data::<IconColor>(key).copied() {
+                Some(IconColor::None) => None,
+                Some(IconColor::Color(color)) => Some(color),
+                None => Some(status_appearance.text_color),
+            };
+
             // Render the background of the button.
             if status_appearance.background.is_some() {
                 renderer.fill_quad(
@@ -529,12 +536,7 @@ where
                         unimplemented!()
                     }
                     icon::Handle::Svg(handle) => {
-                        iced_native::svg::Renderer::draw(
-                            renderer,
-                            handle,
-                            Some(status_appearance.text_color),
-                            icon_bounds,
-                        );
+                        iced_native::svg::Renderer::draw(renderer, handle, icon_color, icon_bounds);
                     }
                 }
 

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -234,7 +234,7 @@ where
             // Add close button to measurement if found.
             if self.model.is_closable(key) {
                 button_height = button_height.max(f32::from(self.icon_size));
-                button_width += f32::from(self.icon_size) + f32::from(self.button_spacing);
+                button_width += f32::from(self.icon_size) + f32::from(self.button_spacing) + 8.0;
             }
 
             height = height.max(button_height);
@@ -656,13 +656,11 @@ impl From<Id> for widget::Id {
 
 /// Calculates the bounds of the close button within the area of an item.
 fn close_bounds(area: Rectangle<f32>, icon_size: f32, button_padding: [u16; 4]) -> Rectangle<f32> {
-    let top = f32::from(button_padding[1]);
-    let end = f32::from(button_padding[2]);
-    let unpadded_height = area.height - top - end;
+    let unpadded_height = area.height - f32::from(button_padding[1]) - f32::from(button_padding[3]);
 
     Rectangle {
-        x: area.x + area.width - icon_size - f32::from(button_padding[2]),
-        y: area.y + f32::from(button_padding[1]) + (unpadded_height / 2.0),
+        x: area.x + area.width - icon_size - 8.0,
+        y: area.y + (unpadded_height / 2.0) - (icon_size / 2.0),
         width: icon_size,
         height: icon_size,
     }


### PR DESCRIPTION
These changes extend the functionality of the segmented button widget to support optional and configurable use of close icons which can emit close messages on click. As well as making it possible to override the default color assigned to an item's icon.

An example is also included, and the `IconSource` enum is refactored to unify the `Embedded` and `EmbeddedSvg` variants as a `Handle` variant, using the existing `icon::Handle` enum.

---

Adds support for displaying and handling tab closes, as well as displaying the close icon only on tabs which are hovered or active.

```rs
view_switcher::horizontal(&app.tabs)
    .show_close_icon_on_hover(true)
    .on_activate(Message::TabActivate)
    .on_close(Message::TabClose)
```

Items will display a close icon only if the closable property is set.

```rs
let id = self.tabs.insert().closable().id();
```

By default, `window-close-symbolic` is being used as the close icon, but it can be changed with

```rs
view_switcher::horizontal(&app.tabs)
    .close_icon(IconSource::from("window-close-symbolic"))
```

To activate the item adjacent to the active item on remove, this can be used:

```rs
if self.tabs.is_active(id) {
    if let Some(pos) = self.tabs.position(id) {
        let next = if pos == 0 { pos + 1 } else { pos - 1 };
        self.tabs.activate_position(next);
    }
}

self.tabs.remove(id);
```

The color of an icon can be modified per-item. By default, icons will be filled with the same color as the text. This behavior can be modified by specifying a color (or lack of color):

```rs
let id = self.tabs.insert()
    .closable()
    .icon_color(None)
    .id();
```

Or with

```rs
self.tabs.icon_color_set(id, None);
self.tabs.icon_color_remove(id);
```

When the color is unset, it will match the same color as the text. When set to `None`, it will not modify the color. And setting it to `Some` color will use that color instead of the default.