### PR TITLE
Change the default value to for buttons_visible usize::MAX

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -377,6 +377,7 @@ where
         tree::State::new(LocalState {
             first: self.model.order.iter().copied().next().unwrap_or_default(),
             paragraphs: SecondaryMap::new(),
+            buttons_visible: usize::MAX, // TODO: Maybe calculate this based on the size of the widget.
             ..LocalState::default()
         })
     }


### PR DESCRIPTION
So a bug was introduced in https://github.com/pop-os/libcosmic/commit/ca92049ab66c338b48a2a2eeb85b46e2e597eb13 

where the vertical(I did not test the horizontal) segmented button did not show. The issue was that by default the number of items to show was 0. 

I am not sure we @mmstick would like it to be by default. I am guessing the plans will be to calculate the default number of buttons to show?

You can see the difference by running the "application" example