### PR TITLE
fix: avoid setting WGPU_POWER_PREF=low if system is desktop

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -159,11 +159,23 @@ pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Res
 /// Default to rendering the application with the low power GPU preference.
 #[cfg(feature = "wgpu")]
 fn wgpu_power_pref() {
+    fn is_desktop() -> bool {
+        let chassis = std::fs::read_to_string("/sys/class/dmi/id/chassis_type").unwrap_or_default();
+
+        chassis.trim() == "3"
+    }
+
+    // Ignore if the system is a desktop.
+    if is_desktop() {
+        return;
+    }
+
     // Ignore if requested to run on NVIDIA GPU
     if std::env::var("__NV_PRIME_RENDER_OFFLOAD").ok().as_deref() == Some("1") {
         return;
     }
 
+    #[allow(clippy::items_after_statements)]
     const VAR: &str = "WGPU_POWER_PREF";
     if std::env::var(VAR).is_err() {
         std::env::set_var(VAR, "low");


### PR DESCRIPTION
May fix desktops with integrated graphics having a delay on startup.