### PR TITLE
chore: Update freedesktop-icons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ url = "2.4.0"
 unicode-segmentation = "1.6"
 
 [target.'cfg(unix)'.dependencies]
-freedesktop-icons = "0.2.2"
+freedesktop-icons = "0.2.4"
 
 [dependencies.cosmic-theme]
 path = "cosmic-theme"


### PR DESCRIPTION
0.2.3 and 0.2.4 contain a bunch of fixes to the icon lookup functions. Make sure we are always using the latest version.