### PR TITLE
applet: Add `icon_button_from_handle`

### DIFF
--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -118,29 +118,37 @@ impl Context {
     }
 
     #[must_use]
-    pub fn icon_button<'a, Message: 'static>(
+    pub fn icon_button_from_handle<'a, Message: 'static>(
         &self,
-        icon_name: &'a str,
+        icon: widget::icon::Handle,
     ) -> crate::widget::Button<'a, Message, crate::Theme, Renderer> {
         let suggested = self.suggested_size();
         let applet_padding = self.suggested_padding();
         crate::widget::button(
-            widget::icon(
-                widget::icon::from_name(icon_name)
-                    .symbolic(true)
-                    .size(self.suggested_size().0)
-                    .into(),
-            )
-            .style(theme::Svg::Custom(Rc::new(|theme| {
-                crate::iced_style::svg::Appearance {
-                    color: Some(theme.cosmic().background.on.into()),
-                }
-            })))
-            .width(Length::Fixed(suggested.0 as f32))
-            .height(Length::Fixed(suggested.1 as f32)),
+            widget::icon(icon)
+                .style(theme::Svg::Custom(Rc::new(|theme| {
+                    crate::iced_style::svg::Appearance {
+                        color: Some(theme.cosmic().background.on.into()),
+                    }
+                })))
+                .width(Length::Fixed(suggested.0 as f32))
+                .height(Length::Fixed(suggested.1 as f32)),
         )
         .padding(applet_padding)
         .style(Button::AppletIcon)
+    }
+
+    #[must_use]
+    pub fn icon_button<'a, Message: 'static>(
+        &self,
+        icon_name: &'a str,
+    ) -> crate::widget::Button<'a, Message, crate::Theme, Renderer> {
+        self.icon_button_from_handle(
+            widget::icon::from_name(icon_name)
+                .symbolic(true)
+                .size(self.suggested_size().0)
+                .into(),
+        )
     }
 
     // TODO popup container which tracks the size of itself and requests the popup to resize to match


### PR DESCRIPTION
`StatusNotifierItem` can use either named icons, or pixmap data. So to support the latter, it needs a way to show a non-named icon with the same button styling as any other planel applet icon.

The `StatusNotifierItem` protocol actually supports sending different icons with different sizes, so ideally we'd want a `icon::Data` variant that contains multiple sizes? But just using the largest and scaling works for now.