### PR TITLE
feat(image_button): add optional removable button overlay

### DIFF
--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -207,6 +207,6 @@ impl StyleSheet for crate::Theme {
     }
 
     fn selection_background(&self) -> Background {
-        Background::Color(self.cosmic().bg_color().into())
+        Background::Color(self.cosmic().primary.base.into())
     }
 }

--- a/src/widget/button/mod.rs
+++ b/src/widget/button/mod.rs
@@ -38,6 +38,13 @@ pub fn button<'a, Message>(
     Button::new(content)
 }
 
+pub fn custom_image_button<'a, Message>(
+    content: impl Into<Element<'a, Message>>,
+    on_remove: Option<Message>,
+) -> Button<'a, Message, crate::Renderer> {
+    Button::new_image(content, on_remove)
+}
+
 #[must_use]
 #[derive(Setters)]
 pub struct Builder<'a, Message, Variant> {


### PR DESCRIPTION
This is one of the feature additions required for the wallpaper settings page.

- Adds an optional removable button overlay to the image button widget.
- Refactors image button logic in the button widget implementation.
- Selects the proper background color for the selection indicator and close button
- Updates `cosmic-image-button` example to showcase removable image buttons