### PR TITLE
fix: include Cargo.toml in .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "rust-analyzer.check.overrideCommand": ["just", "check-json"],
-    "git-blame.gitWebUrl": ""
+    "git-blame.gitWebUrl": "",
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml"
+    ]
 }


### PR DESCRIPTION
This was needed for me to get autocomplete with rust-analyzer for libcosmic. If this isn't the right way to do it, vscode suggested it, don't kill the messenger!