### PR TITLE
chore: Update calloop

### DIFF
--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -12,7 +12,7 @@ subscription = ["iced_futures"]
 [dependencies]
 zbus = { version = "3.14.1", default-features = false, optional = true }
 atomicwrites = { git = "https://github.com/jackpot51/rust-atomicwrites" }
-calloop = { version = "0.12.2", optional = true }
+calloop = { version = "0.13.0", optional = true }
 notify = "6.0.0"
 ron = "0.8.0"
 serde = "1.0.152"


### PR DESCRIPTION
smithay now depends on 0.13, this brings cosmic-config for use in cosmic-comp in line with that requirement.