### PR TITLE
fix: Reduce heading line height from 20 to 1

### DIFF
--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -50,7 +50,7 @@ pub fn title4<'a>(text: impl Into<Cow<'a, str>> + 'a) -> Text<'a, Renderer> {
 pub fn heading<'a>(text: impl Into<Cow<'a, str>> + 'a) -> Text<'a, Renderer> {
     Text::new(text)
         .size(14.0)
-        .line_height(20.0)
+        .line_height(1.0)
         .font(crate::font::FONT_SEMIBOLD)
 }
 


### PR DESCRIPTION
This fixes the settings drawer headings having too much vertical padding, reported at https://github.com/pop-os/cosmic-edit/issues/49.

Before:
![Screenshot from 2023-11-28 22-24-26](https://github.com/pop-os/libcosmic/assets/7199422/4fa04379-6713-4d69-8c41-d0cd1c3ca869)

After:
![Screenshot from 2023-11-28 22-24-02](https://github.com/pop-os/libcosmic/assets/7199422/9917898a-bde6-47c0-b939-f7c832a22e78)

[Figma design](https://www.figma.com/file/s2o49ResysE3Q74jRwZrZV/COSMIC-Text-Editor?type=design&node-id=693-90896&mode=design&t=onjDJeoUEeXYzeHJ-0) for reference:
![image](https://github.com/pop-os/libcosmic/assets/7199422/7ae7d858-91f8-4010-8326-596cbc941914)