### PR TITLE
chore: Update calloop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         features:
+        - "" # for cosmic-comp, don't remove!
         - 'winit_debug'
         - 'winit_tokio'
         - winit

--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -10,7 +10,7 @@ subscription = ["iced_futures"]
 
 [dependencies]
 atomicwrites = "0.4.0"
-calloop = { version = "0.10.5", optional = true }
+calloop = { version = "0.12.2", optional = true }
 dirs = "5.0.1"
 notify = "6.0.0"
 ron = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,21 +3,22 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-#[cfg(all(not(feature = "wayland"), not(feature = "winit")))]
-compile_error!("must define `wayland` or `winit` feature");
-
 #[cfg(all(feature = "wayland", feature = "winit"))]
 compile_error!("cannot use `wayland` feature with `winit");
 
 /// Recommended default imports.
 pub mod prelude {
     pub use crate::ext::*;
-    pub use crate::{Also, ApplicationExt, Apply, Element, Renderer, Theme};
+    #[cfg(any(feature = "winit", feature = "wayland"))]
+    pub use crate::ApplicationExt;
+    pub use crate::{Also, Apply, Element, Renderer, Theme};
 }
 
 pub use apply::{Also, Apply};
 
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub mod app;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use app::{Application, ApplicationExt};
 
 #[cfg(feature = "applet")]


### PR DESCRIPTION
Update calloop for compatibility with latest smithay

EDIT:

- Now based on https://github.com/pop-os/libcosmic/pull/174
- Updated iced to include https://github.com/pop-os/iced/pull/65
- Allow compiling without any windowing system features