### PR TITLE
refactor: default the icon theme to Cosmic

### DIFF
--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -80,7 +80,7 @@ impl Default for Settings {
             client_decorations: true,
             debug: false,
             default_font: font::FONT,
-            default_icon_theme: Some(String::from("Pop")),
+            default_icon_theme: Some(String::from("Cosmic")),
             default_text_size: 14.0,
             resizable: Some(8.0),
             scale_factor: std::env::var("COSMIC_SCALE")

--- a/src/icon_theme.rs
+++ b/src/icon_theme.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 
 thread_local! {
     /// The fallback icon theme to search if no icon theme was specified.
-    pub(crate) static DEFAULT: RefCell<String> = RefCell::new(String::from("Pop"));
+    pub(crate) static DEFAULT: RefCell<String> = RefCell::new(String::from("Cosmic"));
 }
 
 /// The fallback icon theme to search if no icon theme was specified.


### PR DESCRIPTION
This would default to using icons from https://github.com/pop-os/cosmic-icons