### PR TITLE
Theme refactoring and improvements

### DIFF
--- a/cosmic-theme/src/model/derivation.rs
+++ b/cosmic-theme/src/model/derivation.rs
@@ -5,6 +5,7 @@ use crate::composite::over;
 
 /// Theme Container colors of a theme, can be a theme background container, primary container, or secondary container
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[must_use]
 pub struct Container {
     /// the color of the container
     pub base: Srgba,
@@ -17,32 +18,22 @@ pub struct Container {
 }
 
 impl Container {
-    /// convert to srgba
-    pub fn into_srgba(self) -> Container {
-        Container {
-            base: self.base.into(),
-            component: self.component.into_srgba(),
-            divider: self.divider.into(),
-            on: self.on.into(),
-        }
-    }
-
-    pub(crate) fn new(component: Component, bg: Srgba, on_bg: Srgba) -> Self {
-        let mut divider_c: Srgba = on_bg.clone().into();
+    pub(crate) fn new(component: Component, base: Srgba, on: Srgba) -> Self {
+        let mut divider_c = base;
         divider_c.alpha = 0.2;
 
-        let divider = over(divider_c.clone(), bg.clone());
         Self {
-            base: bg,
+            base,
             component,
-            divider: divider.into(),
-            on: on_bg,
+            divider: over(divider_c, base),
+            on,
         }
     }
 }
 
 /// The colors for a widget of the Cosmic theme
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[must_use]
 pub struct Component {
     /// The base color of the widget
     pub base: Srgba,
@@ -72,43 +63,32 @@ pub struct Component {
     pub disabled_border: Srgba,
 }
 
+#[allow(clippy::must_use_candidate)]
+#[allow(clippy::doc_markdown)]
 impl Component {
     /// get @hover_state_color
     pub fn hover_state_color(&self) -> Srgba {
-        self.hover.clone().into()
+        self.hover
     }
+
     /// get @pressed_state_color
     pub fn pressed_state_color(&self) -> Srgba {
-        self.pressed.clone().into()
+        self.pressed
     }
+
     /// get @selected_state_color
     pub fn selected_state_color(&self) -> Srgba {
-        self.selected.clone().into()
+        self.selected
     }
+
     /// get @selected_state_text_color
     pub fn selected_state_text_color(&self) -> Srgba {
-        self.selected_text.clone().into()
+        self.selected_text
     }
+
     /// get @focus_color
     pub fn focus_color(&self) -> Srgba {
-        self.focus.clone().into()
-    }
-    /// convert to srgba
-    pub fn into_srgba(self) -> Component {
-        Component {
-            base: self.base.into(),
-            hover: self.hover.into(),
-            pressed: self.pressed.into(),
-            selected: self.selected.into(),
-            selected_text: self.selected_text.into(),
-            focus: self.focus.into(),
-            divider: self.divider.into(),
-            on: self.on.into(),
-            disabled: self.disabled.into(),
-            on_disabled: self.on_disabled.into(),
-            border: self.border.into(),
-            disabled_border: self.disabled_border.into(),
-        }
+        self.focus
     }
 
     /// helper for producing a component from a base color a neutral and an accent
@@ -119,27 +99,27 @@ impl Component {
         hovered: Srgba,
         pressed: Srgba,
     ) -> Self {
-        let base: Srgba = base.into();
-        let mut base_50 = base.clone();
+        let base: Srgba = base;
+        let mut base_50 = base;
         base_50.alpha *= 0.5;
 
-        let on_20 = neutral.clone();
-        let mut on_50: Srgba = on_20.clone().into();
+        let on_20 = neutral;
+        let mut on_50: Srgba = on_20;
         on_50.alpha = 0.5;
 
         Component {
-            base: base.clone().into(),
-            hover: over(hovered.clone(), base).into(),
-            pressed: over(pressed, base).into(),
-            selected: over(hovered, base).into(),
-            selected_text: accent.clone(),
+            base,
+            hover: over(hovered, base),
+            pressed: over(pressed, base),
+            selected: over(hovered, base),
+            selected_text: accent,
             divider: on_20,
             on: neutral,
-            disabled: over(base_50, base).into(),
-            on_disabled: over(on_50, base).into(),
+            disabled: over(base_50, base),
+            on_disabled: over(on_50, base),
             focus: accent,
-            border: base.into(),
-            disabled_border: base_50.into(),
+            border: base,
+            disabled_border: base_50,
         }
     }
 
@@ -153,7 +133,7 @@ impl Component {
         pressed: Srgba,
     ) -> Self {
         let mut component = Component::colored_component(base, overlay, accent, hovered, pressed);
-        component.on = on_button.clone();
+        component.on = on_button;
 
         let mut on_disabled = on_button;
         on_disabled.alpha = 0.5;
@@ -163,6 +143,7 @@ impl Component {
     }
 
     /// helper for producing a component color theme
+    #[allow(clippy::self_named_constructors)]
     pub fn component(
         base: Srgba,
         accent: Srgba,
@@ -172,11 +153,11 @@ impl Component {
         is_high_contrast: bool,
         border: Srgba,
     ) -> Self {
-        let mut base_50 = base.clone();
+        let mut base_50 = base;
         base_50.alpha *= 0.5;
 
-        let mut on_20 = on_component.clone();
-        let mut on_50 = on_20.clone();
+        let mut on_20 = on_component;
+        let mut on_50 = on_20;
 
         on_20.alpha = 0.2;
         on_50.alpha = 0.5;
@@ -185,34 +166,30 @@ impl Component {
         disabled_border.alpha *= 0.5;
 
         Component {
-            base: base.clone().into(),
+            base,
             hover: if base.alpha < 0.001 {
-                hovered.clone()
+                hovered
             } else {
-                over(hovered.clone(), base).into()
+                over(hovered, base)
             },
             pressed: if base.alpha < 0.001 {
-                pressed.clone()
+                pressed
             } else {
-                over(pressed.clone(), base).into()
+                over(pressed, base)
             },
             selected: if base.alpha < 0.001 {
-                hovered.clone()
+                hovered
             } else {
-                over(hovered.clone(), base).into()
+                over(hovered, base)
             },
-            selected_text: accent.clone(),
-            focus: accent.clone(),
-            divider: if is_high_contrast {
-                on_50.clone().into()
-            } else {
-                on_20.into()
-            },
-            on: on_component.clone(),
-            disabled: over(base_50, base).into(),
-            on_disabled: over(on_50, base).into(),
-            border: border.into(),
-            disabled_border: disabled_border.into(),
+            selected_text: accent,
+            focus: accent,
+            divider: if is_high_contrast { on_50 } else { on_20 },
+            on: on_component,
+            disabled: over(base_50, base),
+            on_disabled: over(on_50, base),
+            border,
+            disabled_border,
         }
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -238,7 +238,6 @@ impl Theme {
 
     /// get current container
     /// can be used in a component that is intended to be a child of a `CosmicContainer`
-    #[must_use]
     pub fn current_container(&self) -> &cosmic_theme::Container {
         match self.layer {
             cosmic_theme::Layer::Background => &self.cosmic().background,

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -369,6 +369,7 @@ pub enum Container {
     WindowBackground,
     Background,
     Card,
+    ContextDrawer,
     Custom(Box<dyn Fn(&Theme) -> container::Appearance>),
     Dialog,
     Dropdown,
@@ -384,6 +385,48 @@ impl Container {
     pub fn custom<F: Fn(&Theme) -> container::Appearance + 'static>(f: F) -> Self {
         Self::Custom(Box::new(f))
     }
+
+    #[must_use]
+    pub fn background(theme: &cosmic_theme::Theme) -> container::Appearance {
+        container::Appearance {
+            icon_color: Some(Color::from(theme.background.on)),
+            text_color: Some(Color::from(theme.background.on)),
+            background: Some(iced::Background::Color(theme.background.base.into())),
+            border: Border {
+                radius: theme.corner_radii.radius_xs.into(),
+                ..Default::default()
+            },
+            shadow: Shadow::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn primary(theme: &cosmic_theme::Theme) -> container::Appearance {
+        container::Appearance {
+            icon_color: Some(Color::from(theme.primary.on)),
+            text_color: Some(Color::from(theme.primary.on)),
+            background: Some(iced::Background::Color(theme.primary.base.into())),
+            border: Border {
+                radius: theme.corner_radii.radius_xs.into(),
+                ..Default::default()
+            },
+            shadow: Shadow::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn secondary(theme: &cosmic_theme::Theme) -> container::Appearance {
+        container::Appearance {
+            icon_color: Some(Color::from(theme.secondary.on)),
+            text_color: Some(Color::from(theme.secondary.on)),
+            background: Some(iced::Background::Color(theme.secondary.base.into())),
+            border: Border {
+                radius: theme.corner_radii.radius_xs.into(),
+                ..Default::default()
+            },
+            shadow: Shadow::default(),
+        }
+    }
 }
 
 impl container::StyleSheet for Theme {
@@ -394,7 +437,9 @@ impl container::StyleSheet for Theme {
         let cosmic = self.cosmic();
         match style {
             Container::Transparent => container::Appearance::default(),
+
             Container::Custom(f) => f(self),
+
             Container::WindowBackground => container::Appearance {
                 icon_color: Some(Color::from(cosmic.background.on)),
                 text_color: Some(Color::from(cosmic.background.on)),
@@ -411,56 +456,48 @@ impl container::StyleSheet for Theme {
                 },
                 shadow: Shadow::default(),
             },
-            Container::Background => container::Appearance {
-                icon_color: Some(Color::from(cosmic.background.on)),
+
+            Container::HeaderBar => container::Appearance {
+                icon_color: Some(Color::from(cosmic.accent.base)),
                 text_color: Some(Color::from(cosmic.background.on)),
                 background: Some(iced::Background::Color(cosmic.background.base.into())),
                 border: Border {
-                    radius: cosmic.corner_radii.radius_xs.into(),
+                    radius: [
+                        cosmic.corner_radii.radius_xs[0],
+                        cosmic.corner_radii.radius_xs[1],
+                        cosmic.corner_radii.radius_0[2],
+                        cosmic.corner_radii.radius_0[3],
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 shadow: Shadow::default(),
             },
-            Container::HeaderBar => {
-                let header_top = cosmic.background.base;
 
-                container::Appearance {
-                    icon_color: Some(Color::from(cosmic.accent.base)),
-                    text_color: Some(Color::from(cosmic.background.on)),
-                    background: Some(iced::Background::Color(header_top.into())),
-                    border: Border {
-                        radius: [
-                            cosmic.corner_radii.radius_xs[0],
-                            cosmic.corner_radii.radius_xs[1],
-                            cosmic.corner_radii.radius_0[2],
-                            cosmic.corner_radii.radius_0[3],
-                        ]
-                        .into(),
-                        ..Default::default()
-                    },
-                    shadow: Shadow::default(),
-                }
+            Container::ContextDrawer => {
+                let mut appearance = crate::style::Container::primary(cosmic);
+
+                appearance.border = Border {
+                    color: cosmic.primary.divider.into(),
+                    width: 1.0,
+                    radius: cosmic.corner_radii.radius_s.into(),
+                };
+
+                appearance.shadow = Shadow {
+                    color: cosmic.shade.into(),
+                    offset: Vector::new(0.0, 0.0),
+                    blur_radius: 16.0,
+                };
+
+                appearance
             }
-            Container::Primary => container::Appearance {
-                icon_color: Some(Color::from(cosmic.primary.on)),
-                text_color: Some(Color::from(cosmic.primary.on)),
-                background: Some(iced::Background::Color(cosmic.primary.base.into())),
-                border: Border {
-                    radius: cosmic.corner_radii.radius_xs.into(),
-                    ..Default::default()
-                },
-                shadow: Shadow::default(),
-            },
-            Container::Secondary => container::Appearance {
-                icon_color: Some(Color::from(cosmic.secondary.on)),
-                text_color: Some(Color::from(cosmic.secondary.on)),
-                background: Some(iced::Background::Color(cosmic.secondary.base.into())),
-                border: Border {
-                    radius: cosmic.corner_radii.radius_xs.into(),
-                    ..Default::default()
-                },
-                shadow: Shadow::default(),
-            },
+
+            Container::Background => Container::background(cosmic),
+
+            Container::Primary => Container::primary(cosmic),
+
+            Container::Secondary => Container::secondary(cosmic),
+
             Container::Dropdown => {
                 let theme = self.cosmic();
 
@@ -475,6 +512,7 @@ impl container::StyleSheet for Theme {
                     shadow: Shadow::default(),
                 }
             }
+
             Container::Tooltip => container::Appearance {
                 icon_color: None,
                 text_color: None,

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -374,6 +374,7 @@ pub enum Container {
     Dialog,
     Dropdown,
     HeaderBar,
+    List,
     Primary,
     Secondary,
     Tooltip,
@@ -456,6 +457,21 @@ impl container::StyleSheet for Theme {
                 },
                 shadow: Shadow::default(),
             },
+
+            Container::List => {
+                let component = &self.current_container().component;
+
+                container::Appearance {
+                    icon_color: Some(component.on.into()),
+                    text_color: Some(component.on.into()),
+                    background: Some(Background::Color(component.base.into())),
+                    border: iced::Border {
+                        radius: cosmic.corner_radii.radius_s.into(),
+                        ..Default::default()
+                    },
+                    shadow: Shadow::default(),
+                }
+            }
 
             Container::HeaderBar => container::Appearance {
                 icon_color: Some(Color::from(cosmic.accent.base)),

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -459,7 +459,12 @@ impl container::StyleSheet for Theme {
             },
 
             Container::List => {
-                let component = &self.current_container().component;
+                // TODO: The primary component has the wrong color on the light theme.
+                let component = if cosmic.is_dark {
+                    &self.current_container().component
+                } else {
+                    &cosmic.background.component
+                };
 
                 container::Appearance {
                     icon_color: Some(component.on.into()),

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -8,9 +8,9 @@ use crate::{Apply, Element, Renderer, Theme};
 
 use super::overlay::Overlay;
 
+use iced_core::alignment;
 use iced_core::event::{self, Event};
 use iced_core::widget::{Operation, Tree};
-use iced_core::{alignment, Border};
 use iced_core::{
     layout, mouse, overlay as iced_overlay, renderer, Clipboard, Color, Layout, Length, Padding,
     Rectangle, Shell, Widget,
@@ -85,20 +85,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
             // XXX this is a hack to get around that
             drawer: container(
                 LayerContainer::new(pane)
-                    .style(crate::style::Container::custom(move |theme| {
-                        let palette = theme.cosmic();
-
-                        container::Appearance {
-                            icon_color: Some(Color::from(palette.primary.on)),
-                            text_color: Some(Color::from(palette.primary.on)),
-                            background: Some(iced::Background::Color(palette.primary.base.into())),
-                            border: Border {
-                                radius: palette.corner_radii.radius_s.into(),
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }
-                    }))
+                    .style(crate::style::Container::ContextDrawer)
                     .layer(cosmic_theme::Layer::Primary)
                     .width(Length::Fill)
                     .height(Length::Fill)

--- a/src/widget/list/mod.rs
+++ b/src/widget/list/mod.rs
@@ -9,30 +9,12 @@ pub use self::column::{list_column, ListColumn};
 
 use crate::widget::Container;
 use crate::Element;
-use iced::Background;
-use iced_core::Shadow;
 
 pub fn container<'a, Message>(
     content: impl Into<Element<'a, Message>>,
 ) -> Container<'a, Message, crate::Theme, crate::Renderer> {
     super::container(content)
         .padding([16, 6])
-        .style(crate::theme::Container::custom(style))
+        .style(crate::theme::Container::List)
         .width(iced::Length::Fill)
-}
-
-#[must_use]
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub fn style(theme: &crate::Theme) -> crate::widget::container::Appearance {
-    let container = &theme.current_container().component;
-    crate::widget::container::Appearance {
-        icon_color: Some(container.on.into()),
-        text_color: Some(container.on.into()),
-        background: Some(Background::Color(container.base.into())),
-        border: iced::Border {
-            radius: theme.cosmic().corner_radii.radius_s.into(),
-            ..Default::default()
-        },
-        shadow: Shadow::default(),
-    }
 }

--- a/src/widget/settings/item.rs
+++ b/src/widget/settings/item.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use derive_setters::Setters;
 use iced_core::Length;
-use iced_widget::container;
 
 /// A settings item aligned in a row
 #[must_use]
@@ -80,7 +79,7 @@ impl<'a, Message: 'static> Item<'a, Message> {
             contents.push(text(self.title).width(Length::Fill).into());
         }
 
-        contents.push(widget.into().into());
+        contents.push(widget.into());
 
         item_row(contents)
     }


### PR DESCRIPTION
- Moves custom config styles for `List` and `ContextDrawer` to our `Container` style
- Fixes dark list containers in the context drawer on the light theme
- Applies clippy lints to the derivaion module in cosmic-theme
- Groups and reorganizes the background, primary, and secondary container code so that they're easier to debug
- Adds methods for creating default appearances for background, primary, and secondary containers

The fix for the context drawer on light themes is a workaround until we can figure out why the primary container component has such as a dark background color with the light theme.

Closes #314 