### PR TITLE
Various widget improvements

### DIFF
--- a/src/widget/flex_row/layout.rs
+++ b/src/widget/flex_row/layout.rs
@@ -8,7 +8,7 @@ use iced_core::{Length, Padding, Point, Size};
 use taffy::geometry::Rect;
 use taffy::style::{AlignItems, Dimension, Display, Style};
 use taffy::style_helpers::length;
-use taffy::TaffyTree;
+use taffy::{AlignContent, TaffyTree};
 
 #[allow(clippy::too_many_lines)]
 pub fn resolve<Message>(
@@ -18,6 +18,7 @@ pub fn resolve<Message>(
     padding: Padding,
     column_spacing: f32,
     row_spacing: f32,
+    justify_content: Option<AlignContent>,
     tree: &mut [Tree],
 ) -> Node {
     let limits = limits.shrink(padding);
@@ -42,6 +43,8 @@ pub fn resolve<Message>(
             width: length(max_size.width),
             height: Dimension::Auto,
         },
+
+        justify_content,
 
         padding: Rect {
             left: length(padding.left),

--- a/src/widget/flex_row/widget.rs
+++ b/src/widget/flex_row/widget.rs
@@ -25,8 +25,17 @@ pub struct FlexRow<'a, Message> {
     row_spacing: u16,
     /// Sets the width.
     width: Length,
+    /// Sets minimum width of items that grow.
+    #[setters(into)]
+    min_item_width: Option<f32>,
     /// Sets the max width
     max_width: f32,
+    /// Defines how content will be aligned horizontally.
+    #[setters(skip)]
+    align_items: Option<taffy::AlignItems>,
+    /// Defines how content will be aligned vertically.
+    #[setters(skip)]
+    justify_items: Option<taffy::AlignItems>,
     /// Defines how the content will be justified.
     #[setters(into)]
     justify_content: Option<crate::widget::JustifyContent>,
@@ -40,9 +49,32 @@ impl<'a, Message> FlexRow<'a, Message> {
             column_spacing: 4,
             row_spacing: 4,
             width: Length::Shrink,
+            min_item_width: None,
             max_width: f32::INFINITY,
+            align_items: None,
+            justify_items: None,
             justify_content: None,
         }
+    }
+
+    /// Defines how content will be aligned horizontally.
+    pub fn align_items(mut self, alignment: iced::Alignment) -> Self {
+        self.align_items = Some(match alignment {
+            iced::Alignment::Center => taffy::AlignItems::Center,
+            iced::Alignment::Start => taffy::AlignItems::Start,
+            iced::Alignment::End => taffy::AlignItems::End,
+        });
+        self
+    }
+
+    /// Defines how content will be aligned vertically.
+    pub fn justify_items(mut self, alignment: iced::Alignment) -> Self {
+        self.justify_items = Some(match alignment {
+            iced::Alignment::Center => taffy::AlignItems::Center,
+            iced::Alignment::Start => taffy::AlignItems::Start,
+            iced::Alignment::End => taffy::AlignItems::End,
+        });
+        self
     }
 
     /// Sets the space between each column and row.
@@ -87,6 +119,9 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             self.padding,
             f32::from(self.column_spacing),
             f32::from(self.row_spacing),
+            self.min_item_width,
+            self.align_items,
+            self.justify_items,
             self.justify_content,
             &mut tree.children,
         )

--- a/src/widget/flex_row/widget.rs
+++ b/src/widget/flex_row/widget.rs
@@ -17,6 +17,7 @@ pub struct FlexRow<'a, Message> {
     #[setters(skip)]
     children: Vec<Element<'a, Message>>,
     /// Sets the padding around the widget.
+    #[setters(into)]
     padding: Padding,
     /// Sets the space between each column of items.
     column_spacing: u16,
@@ -29,7 +30,7 @@ pub struct FlexRow<'a, Message> {
 }
 
 impl<'a, Message> FlexRow<'a, Message> {
-    pub const fn new(children: Vec<Element<'a, Message>>) -> Self {
+    pub(crate) const fn new(children: Vec<Element<'a, Message>>) -> Self {
         Self {
             children,
             padding: Padding::ZERO,
@@ -38,6 +39,13 @@ impl<'a, Message> FlexRow<'a, Message> {
             width: Length::Shrink,
             max_width: f32::INFINITY,
         }
+    }
+
+    /// Sets the space between each column and row.
+    pub const fn spacing(mut self, spacing: u16) -> Self {
+        self.column_spacing = spacing;
+        self.row_spacing = spacing;
+        self
     }
 }
 

--- a/src/widget/flex_row/widget.rs
+++ b/src/widget/flex_row/widget.rs
@@ -27,6 +27,9 @@ pub struct FlexRow<'a, Message> {
     width: Length,
     /// Sets the max width
     max_width: f32,
+    /// Defines how the content will be justified.
+    #[setters(into)]
+    justify_content: Option<crate::widget::JustifyContent>,
 }
 
 impl<'a, Message> FlexRow<'a, Message> {
@@ -38,6 +41,7 @@ impl<'a, Message> FlexRow<'a, Message> {
             row_spacing: 4,
             width: Length::Shrink,
             max_width: f32::INFINITY,
+            justify_content: None,
         }
     }
 
@@ -83,6 +87,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             self.padding,
             f32::from(self.column_spacing),
             f32::from(self.row_spacing),
+            self.justify_content,
             &mut tree.children,
         )
     }

--- a/src/widget/grid/layout.rs
+++ b/src/widget/grid/layout.rs
@@ -75,7 +75,7 @@ pub fn resolve<Message>(
         match leaf {
             Ok(leaf) => leafs.push(leaf),
             Err(why) => {
-                tracing::error!(%why, "cannot add leaf node to grid");
+                tracing::error!(?why, "cannot add leaf node to grid");
                 continue;
             }
         }
@@ -134,7 +134,7 @@ pub fn resolve<Message>(
     let root = match root {
         Ok(root) => root,
         Err(why) => {
-            tracing::error!(%why, "grid root style invalid");
+            tracing::error!(?why, "grid root style invalid");
             return Node::new(Size::ZERO);
         }
     };
@@ -146,14 +146,14 @@ pub fn resolve<Message>(
             height: length(max_size.height),
         },
     ) {
-        tracing::error!(%why, "grid layout did not compute");
+        tracing::error!(?why, "grid layout did not compute");
         return Node::new(Size::ZERO);
     }
 
     let grid_layout = match taffy.layout(root) {
         Ok(layout) => layout,
         Err(why) => {
-            tracing::error!(%why, "cannot get layout of grid");
+            tracing::error!(?why, "cannot get layout of grid");
             return Node::new(Size::ZERO);
         }
     };
@@ -183,8 +183,8 @@ pub fn resolve<Message>(
     }
 
     let grid_size = Size {
-        width: grid_layout.size.width,
-        height: grid_layout.size.height,
+        width: grid_layout.content_size.width,
+        height: grid_layout.content_size.height,
     };
 
     Node::with_children(grid_size.expand(padding), nodes)

--- a/src/widget/grid/widget.rs
+++ b/src/widget/grid/widget.rs
@@ -26,6 +26,9 @@ pub struct Grid<'a, Message> {
     column_alignment: Alignment,
     /// Alignment across rows
     row_alignment: Alignment,
+    /// Defines how the content will be justified.
+    #[setters(into, strip_option)]
+    justify_content: Option<crate::widget::JustifyContent>,
     /// Sets the space between each column of items.
     column_spacing: u16,
     /// Sets the space between each item in a row.
@@ -50,6 +53,7 @@ impl<'a, Message> Grid<'a, Message> {
             padding: Padding::ZERO,
             column_alignment: Alignment::Start,
             row_alignment: Alignment::Start,
+            justify_content: None,
             column_spacing: 4,
             row_spacing: 4,
             width: Length::Shrink,
@@ -138,6 +142,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer> for G
             self.padding,
             self.column_alignment,
             self.row_alignment,
+            self.justify_content,
             f32::from(self.column_spacing),
             f32::from(self.row_spacing),
             &mut tree.children,

--- a/src/widget/icon/mod.rs
+++ b/src/widget/icon/mod.rs
@@ -69,7 +69,7 @@ impl Icon {
     }
 
     #[must_use]
-    fn into_element<Message: 'static>(self) -> Element<'static, Message> {
+    fn view<'a, Message: 'a>(self) -> Element<'a, Message> {
         let from_image = |handle| {
             Image::new(handle)
                 .width(
@@ -120,8 +120,8 @@ impl Icon {
     }
 }
 
-impl<Message: 'static> From<Icon> for Element<'static, Message> {
+impl<'a, Message: 'a> From<Icon> for Element<'a, Message> {
     fn from(icon: Icon) -> Self {
-        icon.into_element::<Message>()
+        icon.view::<Message>()
     }
 }

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -141,21 +141,19 @@ where
     }
 }
 
-/// This macro creates a button for a MenuTree.
-#[macro_export]
-macro_rules! menu_button {
-    ($($x:expr),+ $(,)?) => (
-        widget::button(
-            widget::Row::with_children(vec![$($x.into()),+])
+pub fn menu_button<'a, Message: 'a>(
+    children: Vec<crate::Element<'a, Message>>,
+) -> crate::widget::Button<'a, Message> {
+    widget::button(
+        widget::Row::with_children(children)
             .align_items(Alignment::Center)
             .height(Length::Fill)
             .width(Length::Fill),
-        )
-        .height(Length::Fixed(36.0))
-        .padding([4, 16])
-        .width(Length::Fill)
-        .style(theme::Button::MenuItem)
-    );
+    )
+    .height(Length::Fixed(36.0))
+    .padding([4, 16])
+    .width(Length::Fill)
+    .style(theme::Button::MenuItem)
 }
 
 /// Represents a menu item that performs an action when selected or a separator between menu items.
@@ -243,11 +241,11 @@ where
             match item {
                 MenuItem::Button(label, action) => {
                     let key = find_key(&action, key_binds);
-                    let menu_button = menu_button!(
-                        widget::text(label),
-                        widget::horizontal_space(Length::Fill),
-                        widget::text(key),
-                    )
+                    let menu_button = menu_button(vec![
+                        widget::text(label).into(),
+                        widget::horizontal_space(Length::Fill).into(),
+                        widget::text(key).into(),
+                    ])
                     .on_press(action.message());
 
                     trees.push(MenuTree::<Message, Renderer>::new(menu_button));
@@ -255,29 +253,36 @@ where
                 MenuItem::CheckBox(label, value, action) => {
                     let key = find_key(&action, key_binds);
                     trees.push(MenuTree::new(
-                        menu_button!(
+                        menu_button(vec![
                             if value {
-                                // TODO: add a object-select-symbolic icon, `Message: 'static` is required when using an icon widget.
-                                widget::container(widget::text("✓"))
+                                widget::icon::from_name("object-select-symbolic")
+                                    .size(16)
+                                    .icon()
+                                    .width(Length::Fixed(16.0))
+                                    .into()
                             } else {
-                                widget::container(widget::Space::with_width(Length::Fixed(16.0)))
+                                widget::Space::with_width(Length::Fixed(17.0)).into()
                             },
-                            widget::Space::with_width(Length::Fixed(8.0)),
-                            widget::text(label),
-                            widget::horizontal_space(Length::Fill),
-                            widget::text(key)
-                        )
+                            widget::Space::with_width(Length::Fixed(8.0)).into(),
+                            widget::text(label)
+                                .horizontal_alignment(iced::alignment::Horizontal::Left)
+                                .into(),
+                            widget::horizontal_space(Length::Fill).into(),
+                            widget::text(key).into(),
+                        ])
                         .on_press(action.message()),
                     ));
                 }
                 MenuItem::Folder(label, children) => {
                     trees.push(MenuTree::<Message, Renderer>::with_children(
-                        menu_button!(
-                            widget::text(label),
-                            widget::horizontal_space(Length::Fill),
-                            // TODO: add a pan-end-symbolic icon, `Message: 'static` is required when using an icon widget.
-                            widget::text("▶"),
-                        ),
+                        menu_button(vec![
+                            widget::text(label).into(),
+                            widget::horizontal_space(Length::Fill).into(),
+                            widget::icon::from_name("pan-end-symbolic")
+                                .size(16)
+                                .icon()
+                                .into(),
+                        ]),
                         menu_items(key_binds, children),
                     ));
                 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -48,6 +48,9 @@
 
 // Re-exports from Iced
 #[doc(inline)]
+pub use iced::widget::{canvas, Canvas};
+
+#[doc(inline)]
 pub use iced::widget::{checkbox, Checkbox};
 
 #[doc(inline)]

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -231,6 +231,8 @@ pub use icon::{icon, Icon};
 #[cfg(feature = "animated-image")]
 pub mod frames;
 
+pub use taffy::JustifyContent;
+
 pub mod list;
 #[doc(inline)]
 pub use list::{list_column, ListColumn};

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -90,6 +90,9 @@ pub use iced::widget::{slider, vertical_slider, Slider, VerticalSlider};
 pub use iced::widget::{svg, Svg};
 
 #[doc(inline)]
+pub use iced::widget::{text_editor, TextEditor};
+
+#[doc(inline)]
 pub use iced_core::widget::{Id, Operation, Widget};
 
 pub mod aspect_ratio;

--- a/src/widget/settings/mod.rs
+++ b/src/widget/settings/mod.rs
@@ -4,7 +4,7 @@
 pub mod item;
 mod section;
 
-pub use self::item::{item, item_row};
+pub use self::item::{flex_item, flex_item_row, item, item_row};
 pub use self::section::{view_section, Section};
 
 use crate::widget::{column, Column};


### PR DESCRIPTION
Fixed alignment of menu buttons, and uses icons instead of unicode text

![screenshot-2024-05-30-11-13-48](https://github.com/pop-os/libcosmic/assets/4143535/2d28590f-aae6-451d-8b17-c88b6245b0b9)

Improvements for the Grid widget:

- Fixes padding not being applied correctly
- Fixes widget using incorrect width and height for its layout
    - It's now possible to add it to a container and center with `container.center_x()`
- Adds `justify_content` property
- Sets `flex_grow` when a widget is `Fill`

Improvements for the FlexRow widget:

- Rewrites layout with taffy, as used by the grid widget
- Adds `align_items`, `justify_items`, and `justify_content` properties
- Adds `min_item_width` property for wrapping text widgets set to Fill

Adds `flex_` variants of `settings::item`, `settings::item_row`, and `settings::Item::control`

![screenshot-2024-05-30-11-24-22](https://github.com/pop-os/libcosmic/assets/4143535/e45a7ae3-b2a9-4fa7-a0e8-db9307370b7e)

Other improvements

- Added re-exports for the Canvas and TextEdit widgets from Iced
- Removed `'static` lifetime restriction from icon widget
- menu tree's menu_button is now a function instead of a macro