### PR TITLE
[feat] set default color palette based on user preference

### DIFF
--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -101,7 +101,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        Self::dark_default()
+        Self::preferred_theme()
     }
 }
 
@@ -512,6 +512,40 @@ impl Theme {
         };
         builder = builder.accent(adjusted_c);
         builder.build()
+    }
+
+    /// choose default color palette based on preferred GTK color scheme
+    pub fn gtk_prefer_colorscheme() -> Self {
+        let gsettings = "/usr/bin/gsettings";
+
+        let cmd = std::process::Command::new(gsettings)
+            .arg("get")
+            .arg("org.gnome.desktop.interface")
+            .arg("color-scheme")
+            .output();
+
+        if let Ok(cmd) = cmd {
+            let color_scheme = String::from_utf8_lossy(&cmd.stdout);
+
+            if color_scheme.trim().contains("light") {
+                return Self::light_default();
+            }
+        };
+
+        Self::dark_default()
+    }
+
+    /// check current desktop environment and preferred color scheme and set it as default
+    pub fn preferred_theme() -> Self {
+        let current_desktop = std::env::var("XDG_CURRENT_DESKTOP");
+
+        if let Ok(desktop) = current_desktop {
+            if desktop.trim().to_lowercase().contains("gnome") {
+                return Self::gtk_prefer_colorscheme();
+            }
+        }
+
+        Self::dark_default()
     }
 }
 


### PR DESCRIPTION
Hi

Today tried libcosmic on Pop_OS with current Gnome implementation. The problem was with preferred color palette in libcosmic apps. I'm using light theme in my OS and apps was started always as dark theme. Before I was added these feature to my app when using Iced and it was working so considered to add this to libcosmic. I'm not sure if you want to see such features. The implementation is very simple based on `gsettings` app and `color-scheme` value. From my tests on pop os it's working. It should work everywhere where gsettings are installed, otherwise it will default to dark theme as before so nothing lost here :) Would be nice to see it implemented. 