### PR TITLE
Call systemd `StartTransientUnit` when starting app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         - winit_wgpu
         - wayland
         - applet
-        - desktop
+        - desktop,smol
+        - desktop,tokio
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ desktop = [
     "dep:freedesktop-desktop-entry",
     "dep:mime",
     "dep:shlex",
+    "dep:tokio",
     "dep:textdistance",
+    "dep:zbus",
 ]
 # Enables keycode serialization
 serde-keycode = ["iced_core/serde"]
@@ -96,7 +98,7 @@ tokio = { version = "1.24.2", optional = true }
 tracing = "0.1"
 unicode-segmentation = "1.6"
 url = "2.4.0"
-zbus = { version = "4.2.1", default-features = false, optional = true }
+zbus = { version = "4.2.1", default-features = false, features = ["tokio"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 freedesktop-icons = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ debug = ["iced/debug"]
 # Enables pipewire support in ashpd, if ashpd is enabled
 pipewire = ["ashpd?/pipewire"]
 # Enables process spawning helper
-process = ["dep:nix"]
+process = ["dep:libc", "dep:rustix"]
 # Use rfd for file dialogs
 rfd = ["dep:rfd"]
 # Enables desktop files helpers
@@ -83,10 +83,11 @@ derive_setters = "0.1.5"
 fraction = "0.14.0"
 image = { version = "0.25.1", optional = true }
 lazy_static = "1.4.0"
+libc = { version = "0.2.155", optional  = true }
 mime = { version = "0.3.17", optional = true }
-nix = { version = "0.27", features = ["process"], optional = true }
 palette = "0.7.3"
 rfd = { version = "0.14.0", optional = true }
+rustix = { version = "0.38.34", features = ["pipe", "process"], optional = true }
 serde = { version = "1.0.180", features = ["derive"] }
 slotmap = "1.0.6"
 textdistance = { version = "1.0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ desktop = [
     "dep:freedesktop-desktop-entry",
     "dep:mime",
     "dep:shlex",
-    "dep:tokio",
     "dep:textdistance",
     "dep:zbus",
 ]
@@ -42,7 +41,7 @@ serde-keycode = ["iced_core/serde"]
 # Prevents multiple separate process instances.
 single-instance = ["dep:zbus", "ron"]
 # smol async runtime
-smol = ["iced/smol", "zbus?/async-io"]
+smol = ["dep:smol", "iced/smol", "zbus?/async-io"]
 tokio = [
     "dep:tokio",
     "ashpd?/tokio",
@@ -92,13 +91,14 @@ rfd = { version = "0.14.0", optional = true }
 rustix = { version = "0.38.34", features = ["pipe", "process"], optional = true }
 serde = { version = "1.0.180", features = ["derive"] }
 slotmap = "1.0.6"
+smol = { version = "2.0.0", optional = true }
 textdistance = { version = "1.0.2", optional = true }
 thiserror = "1.0.44"
 tokio = { version = "1.24.2", optional = true }
 tracing = "0.1"
 unicode-segmentation = "1.6"
 url = "2.4.0"
-zbus = { version = "4.2.1", default-features = false, features = ["tokio"], optional = true }
+zbus = { version = "4.2.1", default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 freedesktop-icons = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ xdg-portal = ["ashpd"]
 
 [dependencies]
 apply = "0.3.0"
-ashpd = { version = "0.8.1", default-features = false, optional = true }
+ashpd = { version = "0.9.1", default-features = false, optional = true }
 async-fs = { version = "2.1", optional = true }
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "c8d3a1c", optional = true }
 chrono = "0.4.35"
@@ -82,7 +82,7 @@ cosmic-config = { path = "cosmic-config" }
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 css-color = "0.2.5"
 derive_setters = "0.1.5"
-fraction = "0.14.0"
+fraction = "0.15.3"
 image = { version = "0.25.1", optional = true }
 lazy_static = "1.4.0"
 libc = { version = "0.2.155", optional  = true }

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -335,7 +335,7 @@ where
     // https://systemd.io/DESKTOP_ENVIRONMENTS
     //
     // Similar to what Gnome sets, for now.
-    if let Ok(Some(pid)) = tokio::task::spawn_blocking(|| crate::process::spawn(cmd)).await {
+    if let Some(pid) = crate::process::spawn(cmd).await {
         if let Ok(session) = zbus::Connection::session().await {
             if let Ok(systemd_manager) = SystemdMangerProxy::new(&session).await {
                 let _ = systemd_manager

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,9 +1,10 @@
 use std::fs::File;
 use std::io;
 use std::process::{exit, Command, Stdio};
+use tokio::io::AsyncReadExt;
 
 /// Performs a double fork with setsid to spawn and detach a command.
-pub fn spawn(mut command: Command) -> Option<u32> {
+pub async fn spawn(mut command: Command) -> Option<u32> {
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -15,16 +16,11 @@ pub fn spawn(mut command: Command) -> Option<u32> {
 
     match unsafe { libc::fork() } {
         // Parent process
-        child @ 1.. => {
-            let child = rustix::process::Pid::from_raw(child).unwrap();
-            let _res = rustix::process::waitpid(Some(child), rustix::process::WaitOptions::empty());
+        1.. => {
+            drop(write);
             // Read PID from pipe
-            let mut bytes = [0; 4];
-            if rustix::io::read(read, &mut bytes) == Ok(4) {
-                Some(u32::from_ne_bytes(bytes))
-            } else {
-                None
-            }
+            let mut read = tokio::net::unix::pipe::Receiver::from_owned_fd(read).unwrap();
+            read.read_u32().await.ok()
         }
 
         // Child process
@@ -32,7 +28,7 @@ pub fn spawn(mut command: Command) -> Option<u32> {
             let _res = rustix::process::setsid();
             if let Ok(child) = command.spawn() {
                 // Write PID to pipe
-                let _ = rustix::io::write(write, &child.id().to_ne_bytes());
+                let _ = rustix::io::write(write, &child.id().to_be_bytes());
             }
 
             exit(0)

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,31 +1,50 @@
+use std::fs::File;
+use std::io;
 use std::process::{exit, Command, Stdio};
 
-use nix::sys::wait::waitpid;
-use nix::unistd::{fork, ForkResult};
-
 /// Performs a double fork with setsid to spawn and detach a command.
-pub fn spawn(mut command: Command) {
+pub fn spawn(mut command: Command) -> Option<u32> {
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
 
-    unsafe {
-        match fork() {
-            Ok(ForkResult::Parent { child }) => {
-                let _res = waitpid(Some(child), None);
+    let Ok((read, write)) = rustix::pipe::pipe_with(rustix::pipe::PipeFlags::CLOEXEC) else {
+        return None;
+    };
+
+    match unsafe { libc::fork() } {
+        // Parent process
+        child @ 1.. => {
+            let child = rustix::process::Pid::from_raw(child).unwrap();
+            let _res = rustix::process::waitpid(Some(child), rustix::process::WaitOptions::empty());
+            // Read PID from pipe
+            let mut bytes = [0; 4];
+            if rustix::io::read(read, &mut bytes) == Ok(4) {
+                Some(u32::from_ne_bytes(bytes))
+            } else {
+                None
+            }
+        }
+
+        // Child process
+        0 => {
+            let _res = rustix::process::setsid();
+            if let Ok(child) = command.spawn() {
+                // Write PID to pipe
+                let _ = rustix::io::write(write, &child.id().to_ne_bytes());
             }
 
-            Ok(ForkResult::Child) => {
-                let _res = nix::unistd::setsid();
-                let _res = command.spawn();
+            exit(0)
+        }
 
-                exit(0);
-            }
+        ..=-1 => {
+            println!(
+                "failed to fork and spawn command: {}",
+                io::Error::last_os_error()
+            );
 
-            Err(why) => {
-                println!("failed to fork and spawn command: {}", why.desc());
-            }
+            None
         }
     }
 }


### PR DESCRIPTION
This is needed for things like `xdg-desktop-portal` to get the app ID from a pid, in unsandboxed apps.

A couple things still should be fixed here, then `cosmic-launcher`, `cosmic-app-list`, and `cosmic-app-library` will need to be updated to use this.