### PR TITLE
fix: remove rust-analyzer.linkedProjects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
     "rust-analyzer.check.overrideCommand": ["just", "check-json"],
     "git-blame.gitWebUrl": "",
-    "rust-analyzer.linkedProjects": [
-        "./Cargo.toml"
-    ]
 }


### PR DESCRIPTION
I added this a while back because my libcosmic tooling wasn't working. Now it seems to work the other way, removing this line caused my tooling to work again.