### PR TITLE
Add VSCodium support

### DIFF
--- a/cosmic-theme/src/output/mod.rs
+++ b/cosmic-theme/src/output/mod.rs
@@ -21,9 +21,11 @@ pub enum OutputError {
 impl Theme {
     pub fn apply_exports(&self) -> Result<(), OutputError> {
         let gtk_res = Theme::apply_gtk(self.is_dark);
-        let vs_res = self.clone().apply_vs_code();
+        let vscode_res = self.clone().apply_vs_code();
+        let vscodium_res = self.clone().apply_vs_codium();
         gtk_res?;
-        vs_res?;
+        vscode_res?;
+        vscodium_res?;
         Ok(())
     }
 
@@ -35,9 +37,11 @@ impl Theme {
 
     pub fn reset_exports() -> Result<(), OutputError> {
         let gtk_res = Theme::reset_gtk();
-        let vs_res = Theme::reset_vs_code();
+        let vscode_res = Theme::reset_vs_code();
+        let vscodium_res = Theme::reset_vs_codium();
         gtk_res?;
-        vs_res?;
+        vscode_res?;
+        vscodium_res?;
         Ok(())
     }
 }

--- a/cosmic-theme/src/output/vs_code.rs
+++ b/cosmic-theme/src/output/vs_code.rs
@@ -306,4 +306,45 @@ impl Theme {
 
         Ok(())
     }
+
+    pub fn apply_vs_codium(self) -> Result<(), OutputError> {
+        let vs_theme = VsTheme::from(self);
+        let config_dir = dirs::config_dir().ok_or(OutputError::MissingConfigDir)?;
+        let vs_code_dir = config_dir.join("VSCodium").join("User");
+        if !vs_code_dir.exists() {
+            std::fs::create_dir_all(&vs_code_dir).map_err(OutputError::Io)?;
+        }
+
+        // just add the json entry for workbench.colorCustomizations
+        let settings_file = vs_code_dir.join("settings.json");
+        let settings = std::fs::read_to_string(&settings_file).unwrap_or_default();
+        let mut settings: serde_json::Value = serde_json::from_str(&settings)?;
+        settings["workbench.colorCustomizations"] = serde_json::to_value(vs_theme).unwrap();
+        settings["window.autoDetectColorScheme"] = serde_json::Value::Bool(true);
+        std::fs::write(
+            &settings_file,
+            serde_json::to_string_pretty(&settings).unwrap(),
+        )
+        .map_err(OutputError::Io)?;
+
+        Ok(())
+    }
+
+    pub fn reset_vs_codium() -> Result<(), OutputError> {
+        let config_dir = dirs::config_dir().ok_or(OutputError::MissingConfigDir)?;
+        let vs_code_dir = config_dir.join("VSCodium").join("User");
+        let settings_file = vs_code_dir.join("settings.json");
+        // just remove the json entry for workbench.colorCustomizations
+        let settings = std::fs::read_to_string(&settings_file).unwrap_or_default();
+        let mut settings: serde_json::Value = serde_json::from_str(&settings).unwrap_or_default();
+        settings["workbench.colorCustomizations"] = serde_json::Value::Null;
+
+        std::fs::write(
+            &settings_file,
+            serde_json::to_string_pretty(&settings).unwrap(),
+        )
+        .map_err(OutputError::Io)?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR adds support for VSCodium.
Can this be refactored?
I believe there are more VSCode-based editors that have different paths for the ```settings.json``` file...
