### PR TITLE
fix: change message bound for toaster

### DIFF
--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -147,7 +147,7 @@ impl<Message> Toasts<Message> {
     pub fn push(
         &mut self,
         mut toast: Toast<Message>,
-    ) -> Command<crate::app::message::Message<Message>>
+    ) -> Command<Message>
     where
         Message: From<ToastMessage>,
     {


### PR DESCRIPTION
Weird, i can't compile fan-control without this change