### PR TITLE
Theme GTK3/4 window controls to match COSMIC theme

### DIFF
--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -186,8 +186,7 @@ window:not(.maximized) {{
 	border-radius: 6px;
 }}
 
-// Nautilus specific styling - this app handles colors not exactly the same as others
-.view {{ background: red }}
+window, .view {{ background: @window_bg_color }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -149,8 +149,14 @@ impl Theme {
 	transition: 0;
 }}
 .image-button > image,
-.image-button > box {{
+.image-button > box,
+.popup > image {{
 	color: @accent_bg_color;
+}}
+.image-button:insensitive > image, 
+.image-button:insensitive > box,
+.popup:insensitive > image {{
+	opacity: 0.5;
 }}
 .image-button:backdrop > image, 
 .image-button:backdrop > box {{

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -181,9 +181,13 @@ stack:backdrop > box > image,
 .toggle:backdrop > box > contents > image {{
 	filter: grayscale(1) brightness(1.7);
 }}
-window {{
+window {{ background: @window_bg_color }}
+window:not(.maximized) {{
 	border-radius: 6px;
 }}
+
+// Nautilus specific styling - this app handles colors not exactly the same as others
+window, .nautilus-grid-view > overlay scrolledwindow {{ background: @window_bg_color; }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -137,9 +137,9 @@ impl Theme {
 }}
 .close:backdrop > image, 
 .maximize:backdrop > image, 
-.minimize:backdrop > image {
+.minimize:backdrop > image {{
 	filter: grayscale(1) brightness(1.7);
-}
+}}
 .close:hover > image, 
 .maximize:hover > image, 
 .minimize:hover > image {{

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -187,7 +187,7 @@ window:not(.maximized) {{
 }}
 
 // Nautilus specific styling - this app handles colors not exactly the same as others
-window, .view {{ background: @window_bg_color; }}
+.view {{ background: red }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -78,7 +78,7 @@ impl Theme {
         } else {
             Rgba::new(0.0, 0.0, 0.0, 0.12)
         });
-
+        let corner_radius = self.corner_radii.radius_s[0];
         let mut inverted_bg_divider = background.base;
         inverted_bg_divider.alpha = 0.5;
         let scrollbar_outline = to_rgba(inverted_bg_divider);
@@ -183,7 +183,7 @@ stack:backdrop > box > image,
 }}
 window {{ background: @window_bg_color }}
 window:not(.maximized) {{
-	border-radius: 6px;
+	border-radius: {corner_radius:.0}px;
 }}
 
 window, statuspage.view {{ background: @window_bg_color }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -147,8 +147,11 @@ impl Theme {
 }}
 .image-button > image,
 .image-button > box {{
-	transition: 0;
 	color: @accent_bg_color;
+}}
+.image-button:backdrop > image, 
+.image-button:backdrop > box {{
+	filter: grayscale(1) brightness(1.7);
 }}
 "#};
 

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -187,7 +187,7 @@ window:not(.maximized) {{
 }}
 
 // Nautilus specific styling - this app handles colors not exactly the same as others
-window, .nautilus-grid-view > overlay scrolledwindow {{ background: @window_bg_color; }}
+window, .view {{ background: @window_bg_color; }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -73,6 +73,12 @@ impl Theme {
             Rgba::new(0.0, 0.0, 0.0, 0.08)
         });
 
+        let window_control_hover_bg = to_rgba(if self.is_dark {
+            Rgba::new(255.0, 255.0, 255.0, 0.12)
+        } else {
+            Rgba::new(0.0, 0.0, 0.0, 0.12)
+        });
+
         let mut inverted_bg_divider = background.base;
         inverted_bg_divider.alpha = 0.5;
         let scrollbar_outline = to_rgba(inverted_bg_divider);
@@ -113,6 +119,26 @@ impl Theme {
 
 @define-color shade_color {shade};
 @define-color scrollbar_outline_color {scrollbar_outline};
+
+.close, .maximize, .minimize {{
+	background: transparent;
+}}
+.close:not(:hover) > image,
+.maximize:not(:hover) > image,
+.minimize:not(:hover) > image {{
+	background: transparent;
+}}
+.close > image, 
+.maximize > image, 
+.minimize > image {{
+	color: @accent_bg_color;
+	border-radius: 100%;
+}}
+.close:hover > image, 
+.maximize:hover > image, 
+.minimize:hover > image {{
+	background: {window_control_hover_bg};
+}}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -135,6 +135,11 @@ impl Theme {
 	color: @accent_bg_color;
 	border-radius: 100%;
 }}
+.close:backdrop > image, 
+.maximize:backdrop > image, 
+.minimize:backdrop > image {
+	filter: grayscale(1) brightness(1.7);
+}
 .close:hover > image, 
 .maximize:hover > image, 
 .minimize:hover > image {{

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -152,6 +152,7 @@ impl Theme {
 .image-button > box,
 .popup > image,
 .toggle > image,
+.toggle > arrow,
 button > image,
 button > widget > box > image,
 stack > box > image
@@ -166,10 +167,19 @@ button:insensitive > image,
 button:insensitive > widget > box > image {{
 	opacity: 0.5;
 }}
-.image-button:backdrop > image, 
-.image-button:backdrop > box {{
+.image-button:backdrop > image,
+.image-button:backdrop > box,
+.popup:backdrop > image,
+.toggle:backdrop > image,
+.toggle:backdrop > arrow,
+button:backdrop > image,
+button:backdrop > widget > box > image,
+stack:backdrop > box > image {{
 	filter: grayscale(1) brightness(1.7);
 }}
+window {
+	border-radius: 6px;
+}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -145,6 +145,9 @@ impl Theme {
 .minimize:hover > image {{
 	background: {window_control_hover_bg};
 }}
+.image-button {{
+	transition: 0;
+}}
 .image-button > image,
 .image-button > box {{
 	color: @accent_bg_color;

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -153,7 +153,8 @@ impl Theme {
 .popup > image,
 .toggle > image,
 button > image,
-button > widget > box > image
+button > widget > box > image,
+stack > box > image
 {{
 	color: @accent_bg_color;
 }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -153,7 +153,8 @@ impl Theme {
 .popup > image,
 .toggle > image,
 button > image,
-button > widget > box > image
+button > widget > box > image,
+stack > box > image,
 {{
 	color: @accent_bg_color;
 }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -153,8 +153,7 @@ impl Theme {
 .popup > image,
 .toggle > image,
 button > image,
-button > widget > box > image,
-stack > box > image,
+button > widget > box > image
 {{
 	color: @accent_bg_color;
 }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -146,10 +146,10 @@ impl Theme {
 	background: {window_control_hover_bg};
 }}
 .image-button > image,
-.image-button > box {
+.image-button > box {{
 	transition: 0;
 	color: @accent_bg_color;
-}
+}}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -145,6 +145,11 @@ impl Theme {
 .minimize:hover > image {{
 	background: {window_control_hover_bg};
 }}
+.image-button > image,
+.image-button > box {
+	transition: 0;
+	color: @accent_bg_color;
+}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -122,7 +122,6 @@ impl Theme {
 
 .close, .maximize, .minimize {{
 	background: transparent;
-	transition: 0;
 }}
 .close:not(:hover) > image,
 .maximize:not(:hover) > image,
@@ -132,6 +131,7 @@ impl Theme {
 .close > image, 
 .maximize > image, 
 .minimize > image {{
+	transition: 0;
 	color: @accent_bg_color;
 	border-radius: 100%;
 }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -153,9 +153,10 @@ impl Theme {
 .popup > image,
 .toggle > image,
 .toggle > arrow,
+.toggle > box > contents > image,
 button > image,
 button > widget > box > image,
-stack > box > image
+stack > box > image,
 {{
 	color: @accent_bg_color;
 }}
@@ -163,8 +164,10 @@ stack > box > image
 .image-button:insensitive > box,
 .popup:insensitive > image,
 .toggle:insensitive > image,
+.toggle:insensitive > box > contents > image,
 button:insensitive > image,
-button:insensitive > widget > box > image {{
+button:insensitive > widget > box > image,
+stack:insensitive > box > image {{
 	opacity: 0.5;
 }}
 .image-button:backdrop > image,
@@ -174,7 +177,8 @@ button:insensitive > widget > box > image {{
 .toggle:backdrop > arrow,
 button:backdrop > image,
 button:backdrop > widget > box > image,
-stack:backdrop > box > image {{
+stack:backdrop > box > image,
+.toggle:backdrop > box > contents > image {{
 	filter: grayscale(1) brightness(1.7);
 }}
 window {

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -122,6 +122,7 @@ impl Theme {
 
 .close, .maximize, .minimize {{
 	background: transparent;
+	transition: 0;
 }}
 .close:not(:hover) > image,
 .maximize:not(:hover) > image,

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -156,7 +156,7 @@ impl Theme {
 .toggle > box > contents > image,
 button > image,
 button > widget > box > image,
-stack > box > image,
+stack > box > image
 {{
 	color: @accent_bg_color;
 }}

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -186,7 +186,7 @@ window:not(.maximized) {{
 	border-radius: 6px;
 }}
 
-window, scrolledwindow .view {{ background: @window_bg_color }}
+window, statuspage.view {{ background: @window_bg_color }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -150,12 +150,19 @@ impl Theme {
 }}
 .image-button > image,
 .image-button > box,
-.popup > image {{
+.popup > image,
+.toggle > image,
+button > image,
+button > widget > box > image
+{{
 	color: @accent_bg_color;
 }}
 .image-button:insensitive > image, 
 .image-button:insensitive > box,
-.popup:insensitive > image {{
+.popup:insensitive > image,
+.toggle:insensitive > image,
+button:insensitive > image,
+button:insensitive > widget > box > image {{
 	opacity: 0.5;
 }}
 .image-button:backdrop > image, 

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -181,9 +181,9 @@ stack:backdrop > box > image,
 .toggle:backdrop > box > contents > image {{
 	filter: grayscale(1) brightness(1.7);
 }}
-window {
+window {{
 	border-radius: 6px;
-}
+}}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -186,7 +186,7 @@ window:not(.maximized) {{
 	border-radius: 6px;
 }}
 
-window, .view {{ background: @window_bg_color }}
+window, scrolledwindow .view {{ background: @window_bg_color }}
 "#};
 
         css.push_str(&component_gtk4_css("accent", accent));


### PR DESCRIPTION
#### This PR relies on the COSMIC GTK3/4 theming feature and extends it to also theme window control buttons 
_(This covers colors, hover background color, window active/inactive state colors, transitions (animations) and more...)_ 

**Examples below ( ↓ )**

**Eddy - GTK3 (Light/Dark)**
![image](https://github.com/pop-os/libcosmic/assets/162843960/ac9414a5-13f0-4996-9da7-03e0c7f68412)
![image](https://github.com/pop-os/libcosmic/assets/162843960/877d3814-ee8e-4bb7-9144-c73d4faa6cc8)

**Flatseal - GTK4|libadwaita (Light/Dark)**
![image](https://github.com/pop-os/libcosmic/assets/162843960/6db84685-1c04-49ba-be0a-95481d3c5fdd)
![image](https://github.com/pop-os/libcosmic/assets/162843960/b0105443-b3a6-4c08-8b3d-5d4360c28101)

**Main Menu - GTK4|libadwaita (Light/Dark)**
![image](https://github.com/pop-os/libcosmic/assets/162843960/3fb88f3e-5dfa-4211-8f8c-c619182965ea)
![image](https://github.com/pop-os/libcosmic/assets/162843960/4db2fdf1-a79f-47e6-9ea8-156aa4f2650f)

**Nautilus (GNOME Files) - GTK3 (Light/Dark)**
![image](https://github.com/pop-os/libcosmic/assets/162843960/b7a78b5d-d436-4fb1-9db2-3f3678dcb7f9)
![image](https://github.com/pop-os/libcosmic/assets/162843960/9192f8b2-32d7-4b3c-83bb-0fc22d6aaa3a)