### PR TITLE
feat: enable limiting applications to a single instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ debug = ["iced/debug"]
 # Enables pipewire support in ashpd, if ashpd is enabled
 pipewire = ["ashpd?/pipewire"]
 # smol async runtime
-smol = ["iced/smol"]
+smol = ["iced/smol", "zbus/async-io"]
 # Tokio async runtime
-tokio = ["dep:tokio", "ashpd/tokio", "iced/tokio"]
+tokio = ["dep:tokio", "ashpd/tokio", "iced/tokio", "zbus/tokio"]
 # Wayland window support
 wayland = [
   "ashpd?/wayland",
@@ -57,6 +57,7 @@ ashpd = { version = "0.5.0", default-features = false, optional = true }
 url = "2.4.0"
 unicode-segmentation = "1.6"
 css-color = "0.2.5"
+zbus = {version = "3.14.1", default-features = false}
 
 [target.'cfg(unix)'.dependencies]
 freedesktop-icons = "0.2.4"

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -61,6 +61,8 @@ pub struct Core {
 
     #[cfg(feature = "applet")]
     pub applet: crate::applet::Context,
+
+    pub single_instance: bool,
 }
 
 impl Default for Core {
@@ -102,6 +104,7 @@ impl Default for Core {
             },
             #[cfg(feature = "applet")]
             applet: crate::applet::Context::default(),
+            single_instance: false,
         }
     }
 }

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -150,6 +150,13 @@ where
             None
         });
 
+        let single_instance = self
+            .app
+            .core()
+            .single_instance
+            .then(|| super::single_instance_subscription::<T>())
+            .map_or_else(Subscription::none, |s| s.map(super::Message::App));
+
         Subscription::batch(vec![
             self.app.subscription().map(super::Message::App),
             keyboard_nav::subscription()
@@ -174,6 +181,7 @@ where
             })
             .map(super::Message::Cosmic),
             window_events.map(super::Message::Cosmic),
+            single_instance,
         ])
     }
 

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -62,6 +62,9 @@ pub struct Settings {
 
     /// Whether the application should exit when there are no open windows
     pub(crate) exit_on_close: bool,
+
+    /// Only allow a single instance of the application to run
+    pub single_instance: bool,
 }
 
 impl Settings {
@@ -97,6 +100,7 @@ impl Default for Settings {
             theme: crate::theme::system_preference(),
             transparent: false,
             exit_on_close: true,
+            single_instance: false,
         }
     }
 }


### PR DESCRIPTION
This could allow applications to only allow a single instance by default, and when another instance is started, the arguments are passed to the existing application. I could see this possibly being useful for the applets that need to open a specific page of settings. They could spawn `cosmic-settings --network` for example, which might open a new instance on the network configuration page, or if there is one running, the arguments would be passed to the existing instance via dbus. Maybe we should make the interface match d-bus activation? This implementation is a bit different from GApplication and doesn't really use d-bus activation. 