### PR TITLE
fix: return error if vscode config fails to parse, instead of overwriting

### DIFF
--- a/cosmic-theme/src/output/mod.rs
+++ b/cosmic-theme/src/output/mod.rs
@@ -14,6 +14,8 @@ pub enum OutputError {
     Io(std::io::Error),
     #[error("Missing config directory")]
     MissingConfigDir,
+    #[error("Serde Error: {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 impl Theme {

--- a/cosmic-theme/src/output/vs_code.rs
+++ b/cosmic-theme/src/output/vs_code.rs
@@ -277,7 +277,7 @@ impl Theme {
         // just add the json entry for workbench.colorCustomizations
         let settings_file = vs_code_dir.join("settings.json");
         let settings = std::fs::read_to_string(&settings_file).unwrap_or_default();
-        let mut settings: serde_json::Value = serde_json::from_str(&settings).unwrap_or_default();
+        let mut settings: serde_json::Value = serde_json::from_str(&settings)?;
         settings["workbench.colorCustomizations"] = serde_json::to_value(vs_theme).unwrap();
         settings["window.autoDetectColorScheme"] = serde_json::Value::Bool(true);
         std::fs::write(


### PR DESCRIPTION
workaround for #538 