### PR TITLE
feat: update the headerbar to match figma

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -676,8 +676,7 @@ impl<App: Application> ApplicationExt for App {
         let is_condensed = core.is_condensed();
         let focused = core
             .focused_window()
-            .map(|i| i == self.main_window_id())
-            .unwrap_or_default();
+            .is_some_and(|i| i == self.main_window_id());
 
         let content_row = crate::widget::row::with_children({
             let mut widgets = Vec::with_capacity(2);
@@ -731,11 +730,13 @@ impl<App: Application> ApplicationExt for App {
                     if self.nav_model().is_some() {
                         let toggle = crate::widget::nav_bar_toggle()
                             .active(core.nav_bar_active())
+                            .selected(focused)
                             .on_toggle(if is_condensed {
                                 Message::Cosmic(cosmic::Message::ToggleNavBarCondensed)
                             } else {
                                 Message::Cosmic(cosmic::Message::ToggleNavBar)
-                            });
+                            })
+                            .style(crate::theme::Button::HeaderBar);
 
                         header = header.start(toggle);
                     }

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -75,7 +75,9 @@ pub fn appearance(
                 corner_radii = &cosmic.corner_radii.radius_m;
             }
 
-            let (background, _text, _icon) = color(&cosmic.icon_button);
+            let (background, text, icon) = color(&cosmic.icon_button);
+            appearance.text_color = text;
+            appearance.icon_color = icon;
             appearance.background = Some(Background::Color(background));
         }
 
@@ -161,8 +163,8 @@ impl StyleSheet for crate::Theme {
             {
                 Some(self.cosmic().accent_color().into())
             } else if matches!(style, Button::HeaderBar) && !selected {
-                let mut c = Color::from(component.on);
-                c.a = 0.8;
+                let mut c = Color::from(self.cosmic().background.on);
+                c.a = 0.75;
                 Some(c)
             } else {
                 Some(component.on.into())

--- a/src/widget/nav_bar_toggle.rs
+++ b/src/widget/nav_bar_toggle.rs
@@ -13,6 +13,8 @@ pub struct NavBarToggle<Message> {
     active: bool,
     #[setters(strip_option)]
     on_toggle: Option<Message>,
+    style: crate::theme::Button,
+    selected: bool,
 }
 
 #[must_use]
@@ -20,6 +22,8 @@ pub fn nav_bar_toggle<Message>() -> NavBarToggle<Message> {
     NavBarToggle {
         active: false,
         on_toggle: None,
+        style: crate::theme::Button::Text,
+        selected: false,
     }
 }
 
@@ -37,10 +41,11 @@ impl<'a, Message: 'static + Clone> From<NavBarToggle<Message>> for Element<'a, M
             .symbolic(true)
         };
 
-        widget::button::text("")
-            .leading_icon(icon)
+        widget::button::icon(icon)
             .padding([8, 16, 8, 16])
             .on_press_maybe(nav_bar_toggle.on_toggle)
+            .selected(nav_bar_toggle.selected)
+            .style(nav_bar_toggle.style)
             .apply(widget::container)
             .center_y()
             .height(Length::Fill)


### PR DESCRIPTION
I don't think the alpha is actually working for the icon, but the color should match.