### PR TITLE
feat: icon default fallbacks

### DIFF
--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -3,7 +3,7 @@ use cosmic::{
     cosmic_theme,
     iced::widget::{checkbox, column, pick_list, progress_bar, radio, slider, text, text_input},
     iced::{id, Alignment, Length},
-    theme::{self, Button as ButtonTheme, Theme, ThemeType},
+    theme::{self, Button as ButtonTheme, ThemeType},
     widget::{
         button, container, icon, segmented_button, segmented_selection, settings, spin_button,
         toggler, view_switcher,
@@ -417,11 +417,19 @@ impl State {
                 .padding(8)
                 .width(Length::Fill)
                 .into(),
-            container(text("Primary container with some text").size(24))
-                .layer(cosmic_theme::Layer::Primary)
-                .padding(8)
-                .width(Length::Fill)
-                .into(),
+            container(column![
+                text(
+                    "Primary container with some text and a couple icons testing default fallbacks"
+                )
+                .size(24),
+                icon("microphone-sensitivity-high-symbolic-test", 24)
+                    .style(cosmic::theme::Svg::SymbolicActive),
+                icon("microphone-sensitivity-high-symbolic-test", 16).default_fallbacks(false)
+            ])
+            .layer(cosmic_theme::Layer::Primary)
+            .padding(8)
+            .width(Length::Fill)
+            .into(),
             container(text("Secondary container with some text").size(24))
                 .layer(cosmic_theme::Layer::Secondary)
                 .padding(8)

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -542,7 +542,7 @@ where
                 bounds.x += offset;
                 bounds.width -= offset;
 
-                match icon.load(self.icon_size, None, false) {
+                match icon.load(self.icon_size, None, false, true) {
                     icon::Handle::Image(_handle) => {
                         unimplemented!()
                     }
@@ -583,7 +583,7 @@ where
                 let width = f32::from(self.icon_size);
                 let icon_bounds = close_bounds(original_bounds, width, self.button_padding);
 
-                match self.close_icon.load(self.icon_size, None, false) {
+                match self.close_icon.load(self.icon_size, None, false, true) {
                     icon::Handle::Image(_handle) => {
                         unimplemented!()
                     }


### PR DESCRIPTION
This makes icon lookup search for default fallbacks on failure, found by shortening the icon name at ‘-‘ characters.