### PR TITLE
chore: update gtk4-output for the theme to set adwaita named colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,10 @@ members = [
 ]
 exclude = ["examples/design-demo", "iced"]
 
+[workspace.dependencies]
+dirs = "5.0.1"
+
+
 [patch."https://github.com/pop-os/libcosmic"]
 libcosmic = { path = "./" }
 

--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -13,7 +13,6 @@ subscription = ["iced_futures"]
 zbus = { version = "3.14.1", default-features = false, optional = true }
 atomicwrites = { git = "https://github.com/jackpot51/rust-atomicwrites" }
 calloop = { version = "0.12.2", optional = true }
-dirs = "5.0.1"
 notify = "6.0.0"
 ron = "0.8.0"
 serde = "1.0.152"
@@ -23,6 +22,7 @@ iced_futures = { path = "../iced/futures/", default-features = false, optional =
 once_cell = "1.19.0"
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings", branch = "cosmic-settings-daemon", optional = true }
 futures-util = { version = "0.3", optional = true }
+dirs.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 xdg = "2.1"

--- a/cosmic-theme/Cargo.toml
+++ b/cosmic-theme/Cargo.toml
@@ -11,6 +11,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+gtk4-output = []
 no-default = []
 theme-from-image = ["kmeans_colors", "image"]
 
@@ -24,3 +25,5 @@ ron = "0.8"
 lazy_static = "1.4.0"
 csscolorparser = {version = "0.6.2", features = ["serde"]}
 cosmic-config = { path = "../cosmic-config/", default-features = false, features = ["subscription", "macro"] }
+dirs.workspace = true
+thiserror = "1.0.5"

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -35,11 +35,7 @@ impl Theme {
         let headerbar_bg = to_hex(background.base);
         let headerbar_fg = to_hex(background.on);
         let headerbar_border_color = to_hex(background.divider);
-        // TODO undefined
-        // headerbar_darker_shade_color
-        // headerbar_shade_color
 
-        // TODO confirm with design
         let sidebar_bg = to_hex(primary.base);
         let sidebar_fg = to_hex(primary.on);
         let sidebar_shade = to_hex(if self.is_dark {
@@ -59,17 +55,11 @@ impl Theme {
         });
         let secondary_sidebar_backdrop = to_hex(over(backdrop_overlay, secondary.base));
 
-        // TODO undefined
         let headerbar_backdrop = to_hex(background.base);
-        // TODO undefined
-        // let headerbar_shade = to_hex(background.base);
 
         let card_bg = to_hex(background.component.base);
         let card_fg = to_hex(background.component.on);
-        // TODO undefined
-        // let card_shade = to_hex(background.component.base);
 
-        // TODO undefined
         let thumbnail_bg = to_hex(background.component.base);
         let thumbnail_fg = to_hex(background.component.on);
 
@@ -85,17 +75,9 @@ impl Theme {
             Rgba::new(0.0, 0.0, 0.0, 0.08)
         });
 
-        // TODO undefined
         let mut inverted_bg_divider = background.base;
         inverted_bg_divider.alpha = 0.5;
         let scrollbar_outline = to_hex(inverted_bg_divider);
-
-        // TODO define currentColor
-        // let borders = to_hex(if self.is_high_contrast {
-        //     Rgba::new(0.0, 0.0, 0.0, 0.2)
-        // } else {
-        //     Rgba::new(0.0, 0.0, 0.0, 0.5)
-        // });
 
         let mut css = format! {r#"
 @define-color window_bg_color #{window_bg};

--- a/cosmic-theme/src/output/mod.rs
+++ b/cosmic-theme/src/output/mod.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "gtk4-theme")]
+#[cfg(feature = "gtk4-output")]
 /// Module for outputting the Cosmic gtk4 theme type as CSS
 pub mod gtk4_output;
-#[cfg(feature = "gtk4-theme")]
-pub use gtk4_output::*;
-
-#[cfg(feature = "ron-serialization")]
-pub use ron::*;

--- a/src/config/toolkit.rs
+++ b/src/config/toolkit.rs
@@ -18,8 +18,11 @@ pub struct CosmicTk {
     /// Show maximize button in window header.
     pub show_maximize: bool,
 
-    /// Preferred icon theme
+    /// Preferred icon theme.
     pub icon_theme: String,
+
+    /// Apply the theme to other toolkits.
+    pub apply_theme_global: bool,
 }
 
 impl Default for CosmicTk {
@@ -28,6 +31,7 @@ impl Default for CosmicTk {
             show_minimize: true,
             show_maximize: true,
             icon_theme: String::from("Cosmic"),
+            apply_theme_global: false,
         }
     }
 }


### PR DESCRIPTION
This is still a bit incomplete, and some apps use their own custom variables as well, for example the gtk4 text editor. It does work well as far as I can tell, aside from when the gtk4 text editor uses a dark theme and the css is a light theme. This is because it uses custom variables. As it is, this won't actually write to gtk.css, so to test, you have to copy the file to gtk.css.