### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/widget/icon/named.rs
+++ b/src/widget/icon/named.rs
@@ -41,6 +41,7 @@ impl Named {
         }
     }
 
+    #[cfg(not(windows))]
     #[must_use]
     pub fn path(self) -> Option<PathBuf> {
         let mut name = &*self.name;
@@ -82,6 +83,13 @@ impl Named {
 
             result
         })
+    }
+
+    #[cfg(windows)]
+    #[must_use]
+    pub fn path(self) -> Option<PathBuf> {
+        //TODO: implement icon lookup for Windows
+        None
     }
 
     pub fn handle(self) -> Handle {


### PR DESCRIPTION
This fixes compilation for Windows, where freedesktop_icons::lookup is not available. In the future, we could consider a feature to bundle some icons with libcosmic for Windows and macOS, and also have an os-agnostic way to get icons for a mime type.