### PR TITLE
Fix header bar buttons not inheriting icon and text color from headerbar container

### DIFF
--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -147,7 +147,7 @@ impl Default for Core {
                 height: 0,
                 width: 0,
             },
-            focused_window: None,
+            focused_window: Some(window::Id::MAIN),
             #[cfg(feature = "applet")]
             applet: crate::applet::Context::default(),
             #[cfg(feature = "single-instance")]

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -152,7 +152,7 @@ impl Context {
     pub fn icon_button_from_handle<'a, Message: 'static>(
         &self,
         icon: widget::icon::Handle,
-    ) -> crate::widget::Button<'a, Message, crate::Theme, Renderer> {
+    ) -> crate::widget::Button<'a, Message> {
         let symbolic = icon.symbolic;
         let suggested = self.suggested_size(symbolic);
         let applet_padding = self.suggested_padding(symbolic);
@@ -176,7 +176,7 @@ impl Context {
     pub fn icon_button<'a, Message: 'static>(
         &self,
         icon_name: &'a str,
-    ) -> crate::widget::Button<'a, Message, crate::Theme, Renderer> {
+    ) -> crate::widget::Button<'a, Message> {
         self.icon_button_from_handle(
             widget::icon::from_name(icon_name)
                 .symbolic(true)
@@ -371,7 +371,7 @@ pub fn style() -> <crate::Theme as iced_style::application::StyleSheet>::Style {
 
 pub fn menu_button<'a, Message>(
     content: impl Into<Element<'a, Message>>,
-) -> crate::widget::Button<'a, Message, crate::Theme, crate::Renderer> {
+) -> crate::widget::Button<'a, Message> {
     crate::widget::Button::new(content)
         .style(Button::AppletMenu)
         .padding(menu_control_padding())

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -13,27 +13,27 @@ use crate::{
 
 #[derive(Default)]
 pub enum Button {
+    AppletIcon,
     Custom {
         active: Box<dyn Fn(bool, &crate::Theme) -> Appearance>,
         disabled: Box<dyn Fn(&crate::Theme) -> Appearance>,
         hovered: Box<dyn Fn(bool, &crate::Theme) -> Appearance>,
         pressed: Box<dyn Fn(bool, &crate::Theme) -> Appearance>,
     },
+    AppletMenu,
     Destructive,
-    Link,
-    Icon,
     HeaderBar,
+    Icon,
     IconVertical,
     Image,
+    Link,
+    MenuItem,
+    MenuRoot,
     #[default]
     Standard,
     Suggested,
     Text,
     Transparent,
-    AppletMenu,
-    AppletIcon,
-    MenuRoot,
-    MenuItem,
 }
 
 pub fn appearance(
@@ -76,8 +76,6 @@ pub fn appearance(
             }
 
             let (background, text, icon) = color(&cosmic.icon_button);
-            appearance.text_color = text;
-            appearance.icon_color = icon;
             appearance.background = Some(Background::Color(background));
         }
 
@@ -162,10 +160,6 @@ impl StyleSheet for crate::Theme {
             ) && selected
             {
                 Some(self.cosmic().accent_color().into())
-            } else if matches!(style, Button::HeaderBar) && !selected {
-                let mut c = Color::from(self.cosmic().background.on);
-                c.a = 0.75;
-                Some(c)
             } else {
                 Some(component.on.into())
             };
@@ -211,10 +205,6 @@ impl StyleSheet for crate::Theme {
                 ) && selected
                 {
                     Some(self.cosmic().accent_color().into())
-                } else if matches!(style, Button::HeaderBar) && !selected {
-                    let mut c = Color::from(component.on);
-                    c.a = 0.8;
-                    Some(c)
                 } else {
                     Some(component.on.into())
                 };
@@ -236,10 +226,6 @@ impl StyleSheet for crate::Theme {
             ) && selected
             {
                 Some(self.cosmic().accent_color().into())
-            } else if matches!(style, Button::HeaderBar) && !selected {
-                let mut c = Color::from(component.on);
-                c.a = 0.8;
-                Some(c)
             } else {
                 Some(component.on.into())
             };

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -373,7 +373,9 @@ pub enum Container {
     Custom(Box<dyn Fn(&Theme) -> container::Appearance>),
     Dialog,
     Dropdown,
-    HeaderBar,
+    HeaderBar {
+        focused: bool,
+    },
     List,
     Primary,
     Secondary,
@@ -473,22 +475,36 @@ impl container::StyleSheet for Theme {
                 }
             }
 
-            Container::HeaderBar => container::Appearance {
-                icon_color: Some(Color::from(cosmic.accent.base)),
-                text_color: Some(Color::from(cosmic.background.on)),
-                background: Some(iced::Background::Color(cosmic.background.base.into())),
-                border: Border {
-                    radius: [
-                        cosmic.corner_radii.radius_xs[0],
-                        cosmic.corner_radii.radius_xs[1],
-                        cosmic.corner_radii.radius_0[2],
-                        cosmic.corner_radii.radius_0[3],
-                    ]
-                    .into(),
-                    ..Default::default()
-                },
-                shadow: Shadow::default(),
-            },
+            Container::HeaderBar { focused } => {
+                let (icon_color, text_color) = if *focused {
+                    (
+                        Color::from(cosmic.accent.base),
+                        Color::from(cosmic.background.on),
+                    )
+                } else {
+                    use crate::ext::ColorExt;
+                    let unfocused_color = Color::from(cosmic.background.component.on)
+                        .blend_alpha(cosmic.background.base.into(), 0.75);
+                    (unfocused_color, unfocused_color)
+                };
+
+                container::Appearance {
+                    icon_color: Some(icon_color),
+                    text_color: Some(text_color),
+                    background: Some(iced::Background::Color(cosmic.background.base.into())),
+                    border: Border {
+                        radius: [
+                            cosmic.corner_radii.radius_xs[0],
+                            cosmic.corner_radii.radius_xs[1],
+                            cosmic.corner_radii.radius_0[2],
+                            cosmic.corner_radii.radius_0[3],
+                        ]
+                        .into(),
+                        ..Default::default()
+                    },
+                    shadow: Shadow::default(),
+                }
+            }
 
             Container::ContextDrawer => {
                 let mut appearance = crate::style::Container::primary(cosmic);

--- a/src/widget/button/link.rs
+++ b/src/widget/button/link.rs
@@ -58,33 +58,32 @@ pub fn icon() -> Handle {
 
 impl<'a, Message: Clone + 'static> From<Button<'a, Message>> for Element<'a, Message> {
     fn from(mut builder: Button<'a, Message>) -> Element<'a, Message> {
-        let button: super::Button<'a, Message, crate::Theme, crate::Renderer> =
-            row::with_capacity(2)
-                .push({
-                    let mut font = crate::font::DEFAULT;
-                    font.weight = builder.font_weight;
+        let button: super::Button<'a, Message> = row::with_capacity(2)
+            .push({
+                let mut font = crate::font::DEFAULT;
+                font.weight = builder.font_weight;
 
-                    // TODO: Avoid allocation
-                    crate::widget::text(builder.label.to_string())
-                        .size(builder.font_size)
-                        .line_height(LineHeight::Absolute(builder.line_height.into()))
-                        .font(font)
-                })
-                .push_maybe(if builder.variant.trailing_icon {
-                    Some(icon().icon().size(builder.icon_size))
-                } else {
-                    None
-                })
-                .padding(builder.padding)
-                .width(builder.width)
-                .height(builder.height)
-                .spacing(builder.spacing)
-                .align_items(Alignment::Center)
-                .apply(button)
-                .padding(0)
-                .id(builder.id)
-                .on_press_maybe(builder.on_press.take())
-                .style(builder.style);
+                // TODO: Avoid allocation
+                crate::widget::text(builder.label.to_string())
+                    .size(builder.font_size)
+                    .line_height(LineHeight::Absolute(builder.line_height.into()))
+                    .font(font)
+            })
+            .push_maybe(if builder.variant.trailing_icon {
+                Some(icon().icon().size(builder.icon_size))
+            } else {
+                None
+            })
+            .padding(builder.padding)
+            .width(builder.width)
+            .height(builder.height)
+            .spacing(builder.spacing)
+            .align_items(Alignment::Center)
+            .apply(button)
+            .padding(0)
+            .id(builder.id)
+            .on_press_maybe(builder.on_press.take())
+            .style(builder.style);
 
         if builder.tooltip.is_empty() {
             button.into()

--- a/src/widget/button/mod.rs
+++ b/src/widget/button/mod.rs
@@ -26,28 +26,19 @@ pub use text::{destructive, standard, suggested, text};
 mod widget;
 pub use widget::{draw, focus, layout, mouse_interaction, Button};
 
-use crate::iced::Element;
 use iced_core::font::Weight;
 use iced_core::widget::Id;
 use iced_core::{Length, Padding};
 use std::borrow::Cow;
 
-pub fn button<'a, Message, Theme>(
-    content: impl Into<Element<'a, Message, Theme, crate::Renderer>>,
-) -> Button<'a, Message, Theme, crate::Renderer>
-where
-    Theme: style::StyleSheet,
-{
+pub fn button<'a, Message>(content: impl Into<crate::Element<'a, Message>>) -> Button<'a, Message> {
     Button::new(content)
 }
 
-pub fn custom_image_button<'a, Message, Theme>(
-    content: impl Into<Element<'a, Message, Theme, crate::Renderer>>,
+pub fn custom_image_button<'a, Message>(
+    content: impl Into<crate::Element<'a, Message>>,
     on_remove: Option<Message>,
-) -> Button<'a, Message, Theme, crate::Renderer>
-where
-    Theme: style::StyleSheet,
-{
+) -> Button<'a, Message> {
     Button::new_image(content, on_remove)
 }
 

--- a/src/widget/button/text.rs
+++ b/src/widget/button/text.rs
@@ -109,24 +109,23 @@ impl<'a, Message: Clone + 'static> From<Button<'a, Message>> for Element<'a, Mes
                 .into()
         });
 
-        let button: super::Button<'a, Message, crate::Theme, crate::Renderer> =
-            row::with_capacity(3)
-                // Optional icon to place before label.
-                .push_maybe(leading_icon)
-                // Optional label between icons.
-                .push_maybe(label)
-                // Optional icon to place behind the label.
-                .push_maybe(trailing_icon)
-                .padding(builder.padding)
-                .width(builder.width)
-                .height(builder.height)
-                .spacing(builder.spacing)
-                .align_items(Alignment::Center)
-                .apply(button)
-                .padding(0)
-                .id(builder.id)
-                .on_press_maybe(builder.on_press.take())
-                .style(builder.style);
+        let button: super::Button<'a, Message> = row::with_capacity(3)
+            // Optional icon to place before label.
+            .push_maybe(leading_icon)
+            // Optional label between icons.
+            .push_maybe(label)
+            // Optional icon to place behind the label.
+            .push_maybe(trailing_icon)
+            .padding(builder.padding)
+            .width(builder.width)
+            .height(builder.height)
+            .spacing(builder.spacing)
+            .align_items(Alignment::Center)
+            .apply(button)
+            .padding(0)
+            .id(builder.id)
+            .on_press_maybe(builder.on_press.take())
+            .style(builder.style);
 
         if builder.tooltip.is_empty() {
             button.into()

--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -133,7 +133,7 @@ fn date_button<Message>(
     is_month: bool,
     is_day: bool,
     on_select: &dyn Fn(NaiveDate) -> Message,
-) -> crate::widget::Button<'static, Message, crate::Theme, crate::Renderer> {
+) -> crate::widget::Button<'static, Message> {
     let style = if is_day {
         button::Style::Suggested
     } else {

--- a/src/widget/color_picker/mod.rs
+++ b/src/widget/color_picker/mod.rs
@@ -122,7 +122,7 @@ impl ColorPickerModel {
         &self,
         f: T,
         icon_portion: Option<u16>,
-    ) -> crate::widget::Button<'a, Message, crate::Theme, crate::Renderer> {
+    ) -> crate::widget::Button<'a, Message> {
         color_button(
             Some(f(ColorPickerUpdate::ToggleColorPicker)),
             self.applied_color,
@@ -761,7 +761,7 @@ pub fn color_button<'a, Message: 'static>(
     on_press: Option<Message>,
     color: Option<Color>,
     icon_portion: Length,
-) -> crate::widget::Button<'a, Message, crate::Theme, crate::Renderer> {
+) -> crate::widget::Button<'a, Message> {
     let spacing = THEME.with(|t| t.borrow().cosmic().spacing);
 
     button(if color.is_some() {

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -299,7 +299,9 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             .padding(8)
             .spacing(8)
             .apply(widget::container)
-            .style(crate::theme::Container::HeaderBar)
+            .style(crate::theme::Container::HeaderBar {
+                focused: self.focused,
+            })
             .center_y()
             .apply(widget::mouse_area);
 

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -193,8 +193,7 @@ pub fn menu_root<'a, Message, Renderer: renderer::Renderer>(
     label: impl Into<Cow<'a, str>> + 'a,
 ) -> iced::Element<'a, Message, crate::Theme, Renderer>
 where
-    Element<'a, Message, crate::Theme, Renderer>:
-        From<widget::button::Button<'a, Message, crate::Theme, iced::Renderer>>,
+    Element<'a, Message, crate::Theme, Renderer>: From<widget::Button<'a, Message>>,
 {
     widget::button(widget::text(label))
         .padding([4, 12])
@@ -223,8 +222,7 @@ pub fn menu_items<
     children: Vec<MenuItem<A, L>>,
 ) -> Vec<MenuTree<'a, Message, Renderer>>
 where
-    Element<'a, Message, crate::Theme, Renderer>:
-        From<widget::button::Button<'a, Message, crate::Theme, iced::Renderer>>,
+    Element<'a, Message, crate::Theme, Renderer>: From<widget::button::Button<'a, Message>>,
 {
     fn find_key<A: MenuAction>(action: &A, key_binds: &HashMap<KeyBind, A>) -> String {
         for (key_bind, key_action) in key_binds.iter() {


### PR DESCRIPTION
This also requires specializing our button widget so it is now a `Button<'a, Message>` instead of `Button<'a, Message, crate::Theme, crate::Renderer>`.

![screenshot-2024-05-17-17-11-50](https://github.com/pop-os/libcosmic/assets/4143535/969db1a6-a937-48ff-8195-09ef25ca6abe)
