### PR TITLE
fix: context-drawer border & radius

### DIFF
--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -495,7 +495,7 @@ impl container::StyleSheet for Theme {
 
                 appearance.border = Border {
                     color: cosmic.primary.divider.into(),
-                    width: 1.0,
+                    width: 0.0,
                     radius: cosmic.corner_radii.radius_s.into(),
                 };
 

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -88,8 +88,8 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
             // XXX this is a hack to get around that
             drawer: container(
                 LayerContainer::new(pane)
-                    .style(crate::style::Container::ContextDrawer)
                     .layer(cosmic_theme::Layer::Primary)
+                    .style(crate::style::Container::ContextDrawer)
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .max_width(480.0),


### PR DESCRIPTION
the `layer` method needs to be called before the `style` method as it also sets the style of the container.