### PR TITLE
Fix invalid_reference_casting

### DIFF
--- a/src/widget/menu/menu_bar.rs
+++ b/src/widget/menu/menu_bar.rs
@@ -211,6 +211,7 @@ where
         self.height
     }
 
+    #[allow(invalid_reference_casting)]
     fn diff(&mut self, tree: &mut Tree) {
         if tree.children.len() > self.menu_roots.len() {
             tree.children.truncate(self.menu_roots.len());


### PR DESCRIPTION
Whitout this, i get this error when compiling application example and multi-window:

```
error: casting `&T` to `&mut T` is undefined behavior, even if the reference is unused, consider instead using an `UnsafeCell`
   --> src\widget\menu\menu_bar.rs:231:34
    |
229 | ...dget_ptr_mut = widget_ptr as *mut dyn Widget<Message, Renderer>;    
    |                   ------------------------------------------------ casting happend here
230 | ...: find a way to diff_children without unsafe code
231 | ... { &mut *widget_ptr_mut }
    |       ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
    = note: even for types with interior mutability, the only legal way to obtain a mutable pointer from a shared reference is through `UnsafeCell::get`  
    = note: `#[deny(invalid_reference_casting)]` on by default

warning: `libcosmic` (lib) generated 2 warnings
error: could not compile `libcosmic` (lib) due to 1 previous error; 2 warnings emitted
```

Maybe it's because I compiling with 1.75, idk