### PR TITLE
Allow apps to return a command when context drawer is toggled

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -332,6 +332,7 @@ impl<T: Application> Cosmic<T> {
 
             Message::ContextDrawer(show) => {
                 self.app.core_mut().window.show_context = show;
+                return self.app.on_context_drawer();
             }
 
             Message::Drag => return command::drag(None),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -440,6 +440,11 @@ where
         None
     }
 
+    // Called when context drawer is toggled
+    fn on_context_drawer(&mut self) -> iced::Command<Message<Self::Message>> {
+        iced::Command::none()
+    }
+
     /// Called when the escape key is pressed.
     fn on_escape(&mut self) -> iced::Command<Message<Self::Message>> {
         iced::Command::none()


### PR DESCRIPTION
This is important to properly manage focus.