### PR TITLE
fix: fallback to Cosmic icon theme

### DIFF
--- a/examples/cosmic/src/window/demo.rs
+++ b/examples/cosmic/src/window/demo.rs
@@ -8,7 +8,7 @@ use cosmic::{
     iced_core::id,
     theme::ThemeType,
     widget::{
-        button, color_picker::ColorPickerUpdate, cosmic_container::container, dropdown, icon,
+        button, color_picker::ColorPickerUpdate, dropdown, icon, layer_container as container,
         segmented_button, segmented_control, settings, spin_button, tab_bar, toggler,
         ColorPickerModel,
     },

--- a/src/icon_theme.rs
+++ b/src/icon_theme.rs
@@ -6,6 +6,8 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 
+pub const COSMIC: &str = "Cosmic";
+
 thread_local! {
     /// The fallback icon theme to search if no icon theme was specified.
     pub(crate) static DEFAULT: RefCell<Cow<'static, str>> = RefCell::new("Cosmic".into());

--- a/src/icon_theme.rs
+++ b/src/icon_theme.rs
@@ -10,7 +10,7 @@ pub const COSMIC: &str = "Cosmic";
 
 thread_local! {
     /// The fallback icon theme to search if no icon theme was specified.
-    pub(crate) static DEFAULT: RefCell<Cow<'static, str>> = RefCell::new("Cosmic".into());
+    pub(crate) static DEFAULT: RefCell<Cow<'static, str>> = RefCell::new(COSMIC.into());
 }
 
 /// The fallback icon theme to search if no icon theme was specified.


### PR DESCRIPTION
This will fallback to the Cosmic icon theme when an icon isn't found in the default. It does clash a bit with the existing fallback strategy, and I'm not sure if we would prefer to give that priority?