### PR TITLE
Remove Clone constraint on Flags

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -362,7 +362,7 @@ where
     type Executor: iced_futures::Executor;
 
     /// Argument received [`Application::new`].
-    type Flags: Clone;
+    type Flags;
 
     /// Message type specific to our app.
     type Message: Clone + std::fmt::Debug + Send + 'static;


### PR DESCRIPTION
I don't see why we need this, Cosmic don't require it. And i need it for my app