### PR TITLE
fix: add case independent startup_wm_class, name fallback

### DIFF
--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -76,9 +76,19 @@ pub fn load_applications_for_app_ids<'a, 'b>(
 ) -> Vec<DesktopEntryData> {
     let mut app_ids = app_ids.collect::<Vec<_>>();
     let mut applications = load_applications_filtered(locale, |de| {
-        if let Some(i) = app_ids
+        // If appid matches, or startup_wm_class matches...
+        if let Some(i) = app_ids.iter().position(|id| {
+            id == &de.appid
+                || id
+                    .to_lowercase()
+                    .eq(&de.startup_wm_class().unwrap_or_default().to_lowercase())
+        }) {
+            app_ids.remove(i);
+            true
+        // Fallback: If the name matches...
+        } else if let Some(i) = app_ids
             .iter()
-            .position(|id| id == &de.appid || id.eq(&de.startup_wm_class().unwrap_or_default()))
+            .position(|id| id.to_lowercase().eq(&de.name().to_lowercase()))
         {
             app_ids.remove(i);
             true


### PR DESCRIPTION
This PR adds a "name" fallback and changes the startup_wm_class fallback to evaluate independent of case.

Some applications (like element desktop) have a app id capitalized e.g. "Element" when their startup_wm_class is lowercase e.g. "element".

The "name" fallback is separate from the startup_wm_class and appid conditions just in case an app is named something similar to another app's id.

Apps known by me to be fixed by the case insensitive wm_class fallback:
* Element
* RStudio
* Steam
* VLC

Apps known by me to be fixed by the name fallback:
* ONLYOFFICE Desktop Editors

This should fix part (or potentially all) of [this issue](https://github.com/pop-os/cosmic-applets/issues/194), [this issue](https://github.com/pop-os/cosmic-applets/issues/195), and [this issue](https://github.com/pop-os/cosmic-applets/issues/252)

I believe this is similar to what other DEs do to handle problematic apps that don't register their app-id properly.