### PR TITLE
feat: lower the opacity of colors used in the segmented button when disabled

### DIFF
--- a/examples/cosmic/Cargo.toml
+++ b/examples/cosmic/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 apply = "0.3.0"
 fraction = "0.14.0"
-libcosmic = { path = "../..", features = ["debug", "winit", "tokio", "single-instance", "dbus-config", "a11y" ] }
+libcosmic = { path = "../..", features = ["debug", "winit", "tokio", "single-instance", "dbus-config", "a11y", "wgpu" ] }
 once_cell = "1.18"
 slotmap = "1.0.6"
 env_logger = "0.10"

--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -330,15 +330,25 @@ impl State {
                         .spacing(8)
                         .on_activate(Message::Selection)
                         .into(),
+                    text("Disabled Horizontal With Spacing").into(),
+                    segmented_selection::horizontal(&self.selection)
+                        .spacing(8)
+                        .into(),
                     text("Horizontal Multi-Select").into(),
                     segmented_selection::horizontal(&self.multi_selection)
                         .spacing(8)
                         .on_activate(Message::MultiSelection)
                         .into(),
+                    text("Disabled Horizontal Multi-Select").into(),
+                    segmented_selection::horizontal(&self.multi_selection)
+                        .spacing(8)
+                        .into(),
                     text("Vertical").into(),
                     segmented_selection::vertical(&self.selection)
                         .on_activate(Message::Selection)
                         .into(),
+                    text("Disabled Vertical").into(),
+                    segmented_selection::vertical(&self.selection).into(),
                     text("Vertical Multi-Select Shrunk").into(),
                     segmented_selection::vertical(&self.multi_selection)
                         .width(Length::Shrink)


### PR DESCRIPTION
This is needed for the new tiling applet. Transparent text only seems to be working with the wgpu feature at the moment