### PR TITLE
Add `editable_input` widget

### DIFF
--- a/examples/text-input/Cargo.toml
+++ b/examples/text-input/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "text-input"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tracing-log = "0.2.0"
+
+[dependencies.libcosmic]
+path = "../../"
+default-features = false
+features = ["debug", "winit", "tokio", "xdg-portal"]

--- a/examples/text-input/src/main.rs
+++ b/examples/text-input/src/main.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Application API example
+
+use cosmic::app::{Command, Core, Settings};
+use cosmic::{executor, iced, ApplicationExt, Element};
+
+/// Runs application with these settings
+#[rustfmt::skip]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let _ = tracing_log::LogTracer::init();
+
+    cosmic::app::run::<App>(Settings::default(), ())?;
+
+    Ok(())
+}
+
+/// Messages that are used specifically by our [`App`].
+#[derive(Clone, Debug)]
+pub enum Message {
+    EditMode(bool),
+    Input(String),
+}
+
+/// The [`App`] stores application-specific state.
+pub struct App {
+    core: Core,
+    input: String,
+    editing: bool,
+    search_id: cosmic::widget::Id,
+}
+
+/// Implement [`cosmic::Application`] to integrate with COSMIC.
+impl cosmic::Application for App {
+    /// Default async executor to use with the app.
+    type Executor = executor::Default;
+
+    /// Argument received [`cosmic::Application::new`].
+    type Flags = ();
+
+    /// Message type specific to our [`App`].
+    type Message = Message;
+
+    /// The unique application ID to supply to the window manager.
+    const APP_ID: &'static str = "org.cosmic.TextInputsDemo";
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    /// Creates the application, and optionally emits command on initialize.
+    fn init(core: Core, _input: Self::Flags) -> (Self, Command<Self::Message>) {
+        let mut app = App {
+            core,
+            editing: false,
+            input: String::from("Test"),
+            search_id: cosmic::widget::Id::unique(),
+        };
+
+        let commands = Command::batch(vec![
+            cosmic::widget::text_input::focus(app.search_id.clone()),
+            app.update_title(),
+        ]);
+
+        (app, commands)
+    }
+
+    /// Handle application events here.
+    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+        match message {
+            Message::Input(text) => {
+                self.input = text;
+            }
+
+            Message::EditMode(editing) => {
+                self.editing = editing;
+            }
+        }
+
+        Command::none()
+    }
+
+    /// Creates a view after each update.
+    fn view(&self) -> Element<Self::Message> {
+        let editable = cosmic::widget::editable_input(
+            "Input text here",
+            &self.input,
+            self.editing,
+            Message::EditMode,
+        )
+        .on_input(Message::Input)
+        .id(self.search_id.clone());
+
+        let inline = cosmic::widget::inline_input(&self.input).on_input(Message::Input);
+
+        let column = cosmic::widget::column().push(editable).push(inline);
+
+        let centered = cosmic::widget::container(column.width(200))
+            .width(iced::Length::Fill)
+            .height(iced::Length::Shrink)
+            .align_x(iced::alignment::Horizontal::Center)
+            .align_y(iced::alignment::Vertical::Center);
+
+        Element::from(centered)
+    }
+}
+
+impl App
+where
+    Self: cosmic::Application,
+{
+    fn update_title(&mut self) -> Command<Message> {
+        let window_title = format!("COSMIC TextInputs Demo");
+        self.set_header_title(window_title.clone());
+        self.set_window_title(window_title)
+    }
+}

--- a/src/theme/style/text_input.rs
+++ b/src/theme/style/text_input.rs
@@ -11,6 +11,7 @@ use iced_core::Color;
 pub enum TextInput {
     #[default]
     Default,
+    EditableText,
     ExpandableSearch,
     Search,
     Inline,
@@ -42,6 +43,22 @@ impl StyleSheet for crate::Theme {
                 border_width: 1.0,
                 border_offset: None,
                 border_color: container.component.divider.into(),
+                icon_color: container.on.into(),
+                text_color: container.on.into(),
+                placeholder_color: {
+                    let color: Color = container.on.into();
+                    color.blend_alpha(background, 0.7)
+                },
+                selected_text_color: palette.on_accent_color().into(),
+                selected_fill: palette.accent_color().into(),
+                label_color: label_color.into(),
+            },
+            TextInput::EditableText => Appearance {
+                background: Color::TRANSPARENT.into(),
+                border_radius: corner.radius_0.into(),
+                border_width: 0.0,
+                border_offset: None,
+                border_color: Color::TRANSPARENT,
                 icon_color: container.on.into(),
                 text_color: container.on.into(),
                 placeholder_color: {
@@ -147,7 +164,7 @@ impl StyleSheet for crate::Theme {
                 selected_fill: palette.accent_color().into(),
                 label_color: label_color.into(),
             },
-            TextInput::Inline => Appearance {
+            TextInput::EditableText | TextInput::Inline => Appearance {
                 background: Color::TRANSPARENT.into(),
                 border_radius: corner.radius_0.into(),
                 border_width: 0.0,
@@ -226,6 +243,22 @@ impl StyleSheet for crate::Theme {
                 selected_fill: palette.accent_color().into(),
                 label_color: label_color.into(),
             },
+            TextInput::EditableText => Appearance {
+                background: Color::TRANSPARENT.into(),
+                border_radius: corner.radius_0.into(),
+                border_width: 0.0,
+                border_offset: None,
+                border_color: Color::TRANSPARENT,
+                icon_color: container.on.into(),
+                text_color: container.on.into(),
+                placeholder_color: {
+                    let color: Color = container.on.into();
+                    color.blend_alpha(background, 0.7)
+                },
+                selected_text_color: palette.on_accent_color().into(),
+                selected_fill: palette.accent_color().into(),
+                label_color: label_color.into(),
+            },
             TextInput::Inline => Appearance {
                 background: Color::from(container.component.hover).into(),
                 border_radius: corner.radius_0.into(),
@@ -280,6 +313,24 @@ impl StyleSheet for crate::Theme {
                 border_offset: Some(2.0),
                 border_color: palette.accent.base.into(),
                 icon_color: container.on.into(),
+                text_color: container.on.into(),
+                placeholder_color: {
+                    let color: Color = container.on.into();
+                    color.blend_alpha(background, 0.7)
+                },
+                selected_text_color: palette.on_accent_color().into(),
+                selected_fill: palette.accent_color().into(),
+                label_color: label_color.into(),
+            },
+            TextInput::EditableText => Appearance {
+                background: Color::TRANSPARENT.into(),
+                border_radius: corner.radius_0.into(),
+                border_width: 0.0,
+                border_offset: None,
+                border_color: Color::TRANSPARENT,
+                icon_color: container.on.into(),
+                // TODO use regular text color here after text rendering handles multiple colors
+                // in this case, for selected and unselected text
                 text_color: container.on.into(),
                 placeholder_color: {
                     let color: Color = container.on.into();


### PR DESCRIPTION
This widget renders as if it were a normal text widget, but becomes a variation of an inline text input when toggling the edit mode.