### PR TITLE
fix: window menus now supported by windows using wayland feature

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -541,7 +541,6 @@ impl<T: Application> Cosmic<T> {
                 }
             }
             Message::ShowWindowMenu => {
-                #[cfg(not(feature = "wayland"))]
                 return window::show_window_menu(window::Id::MAIN);
             }
             #[cfg(feature = "xdg-portal")]


### PR DESCRIPTION
Requires https://github.com/pop-os/iced/pull/159/