### PR TITLE
Add a `should_exit` method to `Application` trait

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -104,7 +104,7 @@ where
 
     #[cfg(feature = "wayland")]
     fn should_exit(&self) -> bool {
-        self.should_exit
+        self.should_exit || self.app.should_exit()
     }
 
     fn style(&self) -> <Self::Theme as iced_style::application::StyleSheet>::Style {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -168,6 +168,11 @@ where
     /// Called before closing the application.
     fn on_app_exit(&mut self) {}
 
+    #[cfg(feature = "wayland")]
+    fn should_exit(&self) -> bool {
+        false
+    }
+
     /// Called when a window requests to be closed.
     fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
         None


### PR DESCRIPTION
A Cosmic application has no way to call `Cosmic<T>::close` to set the `should_exit` flag there, as far as I'm aware.

So it makes sense to add a `should_exit` method here.