### PR TITLE
refactor: rename `cosmic_container` to `layer_container`

### DIFF
--- a/src/widget/layer_container.rs
+++ b/src/widget/layer_container.rs
@@ -10,7 +10,7 @@ use iced_core::widget::Tree;
 use iced_core::{Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Widget};
 pub use iced_style::container::{Appearance, StyleSheet};
 
-pub fn container<'a, Message: 'static, Theme, E>(
+pub fn layer_container<'a, Message: 'static, Theme, E>(
     content: E,
 ) -> LayerContainer<'a, Message, Theme, crate::Renderer>
 where

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -55,8 +55,8 @@ pub mod column {
     }
 }
 
-pub mod cosmic_container;
-pub use cosmic_container::LayerContainer;
+pub mod layer_container;
+pub use layer_container::{layer_container, LayerContainer};
 
 pub mod dialog;
 pub use dialog::{dialog, Dialog};


### PR DESCRIPTION
Makes it available as `cosmic::widget::layer_container()`. @edfloreshz 