### PR TITLE
Config improvements

### DIFF
--- a/cosmic-config-derive/src/lib.rs
+++ b/cosmic-config-derive/src/lib.rs
@@ -45,7 +45,7 @@ fn impl_cosmic_config_entry_macro(ast: &syn::DeriveInput) -> TokenStream {
     let write_each_config_field = fields.iter().map(|field| {
         let field_name = &field.ident;
         quote! {
-            cosmic_config::ConfigSet::set(config, stringify!(#field_name), &self.#field_name)?;
+            cosmic_config::ConfigSet::set(&tx, stringify!(#field_name), &self.#field_name)?;
         }
     });
 

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -314,7 +314,7 @@ impl<'a> ConfigSet for ConfigTransaction<'a> {
     fn set<T: Serialize>(&self, key: &str, value: T) -> Result<(), Error> {
         //TODO: sanitize key (no slashes, cannot be . or ..)
         let key_path = self.config.key_path(key)?;
-        let data = ron::to_string(&value)?;
+        let data = ron::ser::to_string_pretty(&value, ron::ser::PrettyConfig::new())?;
         //TODO: replace duplicates?
         {
             let mut updates = self.updates.lock().unwrap();

--- a/cosmic-theme/src/model/mode.rs
+++ b/cosmic-theme/src/model/mode.rs
@@ -35,11 +35,6 @@ impl ThemeMode {
         1
     }
 
-    /// Set auto-switch from light to dark mode
-    pub fn set_auto_switch(config: &Config, value: bool) -> Result<(), cosmic_config::Error> {
-        config.set("auto_switch", value)
-    }
-
     /// Get the config for the theme mode
     pub fn config() -> Result<Config, cosmic_config::Error> {
         Config::new(THEME_MODE_ID, Self::version())


### PR DESCRIPTION
- fixes issue where transaction was not being used for write_entry
- generates set_field_name setters that can be used to set the value of one key and only write to disk if it changed
- pretty prints config file data