### PR TITLE
Generate documentation and publish to github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pages:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build documentation
+      run: cargo doc --verbose
+    - name: Deploy documentation
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/doc


### PR DESCRIPTION
This makes my life easier so I don't have to keep running `cargo doc --open`