### PR TITLE
Fix derive setter for default_icon_theme.

### DIFF
--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -26,7 +26,7 @@ pub struct Settings {
     pub(crate) default_font: Font,
 
     /// Name of the icon theme to search by default.
-    #[setters(into, strip_option)]
+    #[setters(skip)]
     pub(crate) default_icon_theme: Option<String>,
 
     /// Default size of fonts.
@@ -51,6 +51,19 @@ pub struct Settings {
 
     /// Whether the window should be transparent.
     pub(crate) transparent: bool,
+}
+
+impl Settings {
+    /// Sets the default icon theme, passing an empty string will unset the theme.
+    pub fn default_icon_theme(mut self, value: impl Into<String>) -> Self {
+        let value: String = value.into();
+        self.default_icon_theme = if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        };
+        self
+    }
 }
 
 impl Default for Settings {

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -60,7 +60,7 @@ impl Settings {
         self.default_icon_theme = if value.is_empty() {
             None
         } else {
-            Some(value.to_string())
+            Some(value)
         };
         self
     }

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -26,7 +26,7 @@ pub struct Settings {
     pub(crate) default_font: Font,
 
     /// Name of the icon theme to search by default.
-    #[setters(into)]
+    #[setters(into, strip_option)]
     pub(crate) default_icon_theme: Option<String>,
 
     /// Default size of fonts.

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -57,11 +57,7 @@ impl Settings {
     /// Sets the default icon theme, passing an empty string will unset the theme.
     pub fn default_icon_theme(mut self, value: impl Into<String>) -> Self {
         let value: String = value.into();
-        self.default_icon_theme = if value.is_empty() {
-            None
-        } else {
-            Some(value)
-        };
+        self.default_icon_theme = if value.is_empty() { None } else { Some(value) };
         self
     }
 }


### PR DESCRIPTION
Uses manual implementation for setting the icon theme so that an empty string is treated as `None`.

Fixes this error message in the application example

```sh
error[E0277]: the trait bound `Option<String>: From<&str>` is not satisfied
  --> examples/application/src/main.rs:24:29
   |
24 |         .default_icon_theme("Pop")
   |          ------------------ ^^^^^^^^^ the trait `From<&str>` is not implemented for `Option<String>`
   |          |
   |          required by a bound introduced by this call
```