### PR TITLE
Editable input widget improvements

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -719,6 +719,14 @@ where
         let line_height = self.line_height;
 
         if self.is_editable {
+            if let Some(ref on_edit) = self.on_toggle_edit {
+                let state = tree.state.downcast_mut::<State>();
+                if !state.is_read_only && state.is_focused.is_none() {
+                    state.is_read_only = true;
+                    shell.publish((on_edit)(false));
+                }
+            }
+
             let index = tree.children.len() - 1;
             if let (Some(trailing_icon), Some(tree)) =
                 (self.trailing_icon.as_mut(), tree.children.get_mut(index))


### PR DESCRIPTION
- Emits the `on_toggle_edit` message when the widget loses focus
- Allows entering edit mode by clicking on the text.