### PR TITLE
Remove hardcoded paths in cosmic-config

### DIFF
--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -10,7 +10,6 @@ macro = ["cosmic-config-derive"]
 subscription = ["iced_futures"]
 
 [dependencies]
-# For redox support
 zbus = { version = "3.14.1", default-features = false, optional = true }
 atomicwrites = { git = "https://github.com/jackpot51/rust-atomicwrites" }
 calloop = { version = "0.12.2", optional = true }
@@ -24,3 +23,9 @@ iced_futures = { path = "../iced/futures/", default-features = false, optional =
 once_cell = "1.19.0"
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings", branch = "cosmic-settings-daemon", optional = true }
 futures-util = { version = "0.3", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+xdg = "2.1"
+
+[target.'cfg(windows)'.dependencies]
+known-folders = "1.1.0"


### PR DESCRIPTION
This commit changes the hardcoded /usr/share paths in cosmic-config to become performed via XDG lookups using the `xdg` crate.

This allows the installed files to be discovered on non-FHS Linux, e.g. NixOS.

Hardcoded /var/lib/ is removed entirely because
1. nothing installs to it yet (only user of new_state is cosmic_bg currently and it does not install to /var/lib)
2. it's intended for system states, not template for user state.
3. it's not part of XDG spec.