### PR TITLE
fix(cosmic-config-derive): do not return error when getting config which is not set

### DIFF
--- a/cosmic-config-derive/src/lib.rs
+++ b/cosmic-config-derive/src/lib.rs
@@ -55,6 +55,7 @@ fn impl_cosmic_config_entry_macro(ast: &syn::DeriveInput) -> TokenStream {
         quote! {
             match cosmic_config::ConfigGet::get::<#field_type>(config, stringify!(#field_name)) {
                 Ok(#field_name) => default.#field_name = #field_name,
+                Err(why) if matches!(why, cosmic_config::Error::NoConfigDirectory) => (),
                 Err(e) => errors.push(e),
             }
         }


### PR DESCRIPTION
Fixes logged errors in cosmic-settings when the config files are not created yet.