### PR TITLE
theme: Use boxed functions instead `fn` pointers

### DIFF
--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -277,7 +277,7 @@ impl Window {
                 .spacing(16),
             )
             .padding([20, 24])
-            .style(theme::Container::Custom(list::column::style)),
+            .style(theme::Container::custom(list::column::style)),
         )
         .padding(0)
         .style(theme::Button::Transparent)

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -19,16 +19,18 @@ pub use cosmic_panel_config;
 
 const APPLET_PADDING: u32 = 8;
 
-pub const APPLET_BUTTON_THEME: Button = Button::Custom {
-    active: |t| iced_style::button::Appearance {
-        border_radius: BorderRadius::from(0.0),
-        ..t.active(&Button::Text)
-    },
-    hover: |t| iced_style::button::Appearance {
-        border_radius: BorderRadius::from(0.0),
-        ..t.hovered(&Button::Text)
-    },
-};
+pub fn applet_button_theme() -> Button {
+    Button::Custom {
+        active: Box::new(|t| iced_style::button::Appearance {
+            border_radius: BorderRadius::from(0.0),
+            ..t.active(&Button::Text)
+        }),
+        hover: Box::new(|t| iced_style::button::Appearance {
+            border_radius: BorderRadius::from(0.0),
+            ..t.hovered(&Button::Text)
+        }),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct CosmicAppletHelper {
@@ -130,7 +132,7 @@ impl CosmicAppletHelper {
         };
 
         Container::<Message, Renderer>::new(Container::<Message, Renderer>::new(content).style(
-            crate::theme::Container::Custom(|theme| Appearance {
+            crate::theme::Container::custom(|theme| Appearance {
                 text_color: Some(theme.cosmic().background.on.into()),
                 background: Some(Color::from(theme.cosmic().background.base).into()),
                 border_radius: 12.0,

--- a/src/theme/expander.rs
+++ b/src/theme/expander.rs
@@ -52,7 +52,7 @@ impl std::default::Default for Appearance {
 
 /// A set of rules that dictate the [`Appearance`] of a container.
 pub trait StyleSheet {
-    type Style: Default + Copy;
+    type Style: Default;
 
     /// Produces the [`Appearance`] of a container.
     fn appearance(&self, style: Self::Style) -> Appearance;

--- a/src/theme/segmented_button.rs
+++ b/src/theme/segmented_button.rs
@@ -6,7 +6,7 @@ use crate::{theme::Theme, widget::segmented_button::ItemStatusAppearance};
 use iced_core::{Background, BorderRadius};
 use palette::{rgb::Rgb, Alpha};
 
-#[derive(Clone, Copy, Default)]
+#[derive(Default)]
 pub enum SegmentedButton {
     /// A tabbed widget for switching between views in an interface.
     #[default]
@@ -14,7 +14,7 @@ pub enum SegmentedButton {
     /// A widget for multiple choice selection.
     Selection,
     /// Or implement any custom theme of your liking.
-    Custom(fn(&Theme) -> Appearance),
+    Custom(Box<dyn Fn(&Theme) -> Appearance>),
 }
 
 impl StyleSheet for Theme {

--- a/src/widget/icon.rs
+++ b/src/widget/icon.rs
@@ -207,7 +207,7 @@ impl<'a> Icon<'a> {
 
     fn svg_element<Message: 'static>(&self, handle: svg::Handle) -> Element<'static, Message> {
         svg::Svg::<Renderer>::new(handle)
-            .style(self.style)
+            .style(self.style.clone())
             .width(self.width.unwrap_or(Length::Units(self.size)))
             .height(self.height.unwrap_or(Length::Units(self.size)))
             .content_fit(self.content_fit)

--- a/src/widget/list/column.rs
+++ b/src/widget/list/column.rs
@@ -45,7 +45,7 @@ impl<'a, Message: 'static> ListColumn<'a, Message> {
             .spacing(12)
             .apply(iced::widget::container)
             .padding([16, 6])
-            .style(theme::Container::Custom(style))
+            .style(theme::Container::custom(style))
             .into()
     }
 }

--- a/src/widget/nav_bar.rs
+++ b/src/widget/nav_bar.rs
@@ -36,7 +36,7 @@ where
         .apply(container)
         .height(Length::Fill)
         .padding(11)
-        .style(theme::Container::Custom(nav_bar_style))
+        .style(theme::Container::custom(nav_bar_style))
 }
 
 #[must_use]

--- a/src/widget/search/field.rs
+++ b/src/widget/search/field.rs
@@ -58,7 +58,7 @@ impl<'a, Message: 'static + Clone> Field<'a, Message> {
         .spacing(8)
         .align_items(iced::Alignment::Center)
         .apply(container)
-        .style(crate::theme::Container::Custom(active_style))
+        .style(crate::theme::Container::custom(active_style))
         .into()
     }
 }

--- a/src/widget/spin_button/mod.rs
+++ b/src/widget/spin_button/mod.rs
@@ -83,7 +83,7 @@ impl<'a, Message: 'static> SpinButton<'a, Message> {
         .align_y(Vertical::Center)
         .width(Length::Units(95))
         .height(Length::Units(32))
-        .style(theme::Container::Custom(container_style))
+        .style(theme::Container::custom(container_style))
         .apply(Element::from)
         .map(on_change)
     }

--- a/src/widget/warning.rs
+++ b/src/widget/warning.rs
@@ -51,7 +51,7 @@ impl<'a, Message: 'static + Clone> Warning<'a, Message> {
             ])
             .align_items(Alignment::Center),
         )
-        .style(theme::Container::Custom(warning_container))
+        .style(theme::Container::custom(warning_container))
         .padding(10)
         .align_y(alignment::Vertical::Center)
         .width(Length::Fill)


### PR DESCRIPTION
This is more general, and necessary if the custom theming is dynamically generated.

Iced's builtin theme also uses `Box`ed `Fn`, or `Rc` where clone is required, so this seems reasonable.

Only `Text` is left using `fn`, since it needs to be `Copy`. Hopefully that can be changed in Iced at some point.

`::custom` methods are added to make these variants a little more convenient to construct. This replaces a couple `From` implementations, which are potentially problematic with a generic.