### PR TITLE
app/applet: set `size_limits` to `None` for `autosize`

### DIFF
--- a/src/app/applet/mod.rs
+++ b/src/app/applet/mod.rs
@@ -220,6 +220,9 @@ pub fn run<App: Application>(autosize: bool, flags: App::Flags) -> iced::Result 
     let helper = CosmicAppletHelper::default();
     let mut settings = helper.window_settings();
     settings.autosize = autosize;
+    if autosize {
+        settings.size_limits = Limits::NONE;
+    }
 
     if let Some(icon_theme) = settings.default_icon_theme {
         crate::icon_theme::set_default(icon_theme);


### PR DESCRIPTION
With the default size limit, autosize applets don't work as expected. Setting this to `None` seems to work fairly well, though maybe we'll need to tune some of these settings more later.