### PR TITLE
fix(segmented-button): misaligned icon when text is empty

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -324,6 +324,7 @@ where
         button: Entity,
     ) -> (f32, f32) {
         let mut width = 0.0f32;
+        let mut icon_spacing = 0.0f32;
 
         // Add text to measurement if text was given.
         if let Some((text, entry)) = self
@@ -332,21 +333,24 @@ where
             .get(button)
             .zip(state.paragraphs.entry(button))
         {
-            let paragraph = entry.or_insert_with(|| {
-                crate::Paragraph::with_text(Text {
-                    content: text,
-                    size: iced::Pixels(self.font_size),
-                    bounds: Size::INFINITY,
-                    font,
-                    horizontal_alignment: alignment::Horizontal::Left,
-                    vertical_alignment: alignment::Vertical::Center,
-                    shaping: Shaping::Advanced,
-                    line_height: self.line_height,
-                })
-            });
+            if !text.is_empty() {
+                icon_spacing = f32::from(self.button_spacing);
+                let paragraph = entry.or_insert_with(|| {
+                    crate::Paragraph::with_text(Text {
+                        content: text,
+                        size: iced::Pixels(self.font_size),
+                        bounds: Size::INFINITY,
+                        font,
+                        horizontal_alignment: alignment::Horizontal::Left,
+                        vertical_alignment: alignment::Vertical::Center,
+                        shaping: Shaping::Advanced,
+                        line_height: self.line_height,
+                    })
+                });
 
-            let size = paragraph.min_bounds();
-            width += size.width;
+                let size = paragraph.min_bounds();
+                width += size.width;
+            }
         }
 
         // Add indent to measurement if found.
@@ -356,11 +360,11 @@ where
 
         // Add icon to measurement if icon was given.
         if let Some(icon) = self.model.icon(button) {
-            width += f32::from(icon.size) + f32::from(self.button_spacing);
+            width += f32::from(icon.size) + icon_spacing;
         } else if self.model.is_active(button) {
             // Add selection icon measurements when widget is a selection widget.
             if let crate::theme::SegmentedButton::Control = self.style {
-                width += 16.0 + f32::from(self.button_spacing);
+                width += 16.0 + icon_spacing;
             }
         }
 
@@ -1129,9 +1133,9 @@ where
                 - close_icon_width
                 - f32::from(self.button_padding[2]);
 
-            if self.model.text(key).is_some() {
-                bounds.y = center_y;
+            bounds.y = center_y;
 
+            if self.model.text(key).is_some_and(|text| !text.is_empty()) {
                 // Draw the text for this segmented button or tab.
                 renderer.fill_paragraph(
                     &state.paragraphs[key],


### PR DESCRIPTION
Fixes alignment of segmented controls which use center-aligned buttons without text. Previously, it was assumed that there would be text, and some additional button spacing would be added to the button width calculation.