### PR TITLE
fix: text input attempting to subtract with overflow

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -729,28 +729,30 @@ where
             }
         }
 
-        let index = tree.children.len() - 1;
-        if let (Some(trailing_icon), Some(tree)) =
-            (self.trailing_icon.as_mut(), tree.children.get_mut(index))
-        {
-            let children = text_layout.children();
-            trailing_icon_layout = Some(children.last().unwrap());
+        if tree.children.len() > 0 {
+            let index = tree.children.len() - 1;
+            if let (Some(trailing_icon), Some(tree)) =
+                (self.trailing_icon.as_mut(), tree.children.get_mut(index))
+            {
+                let children = text_layout.children();
+                trailing_icon_layout = Some(children.last().unwrap());
 
-            if let Some(trailing_layout) = trailing_icon_layout {
-                if cursor_position.is_over(trailing_layout.bounds()) {
-                    let res = trailing_icon.as_widget_mut().on_event(
-                        tree,
-                        event.clone(),
-                        trailing_layout,
-                        cursor_position,
-                        renderer,
-                        clipboard,
-                        shell,
-                        viewport,
-                    );
+                if let Some(trailing_layout) = trailing_icon_layout {
+                    if cursor_position.is_over(trailing_layout.bounds()) {
+                        let res = trailing_icon.as_widget_mut().on_event(
+                            tree,
+                            event.clone(),
+                            trailing_layout,
+                            cursor_position,
+                            renderer,
+                            clipboard,
+                            shell,
+                            viewport,
+                        );
 
-                    if res == event::Status::Captured {
-                        return res;
+                        if res == event::Status::Captured {
+                            return res;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes an attempt to subtract with overflow by checking if `children.len() > 0` beforehand.

I'm unsure if this is what we're looking for in this part of the code, @wash2 can you double check this please?

See the [log](https://github.com/pop-os/libcosmic/files/15384768/libcosmic.log) for more details.