### PR TITLE
Add ContextDrawer widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ path = "cosmic-theme"
 [dependencies.iced]
 path = "./iced"
 default-features = false
-features = ["image", "svg", "lazy"]
+features = ["advanced", "image", "svg", "lazy"]
 
 [dependencies.iced_runtime]
 path = "./iced/runtime"

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -132,7 +132,7 @@ impl Config {
             Err(Error::InvalidName(name.to_string()))
         }
     }
-    
+
     /// Get state for the given application name and config version. State is meant to be used to
     /// store items that may need to be exposed to other programs but will change regularly without
     /// user action

--- a/examples/application/src/main.rs
+++ b/examples/application/src/main.rs
@@ -147,7 +147,9 @@ where
     }
 
     fn update_title(&mut self) -> Command<Message> {
-        let title = self.active_page_title().to_owned();
-        self.set_title(title)
+        let header_title = self.active_page_title().to_owned();
+        let window_title = format!("{header_title} — COSMIC AppDemo");
+        self.set_header_title(header_title);
+        self.set_window_title(window_title)
     }
 }

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -85,7 +85,7 @@ fn test_config(config: Config) {
 pub fn main() {
     println!("Testing config");
     test_config(Config::new("com.system76.Example", 1).unwrap());
-    
+
     println!("Testing state");
     test_config(Config::new_state("com.system76.Example", 1).unwrap());
 }

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -15,11 +15,14 @@ pub struct NavBar {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone)]
 pub struct Window {
-    /// Label to as title in headerbar.
+    /// Label to display as context drawer title.
+    pub context_title: String,
+    /// Label to display as header bar title.
     pub header_title: String,
     pub use_template: bool,
     pub can_fullscreen: bool,
     pub sharp_corners: bool,
+    pub show_context: bool,
     pub show_headerbar: bool,
     pub show_window_menu: bool,
     pub show_maximize: bool,
@@ -68,10 +71,12 @@ impl Default for Core {
             title: String::new(),
             system_theme: crate::theme::active(),
             window: Window {
+                context_title: String::new(),
                 header_title: String::new(),
                 use_template: true,
                 can_fullscreen: false,
                 sharp_corners: false,
+                show_context: false,
                 show_headerbar: true,
                 show_maximize: true,
                 show_minimize: true,

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -109,6 +109,16 @@ impl Core {
         self.is_condensed_update();
     }
 
+    /// Set context drawer header title
+    pub fn set_context_title(&mut self, title: String) {
+        self.window.context_title = title;
+    }
+
+    /// Set header bar title
+    pub fn set_header_title(&mut self, title: String) {
+        self.window.header_title = title;
+    }
+
     /// Whether to show or hide the main window's content.
     pub(crate) fn show_content(&self) -> bool {
         !self.is_condensed || !self.nav_bar.toggled_condensed

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -24,6 +24,8 @@ pub enum Message {
     AppThemeChange(Theme),
     /// Requests to close the window.
     Close,
+    /// Closes or shows the context drawer.
+    ContextDrawer(bool),
     /// Requests to drag the window.
     Drag,
     /// Keyboard shortcuts managed by libcosmic.
@@ -166,6 +168,7 @@ where
         if id != window::Id(0) {
             return self.app.view_window(id).map(super::Message::App);
         }
+
         if self.app.core().window.use_template {
             self.app.view_main()
         } else {
@@ -242,12 +245,11 @@ impl<T: Application> Cosmic<T> {
                 keyboard_nav::Message::Fullscreen => return command::toggle_fullscreen(),
             },
 
-            Message::Drag => return command::drag(),
-
-            Message::Close => {
-                self.app.on_app_exit();
-                return self.close();
+            Message::ContextDrawer(show) => {
+                self.app.core_mut().window.show_context = show;
             }
+
+            Message::Drag => return command::drag(),
 
             Message::Minimize => return command::minimize(),
 
@@ -302,6 +304,11 @@ impl<T: Application> Cosmic<T> {
 
             Message::ScaleFactor(factor) => {
                 self.app.core_mut().set_scale_factor(factor);
+            }
+
+            Message::Close => {
+                self.app.on_app_exit();
+                return self.close();
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -229,6 +229,16 @@ pub trait ApplicationExt: Application {
     /// Get the title of the main window.
     fn title(&self) -> &str;
 
+    /// Set the context drawer title.
+    fn set_context_title(&mut self, title: String) {
+        self.core_mut().set_context_title(title);
+    }
+
+    /// Set the header bar title.
+    fn set_header_title(&mut self, title: String) {
+        self.core_mut().set_header_title(title);
+    }
+
     /// Set the title of the main window.
     fn set_title(&mut self, title: String) -> iced::Command<Message<Self::Message>>;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -240,7 +240,7 @@ pub trait ApplicationExt: Application {
     }
 
     /// Set the title of the main window.
-    fn set_title(&mut self, title: String) -> iced::Command<Message<Self::Message>>;
+    fn set_window_title(&mut self, title: String) -> iced::Command<Message<Self::Message>>;
 
     /// View template for the main window.
     fn view_main(&self) -> Element<Message<Self::Message>>;
@@ -264,13 +264,13 @@ impl<App: Application> ApplicationExt for App {
     }
 
     #[cfg(feature = "wayland")]
-    fn set_title(&mut self, title: String) -> iced::Command<Message<Self::Message>> {
+    fn set_window_title(&mut self, title: String) -> iced::Command<Message<Self::Message>> {
         self.core_mut().title = title.clone();
         command::set_title(title)
     }
 
     #[cfg(not(feature = "wayland"))]
-    fn set_title(&mut self, title: String) -> iced::Command<Message<Self::Message>> {
+    fn set_window_title(&mut self, title: String) -> iced::Command<Message<Self::Message>> {
         self.core_mut().title = title.clone();
         iced::Command::none()
     }

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -109,11 +109,13 @@ impl StyleSheet for crate::Theme {
         }
 
         appearance(self, focused, style, |component| {
-            (
-                component.base.into(),
-                Some(component.on.into()),
-                Some(component.on.into()),
-            )
+            let text_color = if let Button::Icon | Button::IconVertical = style {
+                None
+            } else {
+                Some(component.on.into())
+            };
+
+            (component.base.into(), text_color, text_color)
         })
     }
 

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -67,10 +67,10 @@ pub fn appearance(
                 corner_radii = &cosmic.corner_radii.radius_m;
             }
 
-            let (background, _text, icon) = color(&cosmic.icon_button);
+            let (background, text, icon) = color(&cosmic.icon_button);
             appearance.background = Some(Background::Color(background));
-            // appearance.text_color = text;
-            // appearance.icon_color = icon;
+            appearance.text_color = text;
+            appearance.icon_color = icon;
 
             if focused {
                 appearance.text_color = Some(cosmic.accent.on.into());

--- a/src/widget/context_drawer/mod.rs
+++ b/src/widget/context_drawer/mod.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+mod overlay;
+
+mod widget;
+pub use widget::ContextDrawer;
+
+use crate::Element;
+
+pub fn context_drawer<'a, Message: Clone + 'static, Content, Drawer>(
+    header: &'a str,
+    on_close: Message,
+    content: Content,
+    drawer: Drawer,
+) -> ContextDrawer<'a, Message>
+where
+    Content: Into<Element<'a, Message>>,
+    Drawer: Into<Element<'a, Message>>,
+{
+    ContextDrawer::new(header, content, drawer, on_close)
+}

--- a/src/widget/context_drawer/overlay.rs
+++ b/src/widget/context_drawer/overlay.rs
@@ -1,0 +1,119 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::Element;
+
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::widget::{self, Operation, OperationOutputWrapper};
+use iced::advanced::{overlay, renderer};
+use iced::advanced::{Clipboard, Shell};
+use iced::{event, mouse, Event, Point, Rectangle, Size};
+use iced_core::Widget;
+
+pub(super) struct Overlay<'a, 'b, Message> {
+    pub(super) content: &'b mut Element<'a, Message>,
+    pub(super) tree: &'b mut widget::Tree,
+    pub(super) width: f32,
+}
+
+impl<'a, 'b, Message> overlay::Overlay<Message, crate::Renderer> for Overlay<'a, 'b, Message>
+where
+    Message: Clone,
+{
+    fn layout(&self, renderer: &crate::Renderer, bounds: Size, position: Point) -> layout::Node {
+        let limits = layout::Limits::new(Size::ZERO, bounds)
+            .width(self.width)
+            .height(bounds.height - 8.0 - position.y);
+
+        let mut node = self.content.as_widget().layout(renderer, &limits);
+        let node_size = node.size();
+
+        node.move_to(Point {
+            x: if bounds.width > node_size.width - 8.0 {
+                bounds.width - node_size.width - 8.0
+            } else {
+                0.0
+            },
+            y: if bounds.height > node_size.height - 8.0 {
+                bounds.height - node_size.height - 8.0
+            } else {
+                0.0
+            },
+        });
+
+        node
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &crate::Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        self.content.as_widget_mut().on_event(
+            self.tree,
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            &layout.bounds(),
+        )
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut crate::Renderer,
+        theme: &crate::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+    ) {
+        self.content.draw(
+            self.tree,
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            &layout.bounds(),
+        );
+    }
+
+    fn operate(
+        &mut self,
+        layout: Layout<'_>,
+        renderer: &crate::Renderer,
+        operation: &mut dyn Operation<OperationOutputWrapper<Message>>,
+    ) {
+        self.content
+            .as_widget_mut()
+            .operate(self.tree, layout, renderer, operation);
+    }
+
+    fn mouse_interaction(
+        &self,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &crate::Renderer,
+    ) -> mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(self.tree, layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'c>(
+        &'c mut self,
+        layout: Layout<'_>,
+        renderer: &crate::Renderer,
+    ) -> Option<overlay::Element<'c, Message, crate::Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(self.tree, layout, renderer)
+    }
+}

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -1,0 +1,239 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::widget::{
+    button, column, container, icon, row, scrollable, text, LayerContainer, Space,
+};
+use crate::{Apply, Element, Renderer, Theme};
+
+use super::overlay::Overlay;
+
+use iced_core::alignment;
+use iced_core::event::{self, Event};
+use iced_core::widget::{Operation, Tree};
+use iced_core::{
+    layout, mouse, overlay as iced_overlay, renderer, Clipboard, Color, Layout, Length, Padding,
+    Rectangle, Shell, Widget,
+};
+
+use iced_renderer::core::widget::OperationOutputWrapper;
+pub use iced_style::container::{Appearance, StyleSheet};
+
+#[must_use]
+pub struct ContextDrawer<'a, Message> {
+    content: Element<'a, Message>,
+    drawer: Element<'a, Message>,
+    on_close: Option<Message>,
+}
+
+impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
+    /// Creates an empty [`ContextDrawer`].
+    pub fn new<Content, Drawer>(
+        header: &'a str,
+        content: Content,
+        drawer: Drawer,
+        on_close: Message,
+    ) -> Self
+    where
+        Content: Into<Element<'a, Message>>,
+        Drawer: Into<Element<'a, Message>>,
+    {
+        let header = row::with_capacity(3)
+            .height(Length::Fixed(80.0))
+            .width(Length::Fixed(480.0))
+            .padding(Padding {
+                top: 0.0,
+                bottom: 0.0,
+                left: 32.0,
+                right: 32.0,
+            })
+            .push(Space::new(Length::FillPortion(1), Length::Shrink))
+            .push(
+                text::heading(header)
+                    .width(Length::FillPortion(1))
+                    .height(Length::Fill)
+                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .vertical_alignment(alignment::Vertical::Center),
+            )
+            .push(
+                button::text("Close")
+                    .trailing_icon(icon::from_name("go-next-symbolic"))
+                    .on_press(on_close)
+                    .apply(container)
+                    .width(Length::FillPortion(1))
+                    .height(Length::Fill)
+                    .align_x(alignment::Horizontal::Right)
+                    .center_y(),
+            );
+
+        let pane = column::with_capacity(2).push(header).push(scrollable(
+            container(drawer.into()).padding(Padding {
+                top: 0.0,
+                left: 32.0,
+                right: 32.0,
+                bottom: 32.0,
+            }),
+        ));
+
+        ContextDrawer {
+            content: content.into(),
+            drawer: LayerContainer::new(pane)
+                .style(crate::style::Container::custom(move |theme| {
+                    let palette = theme.cosmic();
+
+                    container::Appearance {
+                        icon_color: Some(Color::from(palette.primary.on)),
+                        text_color: Some(Color::from(palette.primary.on)),
+                        background: Some(iced::Background::Color(palette.primary.base.into())),
+                        border_radius: 8.0.into(),
+                        border_width: 0.0,
+                        border_color: Color::TRANSPARENT,
+                    }
+                }))
+                .layer(cosmic_theme::Layer::Primary)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .max_width(480.0)
+                .into(),
+            on_close: None,
+        }
+    }
+
+    // Optionally assigns message to `on_close` event.
+    pub fn on_close_maybe(mut self, message: Option<Message>) -> Self {
+        self.on_close = message;
+        self
+    }
+}
+
+impl<'a, Message: Clone> Widget<Message, Renderer> for ContextDrawer<'a, Message> {
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content), Tree::new(&self.drawer)]
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut [&mut self.content, &mut self.drawer]);
+    }
+
+    fn width(&self) -> Length {
+        self.content.as_widget().width()
+    }
+
+    fn height(&self) -> Length {
+        self.content.as_widget().height()
+    }
+
+    fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
+        self.content.as_widget().layout(renderer, limits)
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<OperationOutputWrapper<Message>>,
+    ) {
+        self.content
+            .as_widget()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        self.content.as_widget_mut().on_event(
+            &mut tree.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        renderer_style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            renderer_style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+    ) -> Option<iced_overlay::Element<'b, Message, Renderer>> {
+        let bounds = layout.bounds();
+
+        Some(iced_overlay::Element::new(
+            layout.position(),
+            Box::new(Overlay {
+                content: &mut self.drawer,
+                tree: &mut tree.children[1],
+                width: bounds.width,
+            }),
+        ))
+    }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_layout = layout.children().next().unwrap();
+        let c_state = &state.children[0];
+        self.content.as_widget().a11y_nodes(c_layout, c_state, p)
+    }
+}
+
+impl<'a, Message: 'a + Clone> From<ContextDrawer<'a, Message>> for Element<'a, Message> {
+    fn from(widget: ContextDrawer<'a, Message>) -> Element<'a, Message> {
+        Element::new(widget)
+    }
+}

--- a/src/widget/grid/layout.rs
+++ b/src/widget/grid/layout.rs
@@ -7,9 +7,9 @@ use iced_core::layout::{Limits, Node};
 use iced_core::{Alignment, Length, Padding, Point, Size};
 
 use taffy::geometry::{Line, Rect};
-use taffy::style::{AlignContent, AlignItems, Dimension, Display, GridPlacement, Style};
+use taffy::style::{AlignItems, Dimension, Display, GridPlacement, Style};
 use taffy::style_helpers::{auto, length};
-use taffy::{LayoutTree, Taffy};
+use taffy::Taffy;
 
 #[allow(clippy::too_many_lines)]
 pub fn resolve<Message>(

--- a/src/widget/grid/mod.rs
+++ b/src/widget/grid/mod.rs
@@ -4,7 +4,7 @@
 pub mod layout;
 pub mod widget;
 
-pub use widget::{Grid, Item};
+pub use widget::Grid;
 
 /// Responsively generates rows and columns of widgets based on its dimmensions.
 pub const fn grid<'a, Message>() -> Grid<'a, Message> {

--- a/src/widget/grid/widget.rs
+++ b/src/widget/grid/widget.rs
@@ -309,21 +309,3 @@ impl From<(u16, u16, u16, u16)> for Assignment {
         }
     }
 }
-
-#[must_use]
-pub struct Item<'a, Message> {
-    widget: Element<'a, Message>,
-    assignment: Assignment,
-}
-
-impl<'a, Message> Item<'a, Message> {
-    pub fn width(mut self, width: u16) -> Self {
-        self.assignment.width = width;
-        self
-    }
-
-    pub fn height(mut self, height: u16) -> Self {
-        self.assignment.height = height;
-        self
-    }
-}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -31,6 +31,9 @@ pub use card::*;
 pub mod color_picker;
 pub use color_picker::{ColorPicker, ColorPickerModel};
 
+pub mod context_drawer;
+pub use context_drawer::{context_drawer, ContextDrawer};
+
 pub use column::{column, Column};
 pub mod column {
     pub type Column<'a, Message> = iced::widget::Column<'a, Message, crate::Renderer>;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -133,6 +133,7 @@ pub mod popover;
 pub use popover::{popover, Popover};
 
 pub mod rectangle_tracker;
+pub use rectangle_tracker::{rectangle_tracker, RectangleTracker};
 
 pub use row::{row, Row};
 pub mod row {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -29,7 +29,7 @@ pub mod card;
 pub use card::*;
 
 pub mod color_picker;
-pub use color_picker::*;
+pub use color_picker::{ColorPicker, ColorPickerModel};
 
 pub use column::{column, Column};
 pub mod column {

--- a/src/widget/navigation.rs
+++ b/src/widget/navigation.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::widget::{button, column, container, horizontal_space, icon, list, row, text, Column};
+use crate::widget::{button, column, container, horizontal_space, icon, list, row, text};
 use crate::{theme, Apply, Element};
 use iced::Length;
 

--- a/src/widget/rectangle_tracker/mod.rs
+++ b/src/widget/rectangle_tracker/mod.rs
@@ -16,6 +16,27 @@ use std::{fmt::Debug, hash::Hash};
 
 pub use iced_style::container::{Appearance, StyleSheet};
 
+pub fn rectangle_tracker<'a, Message, I, T>(
+    content: T,
+    id: I,
+    tx: UnboundedSender<(I, Rectangle)>,
+) -> RectangleTrackingContainer<'a, Message, crate::Renderer, I>
+where
+    I: Hash + Copy + Send + Sync + Debug + 'a,
+    T: Into<Element<'a, Message, crate::Renderer>>,
+{
+    RectangleTrackingContainer::new(content, id, tx)
+}
+
+pub fn subscription<
+    I: 'static + Hash + Copy + Send + Sync + Debug,
+    R: 'static + Hash + Copy + Send + Sync + Debug + Eq,
+>(
+    id: I,
+) -> iced::Subscription<(I, RectangleUpdate<R>)> {
+    subscription::rectangle_tracker_subscription(id)
+}
+
 #[derive(Clone, Debug)]
 pub struct RectangleTracker<I> {
     tx: UnboundedSender<(I, Rectangle)>,


### PR DESCRIPTION
In addition to implementing the `ContextDrawer` widget, this adds a `Application::context_drawer` method for constructing the view of the context bar, which should be shown when `Core.window.show_context` is set to `true`.  The `ApplicationExt` trait also now has `set_context_title` and `set_header_title` methods. Whereas `ApplicationExt::set_title` has been renamed to `set_window_title`.

cosmic-design-demo PR: https://github.com/pop-os/cosmic-design-demo/pull/3

After merging the cosmic-design-demo PR, it should be updated here as well.