### PR TITLE
refactor: config improvements

### DIFF
--- a/cosmic-config/src/dbus.rs
+++ b/cosmic-config/src/dbus.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::CosmicConfigEntry;
+use crate::{CosmicConfigEntry, Update};
 use cosmic_settings_daemon::{ConfigProxy, CosmicSettingsDaemonProxy};
 use futures_util::SinkExt;
 use iced_futures::futures::{future::pending, StreamExt};
@@ -51,13 +51,6 @@ impl Watcher {
     }
 }
 
-#[derive(Debug)]
-pub struct Update<T> {
-    pub errors: Vec<crate::Error>,
-    pub keys: Vec<&'static str>,
-    pub config: T,
-}
-
 pub fn watcher_subscription<T: CosmicConfigEntry + Send + Sync + Default + 'static + Clone>(
     settings_daemon: CosmicSettingsDaemonProxy<'static>,
     config_id: &'static str,
@@ -79,7 +72,7 @@ pub fn watcher_subscription<T: CosmicConfigEntry + Send + Sync + Default + 'stat
             Ok(config) => config,
             Err((errors, default)) => {
                 if !errors.is_empty() {
-                    eprintln!("Failed to get config: {errors:?}");
+                    eprintln!("Error getting config: {config_id} {errors:?}");
                 }
                 default
             }

--- a/examples/applet/src/window.rs
+++ b/examples/applet/src/window.rs
@@ -13,7 +13,6 @@ const ID: &str = "com.system76.CosmicAppletExample";
 pub struct Window {
     core: Core,
     popup: Option<Id>,
-    id_ctr: u128,
     example_row: bool,
 }
 
@@ -59,13 +58,12 @@ impl cosmic::Application for Window {
                 return if let Some(p) = self.popup.take() {
                     destroy_popup(p)
                 } else {
-                    self.id_ctr += 1;
-                    let new_id = Id(self.id_ctr);
+                    let new_id = Id::unique();
                     self.popup.replace(new_id);
                     let mut popup_settings =
                         self.core
                             .applet
-                            .get_popup_settings(Id(0), new_id, None, None, None);
+                            .get_popup_settings(Id::MAIN, new_id, None, None, None);
                     popup_settings.positioner.size_limits = Limits::NONE
                         .max_width(372.0)
                         .min_width(300.0)

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -214,27 +214,37 @@ impl Core {
         self.system_theme_mode
     }
 
-    #[cfg(feature = "dbus-config")]
-    pub fn watch_config<T: CosmicConfigEntry + Send + Sync + Default + 'static + Clone>(
+    pub fn watch_config<
+        T: CosmicConfigEntry + Send + Sync + Default + 'static + Clone + PartialEq,
+    >(
         &self,
         config_id: &'static str,
-    ) -> iced::Subscription<cosmic_config::dbus::Update<T>> {
+    ) -> iced::Subscription<cosmic_config::Update<T>> {
+        #[cfg(feature = "dbus-config")]
         if let Some(settings_daemon) = self.settings_daemon.clone() {
-            cosmic_config::dbus::watcher_subscription(settings_daemon, config_id, false)
-        } else {
-            iced::Subscription::none()
+            return cosmic_config::dbus::watcher_subscription(settings_daemon, config_id, false);
         }
+        cosmic_config::config_subscription(
+            std::any::TypeId::of::<T>(),
+            std::borrow::Cow::Borrowed(config_id),
+            T::VERSION,
+        )
     }
 
-    #[cfg(feature = "dbus-config")]
-    pub fn watch_state<T: CosmicConfigEntry + Send + Sync + Default + 'static + Clone>(
+    pub fn watch_state<
+        T: CosmicConfigEntry + Send + Sync + Default + 'static + Clone + PartialEq,
+    >(
         &self,
         state_id: &'static str,
-    ) -> iced::Subscription<cosmic_config::dbus::Update<T>> {
+    ) -> iced::Subscription<cosmic_config::Update<T>> {
+        #[cfg(feature = "dbus-config")]
         if let Some(settings_daemon) = self.settings_daemon.clone() {
-            cosmic_config::dbus::watcher_subscription(settings_daemon, state_id, true)
-        } else {
-            iced::Subscription::none()
+            return cosmic_config::dbus::watcher_subscription(settings_daemon, state_id, true);
         }
+        cosmic_config::config_subscription(
+            std::any::TypeId::of::<T>(),
+            std::borrow::Cow::Borrowed(state_id),
+            T::VERSION,
+        )
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -85,15 +85,12 @@ pub fn subscription(is_dark: bool) -> Subscription<crate::theme::Theme> {
         .into(),
         crate::cosmic_theme::Theme::version(),
     )
-    .map(|(_, res)| {
-        let theme = res.unwrap_or_else(|(errors, theme)| {
-            for err in errors {
-                tracing::error!("{:?}", err);
-            }
-            theme
-        });
+    .map(|res| {
+        for err in res.errors {
+            tracing::error!("{:?}", err);
+        }
 
-        Theme::system(Arc::new(theme))
+        Theme::system(Arc::new(res.config))
     })
 }
 


### PR DESCRIPTION
This simplifies watching configs and should also improve error handling by indicating which key failed to be retrieved. I'm not sure I like using `block_on` when connecting to the settings daemon but it avoids restarting the subscriptions.