### PR TITLE
fix: when using wgpu, default to low power GPU

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -135,9 +135,26 @@ pub(crate) fn iced_settings<App: Application>(
 ///
 /// Returns error on application failure.
 pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Result {
+    #[cfg(feature = "wgpu")]
+    wgpu_power_pref();
+
     let settings = iced_settings::<App>(settings, flags);
 
     cosmic::Cosmic::<App>::run(settings)
+}
+
+/// Default to rendering the application with the low power GPU preference.
+#[cfg(feature = "wgpu")]
+fn wgpu_power_pref() {
+    // Ignore if requested to run on NVIDIA GPU
+    if std::env::var("__NV_PRIME_RENDER_OFFLOAD").ok().as_deref() == Some("1") {
+        return;
+    }
+
+    const VAR: &str = "WGPU_POWER_PREF";
+    if std::env::var(VAR).is_err() {
+        std::env::set_var(VAR, "low");
+    }
 }
 
 #[cfg(feature = "single-instance")]


### PR DESCRIPTION
Ensures that the integrated GPU is used by default on hybrid graphics systems; and resolves NVIDIA-related driver issues.

Fixes COSMIC applications immediately freezing on hybrid graphics systems with a NVIDIA GPU.