### PR TITLE
cosmic-config: Add new_state constructor for storing state

### DIFF
--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -3,9 +3,7 @@
 
 use cosmic_config::{Config, ConfigGet, ConfigSet};
 
-pub fn main() {
-    let config = Config::new("com.system76.Example", 1).unwrap();
-
+fn test_config(config: Config) {
     let watcher = config
         .watch(|config, keys| {
             println!("Changed: {:?}", keys);
@@ -82,4 +80,12 @@ pub fn main() {
     );
     println!("Committing transaction");
     println!("Commit transaction: {:?}", tx.commit());
+}
+
+pub fn main() {
+    println!("Testing config");
+    test_config(Config::new("com.system76.Example", 1).unwrap());
+    
+    println!("Testing state");
+    test_config(Config::new_state("com.system76.Example", 1).unwrap());
 }


### PR DESCRIPTION
This will allow cosmic-bg to store the latest background state per output, for the lock screen and cosmic-settings to pick up.