### PR TITLE
fix: match the button overlays with figma

### DIFF
--- a/cosmic-theme/src/model/derivation.rs
+++ b/cosmic-theme/src/model/derivation.rs
@@ -189,9 +189,21 @@ where
 
         Component {
             base: base.clone().into(),
-            hover: over(hovered.clone(), base).into(),
-            pressed: over(pressed, base).into(),
-            selected: over(hovered, base).into(),
+            hover: if base.alpha < 0.001 {
+                hovered.clone()
+            } else {
+                over(hovered.clone(), base).into()
+            },
+            pressed: if base.alpha < 0.001 {
+                pressed.clone()
+            } else {
+                over(pressed.clone(), base).into()
+            },
+            selected: if base.alpha < 0.001 {
+                hovered.clone()
+            } else {
+                over(hovered.clone(), base).into()
+            },
             selected_text: accent.clone(),
             focus: accent.clone(),
             divider: if is_high_contrast {

--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -856,24 +856,10 @@ impl ThemeBuilder {
             color
         };
 
-        let (button_hovered_hue, button_pressed_hye) = if is_dark {
-            (46.0, 22.0)
-        } else {
-            (158.0, 190.0)
-        };
-
-        let button_hovered_overlay = Srgba::new(
-            button_hovered_hue / 255.0,
-            button_hovered_hue / 255.0,
-            button_hovered_hue / 255.0,
-            0.5,
-        );
-        let button_pressed_overlay = Srgba::new(
-            button_pressed_hye / 255.0,
-            button_pressed_hye / 255.0,
-            button_pressed_hye / 255.0,
-            0.5,
-        );
+        let (mut button_hovered_overlay, mut button_pressed_overlay) =
+            (p_ref.neutral_5, p_ref.neutral_2);
+        button_hovered_overlay.alpha = 0.2;
+        button_pressed_overlay.alpha = 0.5;
 
         let mut theme: Theme<Srgba> = Theme {
             name: palette.name().to_string(),


### PR DESCRIPTION
Also, If the button is transparent, uses the overlay directly for hover and pressed states.