### PR TITLE
Fix build on Windows/non-Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ winit = ["iced/winit", "iced_winit"]
 applet = ["cosmic-panel-config", "sctk", "wayland"]
 winit_softbuffer = ["winit", "softbuffer"]
 winit_wgpu = ["winit", "wgpu"]
+
 [dependencies]
-freedesktop-icons = "0.2.2"
 apply = "0.3.0"
 derive_setters = "0.1.5"
 lazy_static = "1.4.0"
@@ -29,6 +29,9 @@ cosmic-panel-config = {git = "https://github.com/pop-os/cosmic-panel", optional 
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", optional = true, rev = "389a4f2" }
 slotmap = "1.0.6"
 fraction = "0.13.0"
+
+[target.'cfg(unix)'.dependencies]
+freedesktop-icons = "0.2.2"
 
 [dependencies.cosmic-theme]
 git = "https://github.com/pop-os/cosmic-theme.git"

--- a/src/widget/icon.rs
+++ b/src/widget/icon.rs
@@ -35,6 +35,7 @@ impl<'a> IconSource<'a> {
         let icon: Option<&Path> = match self {
             IconSource::Handle(handle) => return handle.clone(),
             IconSource::Path(ref path) => Some(path),
+            #[cfg(unix)]
             IconSource::Name(ref name) => {
                 let icon = crate::settings::DEFAULT_ICON_THEME.with(|default_theme| {
                     let default_theme: &str = &default_theme.borrow();
@@ -56,6 +57,9 @@ impl<'a> IconSource<'a> {
 
                 name_path_buffer.as_deref()
             }
+            // TODO: Icon loading mechanism for non-Unix systems
+            #[cfg(not(unix))]
+            IconSource::Name(_) => None,
         };
 
         let is_svg = svg


### PR DESCRIPTION
We'll need libcosmic to work on Windows and macOS if we want to use it in the Keyboard Configurator.

`freedesktop-icons` doesn't seem to build on Windows, so only use it on Unix systems. It does seem to build on macOS, so leave it as a dependency there. A good solution for icon bundling on macOS/Windows will need to be figured out at some point.