### PR TITLE
Fixed crate dependency issue

### DIFF
--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -12,6 +12,7 @@ pub use iced::widget::{radio, Radio};
 pub use iced::widget::{row, Row};
 pub use iced::widget::{slider, Slider};
 pub use iced::widget::{space, Space};
+pub use iced::widget::{text_input as crate_text_input, TextInput};
 
 pub mod aspect_ratio;
 


### PR DESCRIPTION
The module text_input was loaded at line 80, which conflicts with the crate text_input as declared on line 15. Cargo suggests binding the crate name as other_text_input, however, I named it crate_text_input to be more descriptive. I do not know if it will be an issue later in development, but libcosmic does at least compile successfully.