### PR TITLE
fix(theme): light theme surface lightness is inverted

### DIFF
--- a/cosmic-theme/src/steps.rs
+++ b/cosmic-theme/src/steps.rs
@@ -40,9 +40,9 @@ pub fn get_surface_color(
     fallback: &Srgba,
 ) -> Srgba {
     assert!(step_array.len() == 100);
-    if !is_dark && base_index >= 88 {
-        is_dark = true;
-    }
+
+    is_dark = !is_dark && base_index < 88;
+
     get_index(base_index, steps, step_array.len(), is_dark)
         .and_then(|i| step_array.get(i).cloned())
         .unwrap_or_else(|| fallback.to_owned())


### PR DESCRIPTION
> Requires update to cosmic-settings to use the new values when generating a theme.

Currently, light themes are getting darker surfaces when the background lightness is below 89. In Figma, themes with background lightness above 88 have their surfaces darkened; whereas below 88 have their surfaces lightened. This fixes custom light theme surfaces being unusually dark against a darker background. Some comparisons below using color schemes from Figma

Figma

![screenshot-2024-04-22-18-47-39](https://github.com/pop-os/libcosmic/assets/4143535/edc4a266-97a2-46e6-bb05-f6f6865a71eb)

Before

![screenshot-2024-04-22-18-52-44](https://github.com/pop-os/libcosmic/assets/4143535/998e02e7-a24d-4a0b-a093-a5001b8c52c5)

After

![screenshot-2024-04-22-18-54-27](https://github.com/pop-os/libcosmic/assets/4143535/1b1918cc-1f7e-417e-8fe6-ffef0589ad55)
