### PR TITLE
cosmic-config: Don't pull all of iced's dependencies

### DIFF
--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -16,6 +16,6 @@ notify = "6.0.0"
 ron = "0.8.0"
 serde = "1.0.152"
 cosmic-config-derive = { path = "../cosmic-config-derive/", optional = true }
-iced = { path = "../iced/", optional = true }
-iced_futures = { path = "../iced/futures/", optional = true }
+iced = { path = "../iced/", default-features = false,  optional = true }
+iced_futures = { path = "../iced/futures/", default-features = false, optional = true }
 


### PR DESCRIPTION
In combination with https://github.com/pop-os/iced/pull/43 this drops cosmic-configs dependencies even when using subscriptions.