### PR TITLE
fix(app): draggable windows on X11 systems using winit

### DIFF
--- a/examples/application/Cargo.toml
+++ b/examples/application/Cargo.toml
@@ -10,4 +10,4 @@ tracing-subscriber = "0.3.17"
 [dependencies.libcosmic]
 path = "../../"
 default-features = false
-features = ["debug", "wayland", "tokio"]
+features = ["debug", "winit", "tokio"]

--- a/examples/application/src/main.rs
+++ b/examples/application/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .antialiasing(true)
         .client_decorations(true)
         .debug(false)
-        .default_icon_theme(Some("Pop".into()))
+        .default_icon_theme("Pop")
         .default_text_size(16.0)
         .scale_factor(1.0)
         .size((1024, 768))

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,8 +14,6 @@ use iced_runtime::command::platform_specific::wayland::Action as WaylandAction;
 #[cfg(feature = "wayland")]
 use iced_runtime::command::platform_specific::Action as PlatformAction;
 use iced_runtime::command::Action;
-#[cfg(not(feature = "wayland"))]
-use iced_runtime::window::Action as WindowAction;
 use std::future::Future;
 
 /// Yields a command which contains a batch of commands.
@@ -42,7 +40,7 @@ pub fn drag<M>() -> Command<M> {
 /// Initiates a window drag.
 #[cfg(not(feature = "wayland"))]
 pub fn drag<M>() -> Command<M> {
-    iced::Command::none()
+    iced_runtime::window::drag()
 }
 
 /// Fullscreens the window.
@@ -54,7 +52,7 @@ pub fn fullscreen<M>() -> Command<M> {
 /// Fullscreens the window.
 #[cfg(not(feature = "wayland"))]
 pub fn fullscreen<M>() -> Command<M> {
-    iced::Command::single(Action::Window(WindowAction::ChangeMode(Mode::Fullscreen)))
+    iced_runtime::window::change_mode(Mode::Fullscreen)
 }
 
 /// Minimizes the window.
@@ -66,7 +64,7 @@ pub fn minimize<M>() -> Command<M> {
 /// Minimizes the window.
 #[cfg(not(feature = "wayland"))]
 pub fn minimize<M>() -> Command<M> {
-    iced::Command::single(Action::Window(WindowAction::ChangeMode(Mode::Hidden)))
+    iced_runtime::window::minimize(true)
 }
 
 /// Sets the title of a window.
@@ -94,7 +92,7 @@ pub fn set_windowed<M>() -> Command<M> {
 /// Sets the window mode to windowed.
 #[cfg(not(feature = "wayland"))]
 pub fn set_windowed<M>() -> Command<M> {
-    iced::Command::single(Action::Window(WindowAction::ChangeMode(Mode::Windowed)))
+    iced_runtime::window::change_mode(Mode::Windowed)
 }
 
 /// Toggles the windows' maximization state.
@@ -106,7 +104,7 @@ pub fn toggle_fullscreen<M>() -> Command<M> {
 /// Toggles the windows' maximization state.
 #[cfg(not(feature = "wayland"))]
 pub fn toggle_fullscreen<M>() -> Command<M> {
-    iced::Command::single(Action::Window(WindowAction::ToggleMaximize))
+    iced_runtime::window::toggle_maximize()
 }
 
 /// Creates a command to apply an action to a window.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -22,7 +22,7 @@ pub fn batch<M>(commands: impl IntoIterator<Item = Command<M>>) -> Command<M> {
 }
 
 /// Yields a command which will run the future on the runtime executor.
-pub fn future<M: Send + 'static>(future: impl Future<Output = M> + Send + 'static) -> Command<M> {
+pub fn future<M>(future: impl Future<Output = M> + Send + 'static) -> Command<M> {
     Command::single(Action::Future(Box::pin(future)))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod app;
 pub use app::{Application, ApplicationExt};
 
+pub use iced::Command;
 pub mod command;
 pub use cosmic_config;
 pub use cosmic_theme;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -3,6 +3,17 @@
 
 //! Cosmic-themed widget implementations.
 
+// Re-exports from Iced
+pub use iced::widget::{checkbox, Checkbox};
+pub use iced::widget::{column, Column};
+pub use iced::widget::{image, Image};
+pub use iced::widget::{pick_list, PickList};
+pub use iced::widget::{radio, Radio};
+pub use iced::widget::{row, Row};
+pub use iced::widget::{slider, Slider};
+pub use iced::widget::{space, Space};
+pub use iced::widget::{text_input, TextInput};
+
 pub mod aspect_ratio;
 
 mod button;
@@ -37,20 +48,15 @@ pub use popover::{popover, Popover};
 
 pub mod rectangle_tracker;
 
+mod scrollable;
+pub use scrollable::*;
+
 pub mod search;
 
 pub mod segmented_button;
-pub use segmented_button::horizontal as horizontal_segmented_button;
-pub use segmented_button::vertical as vertical_segmented_button;
-
 pub mod segmented_selection;
-pub use segmented_selection::horizontal as horizontal_segmented_selection;
-pub use segmented_selection::vertical as vertical_segmented_selection;
 
 pub mod settings;
-
-mod scrollable;
-pub use scrollable::*;
 
 pub mod spin_button;
 pub use spin_button::{spin_button, SpinButton};


### PR DESCRIPTION
This will enable the window drag feature to work when clicking and dragging the headerbar in an libcosmic application using the Application trait. The default feature for the application example is now `winit`. Although usable in Wayland, window drag and resize does not work in Wayland since it's not supported by winit right now.