### PR TITLE
feat: allow creating apps with no main window on wayland

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -80,17 +80,21 @@ pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Res
     {
         use iced::wayland::actions::window::SctkWindowSettings;
         use iced_sctk::settings::InitialSurface;
-        iced.initial_surface = InitialSurface::XdgWindow(SctkWindowSettings {
-            app_id: Some(App::APP_ID.to_owned()),
-            autosize: settings.autosize,
-            client_decorations: settings.client_decorations,
-            resizable: settings.resizable,
-            size: settings.size,
-            size_limits: settings.size_limits,
-            title: None,
-            transparent: settings.transparent,
-            ..SctkWindowSettings::default()
-        });
+        iced.initial_surface = if settings.no_main_window {
+            InitialSurface::None
+        } else {
+            InitialSurface::XdgWindow(SctkWindowSettings {
+                app_id: Some(App::APP_ID.to_owned()),
+                autosize: settings.autosize,
+                client_decorations: settings.client_decorations,
+                resizable: settings.resizable,
+                size: settings.size,
+                size_limits: settings.size_limits,
+                title: None,
+                transparent: settings.transparent,
+                ..SctkWindowSettings::default()
+            })
+        };
     }
 
     #[cfg(not(feature = "wayland"))]

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -19,6 +19,10 @@ pub struct Settings {
     #[cfg(feature = "wayland")]
     pub(crate) autosize: bool,
 
+    /// Set the application to not create a main window
+    #[cfg(feature = "wayland")]
+    pub(crate) no_main_window: bool,
+
     /// Whether the window should have a border, a title bar, etc. or not.
     pub(crate) client_decorations: bool,
 
@@ -71,6 +75,8 @@ impl Default for Settings {
             antialiasing: true,
             #[cfg(feature = "wayland")]
             autosize: false,
+            #[cfg(feature = "wayland")]
+            no_main_window: false,
             client_decorations: true,
             debug: false,
             default_font: font::FONT,


### PR DESCRIPTION
This adds a setting for disabling the main window. It is useful for the app library, launcher and similar apps.