### PR TITLE
improv(menu): simplify menu construction.

### DIFF
--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "menu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tracing-log = "0.2.0"
+
+[dependencies.libcosmic]
+path = "../../"
+default-features = false
+features = ["debug", "winit", "tokio", "xdg-portal"]

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -1,0 +1,178 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Application API example
+
+use cosmic::app::{Command, Core, Settings};
+use cosmic::iced::window;
+use cosmic::iced_core::alignment::{Horizontal, Vertical};
+use cosmic::iced_core::keyboard::Key;
+use cosmic::iced_core::{Length, Size};
+use cosmic::widget::menu::action::MenuAction;
+use cosmic::widget::menu::key_bind::KeyBind;
+use cosmic::widget::menu::key_bind::Modifier;
+use cosmic::widget::menu::menu_tree::{menu_items, menu_root, MenuItem};
+use cosmic::widget::menu::{ItemHeight, ItemWidth, MenuBar, MenuTree};
+use cosmic::widget::segmented_button::Entity;
+use cosmic::{executor, Element};
+use std::collections::HashMap;
+use std::{env, process};
+
+/// Runs application with these settings
+#[rustfmt::skip]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let _ = tracing_log::LogTracer::init();
+
+    let settings = Settings::default()
+        .antialiasing(true)
+        .client_decorations(true)
+        .debug(false)
+        .default_icon_theme("Pop")
+        .default_text_size(16.0)
+        .scale_factor(1.0)
+        .size(Size::new(1024., 768.));
+
+    cosmic::app::run::<App>(settings, ())?;
+
+    Ok(())
+}
+
+/// Messages that are used specifically by our [`App`].
+#[derive(Clone, Debug)]
+pub enum Message {
+    WindowClose,
+    WindowNew,
+}
+
+/// The [`App`] stores application-specific state.
+pub struct App {
+    core: Core,
+    key_binds: HashMap<KeyBind, Action>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Action {
+    WindowClose,
+    WindowNew,
+}
+
+impl MenuAction for Action {
+    type Message = Message;
+    fn message(&self, _entity_opt: Option<Entity>) -> Self::Message {
+        match self {
+            Action::WindowClose => Message::WindowClose,
+            Action::WindowNew => Message::WindowNew,
+        }
+    }
+}
+
+/// Implement [`cosmic::Application`] to integrate with COSMIC.
+impl cosmic::Application for App {
+    /// Default async executor to use with the app.
+    type Executor = executor::Default;
+
+    /// Argument received [`cosmic::Application::new`].
+    type Flags = ();
+
+    /// Message type specific to our [`App`].
+    type Message = Message;
+
+    /// The unique application ID to supply to the window manager.
+    const APP_ID: &'static str = "org.cosmic.AppDemo";
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    /// Creates the application, and optionally emits command on initialize.
+    fn init(core: Core, _input: Self::Flags) -> (Self, Command<Self::Message>) {
+        let app = App {
+            core,
+            key_binds: key_binds(),
+        };
+
+        (app, Command::none())
+    }
+
+    fn header_start(&self) -> Vec<Element<Self::Message>> {
+        vec![menu_bar(&self.key_binds)]
+    }
+
+    /// Handle application events here.
+    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+        match message {
+            Message::WindowClose => {
+                return window::close(window::Id::MAIN);
+            }
+            Message::WindowNew => match env::current_exe() {
+                Ok(exe) => match process::Command::new(&exe).spawn() {
+                    Ok(_child) => {}
+                    Err(err) => {
+                        eprintln!("failed to execute {:?}: {}", exe, err);
+                    }
+                },
+                Err(err) => {
+                    eprintln!("failed to get current executable path: {}", err);
+                }
+            },
+        }
+        Command::none()
+    }
+
+    /// Creates a view after each update.
+    fn view(&self) -> Element<Self::Message> {
+        let text = cosmic::widget::text("Menu Example");
+
+        let centered = cosmic::widget::container(text)
+            .width(Length::Fill)
+            .height(Length::Shrink)
+            .align_x(Horizontal::Center)
+            .align_y(Vertical::Center);
+
+        Element::from(centered)
+    }
+}
+
+pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, Action>) -> Element<'a, Message> {
+    MenuBar::new(vec![MenuTree::with_children(
+        menu_root("File"),
+        menu_items(
+            key_binds,
+            vec![
+                MenuItem::Action("New window", Action::WindowNew),
+                MenuItem::Separator,
+                MenuItem::Action("Quit", Action::WindowClose),
+            ],
+        ),
+    )])
+    .item_height(ItemHeight::Dynamic(40))
+    .item_width(ItemWidth::Uniform(240))
+    .spacing(4.0)
+    .into()
+}
+
+pub fn key_binds() -> HashMap<KeyBind, Action> {
+    let mut key_binds = HashMap::new();
+
+    macro_rules! bind {
+        ([$($modifier:ident),* $(,)?], $key:expr, $action:ident) => {{
+            key_binds.insert(
+                KeyBind {
+                    modifiers: vec![$(Modifier::$modifier),*],
+                    key: $key,
+                },
+                Action::$action,
+            );
+        }};
+    }
+
+    bind!([Ctrl], Key::Character("w".into()), WindowClose);
+    bind!([Ctrl, Shift], Key::Character("n".into()), WindowNew);
+
+    key_binds
+}

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -54,7 +54,9 @@
 //! ```
 //!
 
+pub mod action;
 mod flex;
+pub mod key_bind;
 pub mod menu_bar;
 mod menu_inner;
 pub mod menu_tree;

--- a/src/widget/menu/action.rs
+++ b/src/widget/menu/action.rs
@@ -1,0 +1,7 @@
+use crate::widget::segmented_button::Entity;
+
+pub trait MenuAction: Clone + Copy + Eq + PartialEq {
+    type Message;
+
+    fn message(&self, entity: Option<Entity>) -> Self::Message;
+}

--- a/src/widget/menu/action.rs
+++ b/src/widget/menu/action.rs
@@ -1,7 +1,57 @@
 use crate::widget::segmented_button::Entity;
 
+/// `MenuAction` is a trait that represents an action in a menu.
+///
+/// It is used to define the behavior of menu items when they are activated.
+/// Each menu item can have a unique action associated with it.
+///
+/// This trait is generic over a type `Message` which is the type of message
+/// that will be produced when the action is triggered.
+///
+/// # Example
+///
+/// ```
+/// use cosmic::widget::menu::action::MenuAction;
+/// use cosmic::widget::segmented_button::Entity;
+///
+/// #[derive(Clone, Copy, Eq, PartialEq)]
+/// enum MyMessage {
+///     Open,
+///     Save,
+///     Quit,
+/// }
+///
+/// #[derive(Clone, Copy, Eq, PartialEq)]
+/// enum MyAction {
+///     Open,
+///     Save,
+///     Quit,
+/// }
+///
+/// impl MenuAction for MyAction {
+///     type Message = MyMessage;
+///
+///     fn message(&self, entity: Option<Entity>) -> Self::Message {
+///         match self {
+///             MyAction::Open => MyMessage::Open,
+///             MyAction::Save => MyMessage::Save,
+///             MyAction::Quit => MyMessage::Quit,
+///         }
+///     }
+/// }
+/// ```
 pub trait MenuAction: Clone + Copy + Eq + PartialEq {
+    /// The type of message that will be produced when the action is triggered.
     type Message;
 
+    /// Returns a message of type `Self::Message` when the action is triggered.
+    ///
+    /// # Arguments
+    ///
+    /// * `entity` - An optional `Entity` that may be associated with the action.
+    ///
+    /// # Returns
+    ///
+    /// * `Self::Message` - The message that is produced when the action is triggered.
     fn message(&self, entity: Option<Entity>) -> Self::Message;
 }

--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -1,0 +1,39 @@
+use iced_core::keyboard::{Key, Modifiers};
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Modifier {
+    Super,
+    Ctrl,
+    Alt,
+    Shift,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct KeyBind {
+    pub modifiers: Vec<Modifier>,
+    pub key: Key,
+}
+
+impl KeyBind {
+    pub fn matches(&self, modifiers: Modifiers, key: &Key) -> bool {
+        key == &self.key
+            && modifiers.logo() == self.modifiers.contains(&Modifier::Super)
+            && modifiers.control() == self.modifiers.contains(&Modifier::Ctrl)
+            && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
+            && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
+    }
+}
+
+impl fmt::Display for KeyBind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for modifier in self.modifiers.iter() {
+            write!(f, "{:?} + ", modifier)?;
+        }
+        match &self.key {
+            Key::Character(c) => write!(f, "{}", c.to_uppercase()),
+            Key::Named(named) => write!(f, "{:?}", named),
+            other => write!(f, "{:?}", other),
+        }
+    }
+}

--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -1,6 +1,13 @@
 use iced_core::keyboard::{Key, Modifiers};
 use std::fmt;
 
+/// Represents the modifier keys on a keyboard.
+///
+/// It has four variants:
+/// * `Super`: Represents the Super key (also known as the Windows key on Windows, Command key on macOS).
+/// * `Ctrl`: Represents the Control key.
+/// * `Alt`: Represents the Alt key.
+/// * `Shift`: Represents the Shift key.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Modifier {
     Super,
@@ -9,13 +16,27 @@ pub enum Modifier {
     Shift,
 }
 
+/// Represents a combination of a key and modifiers.
+/// It is used to define keyboard shortcuts.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct KeyBind {
+    /// A vector of modifiers for the key binding.
     pub modifiers: Vec<Modifier>,
+    /// The key for the key binding.
     pub key: Key,
 }
 
 impl KeyBind {
+    /// Checks if the given key and modifiers match the `KeyBind`.
+    ///
+    /// # Arguments
+    ///
+    /// * `modifiers` - A `Modifiers` instance representing the current active modifiers.
+    /// * `key` - A reference to the `Key` that is being checked.
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
     pub fn matches(&self, modifiers: Modifiers, key: &Key) -> bool {
         key == &self.key
             && modifiers.logo() == self.modifiers.contains(&Modifier::Super)

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -137,6 +137,7 @@ where
     }
 }
 
+/// This macro creates a button for a MenuTree.
 macro_rules! menu_button {
     ($($x:expr),+ $(,)?) => (
         widget::button(
@@ -154,11 +155,26 @@ macro_rules! menu_button {
     );
 }
 
+/// Represents a menu item that performs an action when selected or a separator between menu items.
+///
+/// - `Action` - Represents a menu item that performs an action when selected.
+///     - `L` - The label of the menu item.
+///     - `A` - The action to perform when the menu item is selected, the action must implement the `MenuAction` trait.
+/// - `Separator` - Represents a separator between menu items.
 pub enum MenuItem<A: MenuAction, L: Into<Cow<'static, str>>> {
+    /// Represents a menu item that performs an action when selected.
     Action(L, A),
+    /// Represents a separator between menu items.
     Separator,
 }
 
+/// Create a root menu item.
+///
+/// # Arguments
+/// - `label` - The label of the menu item.
+///
+/// # Returns
+/// - A button for the root menu item.
 pub fn menu_root<'a, Message, Renderer: renderer::Renderer>(
     label: impl Into<Cow<'a, str>> + 'a,
 ) -> iced::Element<'a, Message, crate::Theme, Renderer>
@@ -172,6 +188,16 @@ where
         .into()
 }
 
+/// Create a list of menu items from a vector of `MenuItem`.
+///
+/// The `MenuItem` can be either an action or a separator.
+///
+/// # Arguments
+/// - `key_binds` - A reference to a `HashMap` that maps `KeyBind` to `A`.
+/// - `children` - A vector of `MenuItem`.
+///
+/// # Returns
+/// - A vector of `MenuTree`.
 pub fn menu_items<
     'a,
     A: MenuAction<Message = Message>,


### PR DESCRIPTION
This PR simplifies the menu declaration for cosmic applications.

It is not longer required that the user builds each widget for the menu, it is now possible to construct the necessary widgets based on user input, applying a standard style to all menus across applications.

## Example

```rust
MenuBar::new(vec![MenuTree::with_children(
    menu_root("File"),
    menu_items(
        key_binds,
        vec![
            MenuItem::Action("New window", Action::WindowNew),
            MenuItem::Separator,
            MenuItem::Action("Quit", Action::WindowClose),
        ],
    ),
)])
```

## Changelog

- Added `MenuAction` trait to call the `message` method on button press.
- Added two new methods to construct a `MenuTree`.
- Added `MenuItem` enum to represent an action or a separator in a `MenuTree`.
- Added menu example.
- Moved `Modifier` enum and `KeyBind` struct to libcosmic.
- Moved `menu_button` macro to libcosmic.