### PR TITLE
feat: toast widget

### DIFF
--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -350,6 +350,4 @@ pub mod warning;
 #[doc(inline)]
 pub use warning::*;
 
-mod toaster;
-#[doc(inline)]
-pub use toaster::toaster;
+pub mod toaster;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -349,3 +349,7 @@ pub mod tooltip {
 pub mod warning;
 #[doc(inline)]
 pub use warning::*;
+
+mod toaster;
+#[doc(inline)]
+pub use toaster::toaster;

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -3,47 +3,39 @@
 
 use std::time::Duration;
 
-use iced::{Command, Length};
-use iced_core::{Element};
 use crate::widget::container;
 use crate::widget::Column;
+use iced::{Command, Length};
+use iced_core::Element;
 use widget::Toaster;
 
 use crate::ext::CollectionWidget;
 
 use super::{button, row, text};
 
-
 mod widget;
 
-pub fn toaster<'a, Message: Clone + 'a, Theme, Renderer>(
+pub fn toaster<'a, Message>(
     toasts: &'a Toasts<Message>,
-    content: impl Into<Element<'a, Message, Theme, Renderer>>,
-) -> Element<'a, Message, Theme, Renderer>
+    content: impl Into<Element<'a, Message, crate::Theme, iced::Renderer>>,
+) -> Element<'a, Message, crate::Theme, iced::Renderer>
 where
-    Renderer: iced_core::Renderer,
+    Message: Clone + 'a,
 {
+    let make_toast = |toast: &'a Toast<Message>| {
+        let row = row().push(text(&toast.message)).push_maybe(
+            toast
+                .action
+                .as_ref()
+                .map(|t| button(text(t.0.clone())).on_press(t.1.clone())),
+        );
 
-
-    let make_toast = |toast: &Toast<Message>| {
-
-        let row = row()
-            .push(text(toast.message))
-            .push_maybe(toast.action.map(|t| button(text(t.0)).on_press(t.1)));
-
-        container(row)
-            .into()
-
+        container(row).into()
     };
 
+    let col = Column::with_children(toasts.toasts.iter().map(make_toast));
 
-    let col = Column::with_children(toasts.toasts.iter().map(|t| {
-        make_toast(t)
-    }));
-
-
-
-    Toaster::new(col.into(), content.into()).into()
+    Toaster::new(col.into(), content.into(), toasts.toasts.is_empty()).into()
 }
 
 pub enum ToastDuration {

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -1,0 +1,106 @@
+// Copyright 2024 wiiznokes
+// SPDX-License-Identifier: MIT
+
+use std::time::Duration;
+
+use iced::{Command, Length};
+use iced_core::{Element};
+use crate::widget::container;
+use crate::widget::Column;
+use widget::Toaster;
+
+use crate::ext::CollectionWidget;
+
+use super::{button, row, text};
+
+
+mod widget;
+
+pub fn toaster<'a, Message: Clone + 'a, Theme, Renderer>(
+    toasts: &'a Toasts<Message>,
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Element<'a, Message, Theme, Renderer>
+where
+    Renderer: iced_core::Renderer,
+{
+
+
+    let make_toast = |toast: &Toast<Message>| {
+
+        let row = row()
+            .push(text(toast.message))
+            .push_maybe(toast.action.map(|t| button(text(t.0)).on_press(t.1)));
+
+        container(row)
+            .into()
+
+    };
+
+
+    let col = Column::with_children(toasts.toasts.iter().map(|t| {
+        make_toast(t)
+    }));
+
+
+
+    Toaster::new(col.into(), content.into()).into()
+}
+
+pub enum ToastDuration {
+    Short,
+    Medium,
+    Long,
+}
+
+impl ToastDuration {
+    fn duration(&self) -> Duration {
+        match self {
+            ToastDuration::Short => Duration::from_millis(200),
+            ToastDuration::Medium => Duration::from_millis(1000),
+            ToastDuration::Long => Duration::from_millis(5000),
+        }
+    }
+}
+
+pub struct Toast<Message> {
+    message: String,
+    /// (Description, message)
+    action: Option<(String, Message)>,
+
+    duration: ToastDuration,
+
+    id: u32,
+}
+
+pub struct Toasts<Message> {
+    id_count: u32,
+    toasts: Vec<Toast<Message>>,
+}
+
+pub struct ToastMessage(u32);
+
+impl<Message> Toasts<Message> {
+    pub fn push(&mut self, mut toast: Toast<Message>) -> Command<ToastMessage> {
+        toast.id = self.id_count;
+        self.id_count += 1;
+
+        let message = ToastMessage(toast.id);
+        let duration = toast.duration.duration();
+
+        self.toasts.push(toast);
+
+        Command::perform(
+            async move {
+                tokio::time::sleep(duration).await;
+            },
+            |_| message,
+        )
+    }
+
+    pub fn handle_message(&mut self, message: ToastMessage) {
+        self.toasts
+            .iter()
+            .position(|e| e.id == message.0)
+            .map(|index| self.toasts.remove(index));
+    }
+}

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -1,11 +1,14 @@
 // Copyright 2024 wiiznokes
 // SPDX-License-Identifier: MIT
 
+//! A widget that display toats.
+
+use std::collections::VecDeque;
 use std::time::Duration;
 
 use crate::widget::container;
 use crate::widget::Column;
-use iced::{Command, Length};
+use iced::Command;
 use iced_core::Element;
 use widget::Toaster;
 
@@ -15,81 +18,155 @@ use super::{button, row, text};
 
 mod widget;
 
+/// Create a new Toaster widget.
 pub fn toaster<'a, Message>(
     toasts: &'a Toasts<Message>,
     content: impl Into<Element<'a, Message, crate::Theme, iced::Renderer>>,
 ) -> Element<'a, Message, crate::Theme, iced::Renderer>
 where
-    Message: Clone + 'a,
+    Message: From<ToastMessage> + Clone + 'a,
 {
     let make_toast = |toast: &'a Toast<Message>| {
-        let row = row().push(text(&toast.message)).push_maybe(
-            toast
-                .action
-                .as_ref()
-                .map(|t| button(text(t.0.clone())).on_press(t.1.clone())),
-        );
+        let row = row()
+            .push(text(&toast.message))
+            .push_maybe(toast.action.as_ref().map(|action| {
+                button(text(action.description.clone())).on_press(action.message.clone())
+            }))
+            .push(button("close").on_press(ToastMessage(toast.id).into()))
+            .align_items(iced::Alignment::Center);
 
-        container(row).into()
+        container(row)
+            .padding(10)
+            .style(crate::style::Container::Card)
     };
 
-    let col = Column::with_children(toasts.toasts.iter().map(make_toast));
+    let col =
+        Column::with_children(toasts.toasts.iter().rev().map(|t| make_toast(t).into())).spacing(5);
 
     Toaster::new(col.into(), content.into(), toasts.toasts.is_empty()).into()
 }
 
+/// Duration for the [`Toast`]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum ToastDuration {
+    #[default]
     Short,
-    Medium,
     Long,
+    Custom(Duration),
 }
 
 impl ToastDuration {
     fn duration(&self) -> Duration {
         match self {
-            ToastDuration::Short => Duration::from_millis(200),
-            ToastDuration::Medium => Duration::from_millis(1000),
-            ToastDuration::Long => Duration::from_millis(5000),
+            ToastDuration::Short => Duration::from_millis(2000),
+            ToastDuration::Long => Duration::from_millis(3500),
+            ToastDuration::Custom(duration) => *duration,
         }
     }
 }
 
+impl From<Duration> for ToastDuration {
+    fn from(value: Duration) -> Self {
+        Self::Custom(value)
+    }
+}
+
+/// Action that can be triggered by the user.
+///
+/// Example: `undo`
+#[derive(Debug, Clone)]
+pub struct ToastAction<Message> {
+    pub description: String,
+    pub message: Message,
+}
+
+/// Represent the data used to display a [`Toast`]
+#[derive(Debug, Clone)]
 pub struct Toast<Message> {
     message: String,
-    /// (Description, message)
-    action: Option<(String, Message)>,
-
+    action: Option<ToastAction<Message>>,
     duration: ToastDuration,
-
     id: u32,
 }
 
-pub struct Toasts<Message> {
-    id_count: u32,
-    toasts: Vec<Toast<Message>>,
+impl<Message> Toast<Message> {
+    /// Construct a new [`Toast`] with the provided message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            action: None,
+            duration: ToastDuration::default(),
+            id: 0,
+        }
+    }
+
+    /// Set the [`ToastAction`] of this [`Toast`]
+    #[must_use]
+    pub fn action(mut self, action: ToastAction<Message>) -> Self {
+        self.action.replace(action);
+        self
+    }
+
+    /// Set the [`ToastDuration`] of this [`Toast`]
+    #[must_use]
+    pub fn duration(mut self, duration: impl Into<ToastDuration>) -> Self {
+        self.duration = duration.into();
+        self
+    }
 }
 
+#[derive(Debug, Clone)]
+pub struct Toasts<Message> {
+    id_count: u32,
+    toasts: VecDeque<Toast<Message>>,
+    limit: usize,
+}
+
+// need custom impl to not require Message: Clone
+impl<M> Default for Toasts<M> {
+    fn default() -> Self {
+        Self {
+            id_count: 0,
+            toasts: VecDeque::new(),
+            limit: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ToastMessage(u32);
 
 impl<Message> Toasts<Message> {
-    pub fn push(&mut self, mut toast: Toast<Message>) -> Command<ToastMessage> {
+    /// Add a new [`Toast`]
+    pub fn push(
+        &mut self,
+        mut toast: Toast<Message>,
+    ) -> Command<crate::app::message::Message<Message>>
+    where
+        Message: From<ToastMessage>,
+    {
+        while self.toasts.len() >= self.limit {
+            self.toasts.pop_front();
+        }
+
         toast.id = self.id_count;
         self.id_count += 1;
 
         let message = ToastMessage(toast.id);
         let duration = toast.duration.duration();
 
-        self.toasts.push(toast);
+        self.toasts.push_back(toast);
 
         Command::perform(
             async move {
                 tokio::time::sleep(duration).await;
             },
-            |_| message,
+            |_| crate::app::Message::App(message.into()),
         )
     }
 
-    pub fn handle_message(&mut self, message: ToastMessage) {
+    /// Handle the [`ToastMessage`]
+    pub fn handle_message(&mut self, message: &ToastMessage) {
         self.toasts
             .iter()
             .position(|e| e.id == message.0)

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 wiiznokes
 // SPDX-License-Identifier: MIT
 
-//! A widget that display toats.
+//! A widget that displays toasts.
 
 use std::collections::VecDeque;
 use std::time::Duration;
@@ -36,7 +36,7 @@ where
             .align_items(iced::Alignment::Center);
 
         container(row)
-            .padding(10)
+            .padding(crate::theme::active().cosmic().space_xs())
             .style(crate::style::Container::Card)
     };
 

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2024 wiiznokes
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 //! A widget that displays toasts.
 
@@ -14,6 +14,7 @@ use widget::Toaster;
 
 use crate::ext::CollectionWidget;
 
+use super::column;
 use super::{button, row, text};
 
 mod widget;
@@ -40,8 +41,13 @@ where
             .style(crate::style::Container::Card)
     };
 
-    let col =
-        Column::with_children(toasts.toasts.iter().rev().map(|t| make_toast(t).into())).spacing(5);
+    let col = toasts
+        .toasts
+        .iter()
+        .rev()
+        .map(make_toast)
+        .fold(column::with_capacity(toasts.toasts.len()), Column::push)
+        .spacing(crate::theme::active().cosmic().space_xxxs());
 
     Toaster::new(col.into(), content.into(), toasts.toasts.is_empty()).into()
 }

--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -1,41 +1,41 @@
 // Copyright 2024 wiiznokes
 // SPDX-License-Identifier: MIT
 
-use iced::Size;
+use iced::{Limits, Size};
+use iced_core::layout::Node;
 use iced_runtime::core::widget::Id;
 use iced_runtime::{keyboard, Command};
 
 use iced_core::event::{self, Event};
 use iced_core::renderer::{self, Quad, Renderer};
-use iced_core::touch;
 use iced_core::widget::tree::{self, Tree};
 use iced_core::widget::Operation;
 use iced_core::Element;
 use iced_core::{layout, svg};
 use iced_core::{mouse, Border};
 use iced_core::{overlay, Shadow};
+use iced_core::{touch, Overlay};
 use iced_core::{
     Background, Clipboard, Color, Layout, Length, Padding, Point, Rectangle, Shell, Vector, Widget,
 };
 use iced_renderer::core::widget::{operation, OperationOutputWrapper};
 
-
-
-use super::Toasts;
-
 pub struct Toaster<'a, Message, Theme, Renderer> {
     toasts: Element<'a, Message, Theme, Renderer>,
     content: Element<'a, Message, Theme, Renderer>,
+    is_empty: bool,
 }
 
 impl<'a, Message, Theme, Renderer> Toaster<'a, Message, Theme, Renderer> {
     pub fn new(
         toasts: Element<'a, Message, Theme, Renderer>,
         content: Element<'a, Message, Theme, Renderer>,
+        is_empty: bool,
     ) -> Self {
         Self {
             toasts,
             content,
+            is_empty,
         }
     }
 }
@@ -46,7 +46,7 @@ where
     Renderer: iced_core::Renderer,
 {
     fn size(&self) -> Size<Length> {
-        todo!()
+        self.content.as_widget().size()
     }
 
     fn layout(
@@ -55,18 +55,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        todo!()
-    }
-
-    fn mouse_interaction(
-        &self,
-        _state: &Tree,
-        _layout: Layout<'_>,
-        _cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        todo!()
+        self.content
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn draw(
@@ -79,6 +70,183 @@ where
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content), Tree::new(&self.toasts)]
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut [&mut self.content, &mut self.toasts]);
+    }
+
+    fn operate<'b>(
+        &'b self,
+        state: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<OperationOutputWrapper<Message>>,
+    ) {
+        self.content
+            .as_widget()
+            .operate(&mut state.children[0], layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        state: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        self.content.as_widget_mut().on_event(
+            &mut state.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &state.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        state: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        if self.is_empty {
+            None
+        } else {
+            let bounds = layout.bounds();
+
+            Some(overlay::Element::new(
+                bounds.position(),
+                Box::new(ToasterOverlay::new(
+                    &mut state.children[1],
+                    &mut self.toasts,
+                )),
+            ))
+        }
+    }
+}
+
+struct ToasterOverlay<'a, 'b, Message, Theme = iced::Theme, Renderer = iced::Renderer> {
+    state: &'b mut Tree,
+    element: &'b mut Element<'a, Message, Theme, Renderer>,
+}
+
+impl<'a, 'b, Message, Theme, Renderer> ToasterOverlay<'a, 'b, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn new(state: &'b mut Tree, element: &'b mut Element<'a, Message, Theme, Renderer>) -> Self {
+        Self { state, element }
+    }
+}
+
+impl<'a, 'b, Message, Theme, Renderer> Overlay<Message, Theme, Renderer>
+    for ToasterOverlay<'a, 'b, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn layout(
+        &mut self,
+        renderer: &Renderer,
+        bounds: Size,
+        position: Point,
+        _translation: Vector,
+    ) -> Node {
+        todo!()
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+    ) {
+        let bounds = layout.bounds();
+        self.element
+            .as_widget()
+            .draw(self.state, renderer, theme, style, layout, cursor, &bounds);
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<Message>,
+    ) -> event::Status {
+        self.element.as_widget_mut().on_event(
+            self.state,
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            &layout.bounds(),
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.element
+            .as_widget()
+            .mouse_interaction(self.state, layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'c>(
+        &'c mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'c, Message, Theme, Renderer>> {
+        self.element
+            .as_widget_mut()
+            .overlay(self.state, layout, renderer)
     }
 }
 
@@ -87,7 +255,7 @@ impl<'a, Message, Theme, Renderer> From<Toaster<'a, Message, Theme, Renderer>>
 where
     Renderer: renderer::Renderer + 'a,
     Theme: 'a,
-    Message: 'a
+    Message: 'a,
 {
     fn from(
         toggler: Toaster<'a, Message, Theme, Renderer>,

--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -270,8 +270,8 @@ where
     Message: 'a,
 {
     fn from(
-        toggler: Toaster<'a, Message, Theme, Renderer>,
+        toaster: Toaster<'a, Message, Theme, Renderer>,
     ) -> Element<'a, Message, Theme, Renderer> {
-        Element::new(toggler)
+        Element::new(toaster)
     }
 }

--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -1,0 +1,97 @@
+// Copyright 2024 wiiznokes
+// SPDX-License-Identifier: MIT
+
+use iced::Size;
+use iced_runtime::core::widget::Id;
+use iced_runtime::{keyboard, Command};
+
+use iced_core::event::{self, Event};
+use iced_core::renderer::{self, Quad, Renderer};
+use iced_core::touch;
+use iced_core::widget::tree::{self, Tree};
+use iced_core::widget::Operation;
+use iced_core::Element;
+use iced_core::{layout, svg};
+use iced_core::{mouse, Border};
+use iced_core::{overlay, Shadow};
+use iced_core::{
+    Background, Clipboard, Color, Layout, Length, Padding, Point, Rectangle, Shell, Vector, Widget,
+};
+use iced_renderer::core::widget::{operation, OperationOutputWrapper};
+
+
+
+use super::Toasts;
+
+pub struct Toaster<'a, Message, Theme, Renderer> {
+    toasts: Element<'a, Message, Theme, Renderer>,
+    content: Element<'a, Message, Theme, Renderer>,
+}
+
+impl<'a, Message, Theme, Renderer> Toaster<'a, Message, Theme, Renderer> {
+    pub fn new(
+        toasts: Element<'a, Message, Theme, Renderer>,
+        content: Element<'a, Message, Theme, Renderer>,
+    ) -> Self {
+        Self {
+            toasts,
+            content,
+        }
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Toaster<'a, Message, Theme, Renderer>
+where
+    Renderer: iced_core::Renderer,
+{
+    fn size(&self) -> Size<Length> {
+        todo!()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        todo!()
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &Tree,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &Renderer,
+    ) -> mouse::Interaction {
+        todo!()
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Toaster<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer + 'a,
+    Theme: 'a,
+    Message: 'a
+{
+    fn from(
+        toggler: Toaster<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
+        Element::new(toggler)
+    }
+}

--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -1,5 +1,5 @@
 // Copyright 2024 wiiznokes
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 use iced::{Limits, Size};
 use iced_core::layout::Node;

--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -3,22 +3,18 @@
 
 use iced::{Limits, Size};
 use iced_core::layout::Node;
-use iced_runtime::core::widget::Id;
-use iced_runtime::{keyboard, Command};
 
 use iced_core::event::{self, Event};
-use iced_core::renderer::{self, Quad, Renderer};
-use iced_core::widget::tree::{self, Tree};
+use iced_core::layout;
+use iced_core::mouse;
+use iced_core::overlay;
+use iced_core::renderer::{self};
+use iced_core::widget::tree::Tree;
 use iced_core::widget::Operation;
 use iced_core::Element;
-use iced_core::{layout, svg};
-use iced_core::{mouse, Border};
-use iced_core::{overlay, Shadow};
-use iced_core::{touch, Overlay};
-use iced_core::{
-    Background, Clipboard, Color, Layout, Length, Padding, Point, Rectangle, Shell, Vector, Widget,
-};
-use iced_renderer::core::widget::{operation, OperationOutputWrapper};
+use iced_core::Overlay;
+use iced_core::{Clipboard, Layout, Length, Point, Rectangle, Shell, Vector, Widget};
+use iced_renderer::core::widget::OperationOutputWrapper;
 
 pub struct Toaster<'a, Message, Theme, Renderer> {
     toasts: Element<'a, Message, Theme, Renderer>,
@@ -145,7 +141,7 @@ where
         &'b mut self,
         state: &'b mut Tree,
         layout: Layout<'_>,
-        renderer: &Renderer,
+        _renderer: &Renderer,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         if self.is_empty {
             None
@@ -189,7 +185,23 @@ where
         position: Point,
         _translation: Vector,
     ) -> Node {
-        todo!()
+        let limits = Limits::new(Size::ZERO, bounds);
+
+        let mut node = self
+            .element
+            .as_widget()
+            .layout(self.state, renderer, &limits);
+
+        let offset = 15.;
+
+        let position = Point::new(
+            (bounds.width / 2.) - (node.size().width / 2.),
+            bounds.height - (node.size().height + offset),
+        );
+
+        node.move_to_mut(position);
+
+        node
     }
 
     fn draw(


### PR DESCRIPTION
Attempt to implement https://github.com/pop-os/cosmic-files/issues/183

I implemented this feature in fan-control. You can see the change i needed to make in [this commit](https://github.com/wiiznokes/fan-control/compare/master...toats).

The duration chosen comes from [Android](https://stackoverflow.com/questions/7965135/what-is-the-duration-of-a-toast-length-long-and-length-short).

There is more just to match the Ui design, but the idea is there. I'm not sure i will implement it as i don't really know where to search for padding, colours, ect..

![Capture d’écran du 2024-06-28 00-21-00](https://github.com/pop-os/libcosmic/assets/78230769/0af4f062-6c63-451e-bfe7-fbcb6ba205ec)


