### PR TITLE
header_bar: Show window menu on right click

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -69,6 +69,7 @@ pub enum Message {
     SurfaceClosed(window::Id),
     /// Activate the application
     Activate(String),
+    ShowWindowMenu,
 }
 
 #[derive(Default)]
@@ -407,6 +408,10 @@ impl<T: Application> Cosmic<T> {
                 if let Some(msg) = self.app.on_close_requested(id) {
                     return self.app.update(msg);
                 }
+            }
+            Message::ShowWindowMenu => {
+                #[cfg(not(feature = "wayland"))]
+                return window::show_window_menu(window::Id::MAIN);
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -661,7 +661,8 @@ impl<App: Application> ApplicationExt for App {
                         .window_id(window::Id::MAIN)
                         .title(&core.window.header_title)
                         .on_drag(Message::Cosmic(cosmic::Message::Drag))
-                        .on_close(Message::Cosmic(cosmic::Message::Close));
+                        .on_close(Message::Cosmic(cosmic::Message::Close))
+                        .on_right_click(Message::Cosmic(cosmic::Message::ShowWindowMenu));
 
                     if self.nav_model().is_some() {
                         let toggle = crate::widget::nav_bar_toggle()

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -16,6 +16,7 @@ pub fn header_bar<'a, Message>() -> HeaderBar<'a, Message> {
         on_drag: None,
         on_maximize: None,
         on_minimize: None,
+        on_right_click: None,
         start: Vec::new(),
         center: Vec::new(),
         end: Vec::new(),
@@ -44,6 +45,10 @@ pub struct HeaderBar<'a, Message> {
     /// A message emitted when the minimize button is pressed.
     #[setters(strip_option)]
     on_minimize: Option<Message>,
+
+    /// A message emitted when the header is right clicked.
+    #[setters(strip_option)]
+    on_right_click: Option<Message>,
 
     /// The window id for the headerbar.
     #[setters(strip_option)]
@@ -335,6 +340,10 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
         // Assigns a message to emit when the headerbar is double-clicked.
         if let Some(message) = self.on_maximize.clone() {
             widget = widget.on_release(message);
+        }
+
+        if let Some(message) = self.on_right_click.clone() {
+            widget = widget.on_right_press(message);
         }
 
         widget.into()


### PR DESCRIPTION
With this, apps like cosmic-term require no changes to show the compositor window menu when the header is right clicked.

Requires https://github.com/pop-os/iced/pull/103.