### PR TITLE
Add on_middle_press to nav bar and segmented button

### DIFF
--- a/src/widget/nav_bar.rs
+++ b/src/widget/nav_bar.rs
@@ -101,6 +101,15 @@ impl<'a, Message: Clone + 'static> NavBar<'a, Message> {
         self
     }
 
+    /// Emitted when the middle mouse button is pressed on a button.
+    pub fn on_middle_press<T>(mut self, on_middle_press: T) -> Self
+    where
+        T: Fn(Id) -> Message + 'static,
+    {
+        self.segmented_button = self.segmented_button.on_middle_press(on_middle_press);
+        self
+    }
+
     /// Handle the dnd drop event.
     pub fn on_dnd_drop<D: AllowedMimeTypes>(
         mut self,


### PR DESCRIPTION
This is required to implement middle-click to open in a new tab from nav bar in COSMIC Files.

Relevant issue: https://github.com/pop-os/cosmic-files/issues/261
Will be implemented in: https://github.com/pop-os/cosmic-files/pull/266
