### PR TITLE
fix: Use globals instead of thread-locals

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -48,7 +48,6 @@ pub mod message {
 pub use self::command::Command;
 pub use self::core::Core;
 pub use self::settings::Settings;
-use crate::config::CosmicTk;
 use crate::prelude::*;
 use crate::theme::THEME;
 use crate::widget::{context_drawer, id_container, menu, nav_bar, popover};
@@ -58,7 +57,6 @@ use iced::Subscription;
 use iced::{multi_window::Application as IcedApplication, window};
 #[cfg(any(not(feature = "winit"), not(feature = "multi-window")))]
 use iced::{window, Application as IcedApplication};
-use iced_core::mouse;
 pub use message::Message;
 use url::Url;
 #[cfg(feature = "single-instance")]
@@ -87,10 +85,7 @@ pub(crate) fn iced_settings<App: Application>(
         crate::icon_theme::set_default(crate::config::icon_theme());
     }
 
-    THEME.with(move |t| {
-        let mut cosmic_theme = t.borrow_mut();
-        cosmic_theme.set_theme(settings.theme.theme_type);
-    });
+    THEME.lock().unwrap().set_theme(settings.theme.theme_type);
 
     let mut iced = iced::Settings::with_flags((core, flags));
 

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -375,10 +375,7 @@ pub fn run<App: Application>(autosize: bool, flags: App::Flags) -> iced::Result 
     core.set_window_width(width);
     core.set_window_height(height);
 
-    THEME.with(move |t| {
-        let mut cosmic_theme = t.borrow_mut();
-        cosmic_theme.set_theme(settings.theme.theme_type);
-    });
+    THEME.lock().unwrap().set_theme(settings.theme.theme_type);
 
     let mut iced = iced::Settings::with_flags((core, flags));
 
@@ -435,11 +432,7 @@ pub fn padded_control<'a, Message>(
 }
 
 pub fn menu_control_padding() -> Padding {
-    THEME
-        .with(|t| {
-            let t = t.borrow();
-            let cosmic = t.cosmic();
-            [cosmic.space_xxs(), cosmic.space_m()]
-        })
-        .into()
+    let guard = THEME.lock().unwrap();
+    let cosmic = guard.cosmic();
+    [cosmic.space_xxs(), cosmic.space_m()].into()
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,53 +6,60 @@
 use cosmic_config::cosmic_config_derive::CosmicConfigEntry;
 use cosmic_config::{Config, CosmicConfigEntry};
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{LazyLock, Mutex};
 
 /// ID for the `CosmicTk` config.
 pub const ID: &str = "com.system76.CosmicTk";
 
-thread_local! {
-    pub static COSMIC_TK: RefCell<CosmicTk> = RefCell::new(CosmicTk::config()
-    .map(|c| {
-        CosmicTk::get_entry(&c).unwrap_or_else(|(errors, mode)| {
-            for why in errors {
-                tracing::error!(?why, "CosmicTk config entry error");
-            }
-            mode
-        })
-    })
-    .unwrap_or_default())
-}
+pub static COSMIC_TK: LazyLock<Mutex<CosmicTk>> = LazyLock::new(|| {
+    Mutex::new(
+        CosmicTk::config()
+            .map(|c| {
+                CosmicTk::get_entry(&c).unwrap_or_else(|(errors, mode)| {
+                    for why in errors {
+                        tracing::error!(?why, "CosmicTk config entry error");
+                    }
+                    mode
+                })
+            })
+            .unwrap_or_default(),
+    )
+});
 
 /// Apply the theme to other toolkits.
+#[allow(clippy::missing_panics_doc)]
 pub fn apply_theme_global() -> bool {
-    COSMIC_TK.with(|tk| tk.borrow().apply_theme_global)
+    COSMIC_TK.lock().unwrap().apply_theme_global
 }
 
 /// Show minimize button in window header.
+#[allow(clippy::missing_panics_doc)]
 pub fn show_minimize() -> bool {
-    COSMIC_TK.with(|tk| tk.borrow().show_minimize)
+    COSMIC_TK.lock().unwrap().show_minimize
 }
 
 /// Show maximize button in window header.
+#[allow(clippy::missing_panics_doc)]
 pub fn show_maximize() -> bool {
-    COSMIC_TK.with(|tk| tk.borrow().show_maximize)
+    COSMIC_TK.lock().unwrap().show_maximize
 }
 
 /// Preferred icon theme.
+#[allow(clippy::missing_panics_doc)]
 pub fn icon_theme() -> String {
-    COSMIC_TK.with(|tk| tk.borrow().icon_theme.clone())
+    COSMIC_TK.lock().unwrap().icon_theme.clone()
 }
 
 /// Density of CSD/SSD header bars.
+#[allow(clippy::missing_panics_doc)]
 pub fn header_size() -> Density {
-    COSMIC_TK.with(|tk| tk.borrow().header_size)
+    COSMIC_TK.lock().unwrap().header_size
 }
 
 /// Interface density.
+#[allow(clippy::missing_panics_doc)]
 pub fn interface_density() -> Density {
-    COSMIC_TK.with(|tk| tk.borrow().interface_density)
+    COSMIC_TK.lock().unwrap().interface_density
 }
 
 #[derive(Clone, CosmicConfigEntry, Debug, Eq, PartialEq)]

--- a/src/icon_theme.rs
+++ b/src/icon_theme.rs
@@ -4,22 +4,21 @@
 //! Select the preferred icon theme.
 
 use std::borrow::Cow;
-use std::cell::RefCell;
+use std::sync::Mutex;
 
 pub const COSMIC: &str = "Cosmic";
 
-thread_local! {
-    /// The fallback icon theme to search if no icon theme was specified.
-    pub(crate) static DEFAULT: RefCell<Cow<'static, str>> = RefCell::new(COSMIC.into());
-}
+pub(crate) static DEFAULT: Mutex<Cow<'static, str>> = Mutex::new(Cow::Borrowed(COSMIC));
 
 /// The fallback icon theme to search if no icon theme was specified.
 #[must_use]
+#[allow(clippy::missing_panics_doc)]
 pub fn default() -> String {
-    DEFAULT.with(|theme| theme.borrow().to_string())
+    DEFAULT.lock().unwrap().to_string()
 }
 
 /// Set the fallback icon theme to search when loading system icons.
+#[allow(clippy::missing_panics_doc)]
 pub fn set_default(name: impl Into<Cow<'static, str>>) {
-    DEFAULT.with(|theme| *theme.borrow_mut() = name.into());
+    *DEFAULT.lock().unwrap() = name.into();
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -15,8 +15,7 @@ use cosmic_theme::Component;
 use cosmic_theme::LayeredTheme;
 use iced_futures::Subscription;
 
-use std::cell::RefCell;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "dbus-config")]
 use cosmic_config::dbus;
@@ -46,18 +45,21 @@ lazy_static::lazy_static! {
     };
 }
 
-thread_local! {
-    pub(crate) static THEME: RefCell<Theme> = RefCell::new(Theme { theme_type: ThemeType::Dark, layer: cosmic_theme::Layer::Background });
-}
+pub(crate) static THEME: Mutex<Theme> = Mutex::new(Theme {
+    theme_type: ThemeType::Dark,
+    layer: cosmic_theme::Layer::Background,
+});
 
 /// Currently-defined theme.
+#[allow(clippy::missing_panics_doc)]
 pub fn active() -> Theme {
-    THEME.with(|theme| theme.borrow().clone())
+    THEME.lock().unwrap().clone()
 }
 
 /// Currently-defined theme type.
+#[allow(clippy::missing_panics_doc)]
 pub fn active_type() -> ThemeType {
-    THEME.with(|theme| theme.borrow().theme_type.clone())
+    THEME.lock().unwrap().theme_type.clone()
 }
 
 /// Whether the active theme has a dark preference.

--- a/src/widget/button/icon.rs
+++ b/src/widget/button/icon.rs
@@ -31,95 +31,85 @@ pub fn icon<'a, Message>(handle: impl Into<Handle>) -> Button<'a, Message> {
 
 impl<'a, Message> Button<'a, Message> {
     pub fn new(icon: Icon) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
-            let padding = theme.space_xxs();
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
+        let padding = theme.space_xxs();
 
-            Self {
-                id: Id::unique(),
-                label: Cow::Borrowed(""),
-                tooltip: Cow::Borrowed(""),
-                on_press: None,
-                width: Length::Shrink,
-                height: Length::Shrink,
-                padding: Padding::from(padding),
-                spacing: theme.space_xxxs(),
-                icon_size: if icon.handle.symbolic { 16 } else { 24 },
-                line_height: 20,
-                font_size: 14,
-                font_weight: Weight::Normal,
-                style: Style::Icon,
-                variant: icon,
-            }
-        })
+        Self {
+            id: Id::unique(),
+            label: Cow::Borrowed(""),
+            tooltip: Cow::Borrowed(""),
+            on_press: None,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            padding: Padding::from(padding),
+            spacing: theme.space_xxxs(),
+            icon_size: if icon.handle.symbolic { 16 } else { 24 },
+            line_height: 20,
+            font_size: 14,
+            font_weight: Weight::Normal,
+            style: Style::Icon,
+            variant: icon,
+        }
     }
 
     /// Applies the **Extra Small** button size preset.
     pub fn extra_small(mut self) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
 
-            self.font_size = 14;
-            self.font_weight = Weight::Normal;
-            self.icon_size = 16;
-            self.line_height = 20;
-            self.padding = Padding::from(theme.space_xxs());
-            self.spacing = theme.space_xxxs();
-        });
+        self.font_size = 14;
+        self.font_weight = Weight::Normal;
+        self.icon_size = 16;
+        self.line_height = 20;
+        self.padding = Padding::from(theme.space_xxs());
+        self.spacing = theme.space_xxxs();
 
         self
     }
 
     /// Applies the **Medium** button size preset.
     pub fn medium(mut self) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
 
-            self.font_size = 24;
-            self.font_weight = Weight::Normal;
-            self.icon_size = 32;
-            self.line_height = 32;
-            self.padding = Padding::from(theme.space_xs());
-            self.spacing = theme.space_xxs();
-        });
+        self.font_size = 24;
+        self.font_weight = Weight::Normal;
+        self.icon_size = 32;
+        self.line_height = 32;
+        self.padding = Padding::from(theme.space_xs());
+        self.spacing = theme.space_xxs();
 
         self
     }
 
     /// Applies the **Large** button size preset.
     pub fn large(mut self) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
 
-            self.font_size = 28;
-            self.font_weight = Weight::Normal;
-            self.icon_size = 40;
-            self.line_height = 36;
-            self.padding = Padding::from(theme.space_xs());
-            self.spacing = theme.space_xxs();
-        });
+        self.font_size = 28;
+        self.font_weight = Weight::Normal;
+        self.icon_size = 40;
+        self.line_height = 36;
+        self.padding = Padding::from(theme.space_xs());
+        self.spacing = theme.space_xxs();
 
         self
     }
 
     /// Applies the **Extra Large** button size preset.
     pub fn extra_large(mut self) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
-            let padding = theme.space_xs();
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
+        let padding = theme.space_xs();
 
-            self.font_size = 32;
-            self.font_weight = Weight::Light;
-            self.icon_size = 56;
-            self.line_height = 44;
-            self.padding = Padding::from(padding);
-            self.spacing = theme.space_xxs();
-        });
+        self.font_size = 32;
+        self.font_weight = Weight::Light;
+        self.icon_size = 56;
+        self.line_height = 44;
+        self.padding = Padding::from(padding);
+        self.spacing = theme.space_xxs();
 
         self
     }

--- a/src/widget/button/style.rs
+++ b/src/widget/button/style.rs
@@ -44,7 +44,7 @@ pub struct Appearance {
 impl Appearance {
     // TODO: `Radius` is not `const fn` compatible.
     pub fn new() -> Self {
-        let rad_0 = THEME.with(|t| t.borrow().cosmic().corner_radii.radius_0);
+        let rad_0 = THEME.lock().unwrap().cosmic().corner_radii.radius_0;
         Self {
             shadow_offset: Vector::new(0.0, 0.0),
             background: None,

--- a/src/widget/button/text.rs
+++ b/src/widget/button/text.rs
@@ -51,26 +51,24 @@ impl Text {
 
 impl<'a, Message> Button<'a, Message> {
     pub fn new(text: Text) -> Self {
-        crate::theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
-            Self {
-                id: Id::unique(),
-                label: Cow::Borrowed(""),
-                tooltip: Cow::Borrowed(""),
-                on_press: None,
-                width: Length::Shrink,
-                height: Length::Fixed(theme.space_l().into()),
-                padding: Padding::from([0, theme.space_s()]),
-                spacing: theme.space_xxxs(),
-                icon_size: 16,
-                line_height: 20,
-                font_size: 14,
-                font_weight: Weight::Normal,
-                style: Style::Standard,
-                variant: text,
-            }
-        })
+        let guard = crate::theme::THEME.lock().unwrap();
+        let theme = guard.cosmic();
+        Self {
+            id: Id::unique(),
+            label: Cow::Borrowed(""),
+            tooltip: Cow::Borrowed(""),
+            on_press: None,
+            width: Length::Shrink,
+            height: Length::Fixed(theme.space_l().into()),
+            padding: Padding::from([0, theme.space_s()]),
+            spacing: theme.space_xxxs(),
+            icon_size: 16,
+            line_height: 20,
+            font_size: 14,
+            font_weight: Weight::Normal,
+            style: Style::Standard,
+            variant: text,
+        }
     }
 
     pub fn leading_icon(mut self, icon: impl Into<icon::Handle>) -> Self {

--- a/src/widget/button/widget.rs
+++ b/src/widget/button/widget.rs
@@ -423,7 +423,7 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
             renderer.with_layer(parent_bounds, |renderer| {
                 let selection_background = theme.selection_background();
 
-                let c_rad = THEME.with(|t| t.borrow().cosmic().corner_radii);
+                let c_rad = THEME.lock().unwrap().cosmic().corner_radii;
 
                 // NOTE: Workaround to round the border of the unselected, unhovered image.
                 if !self.selected && !is_mouse_over {

--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -177,11 +177,7 @@ fn padded_control<'a, Message>(
 }
 
 fn menu_control_padding() -> Padding {
-    crate::theme::THEME
-        .with(|t| {
-            let t = t.borrow();
-            let cosmic = t.cosmic();
-            [cosmic.space_xxs(), cosmic.space_m()]
-        })
-        .into()
+    let guard = crate::theme::THEME.lock().unwrap();
+    let cosmic = guard.cosmic();
+    [cosmic.space_xxs(), cosmic.space_m()].into()
 }

--- a/src/widget/color_picker/mod.rs
+++ b/src/widget/color_picker/mod.rs
@@ -287,7 +287,7 @@ where
         copied_to_clipboard_label: T,
     ) -> ColorPicker<'a, Message> {
         let on_update = self.on_update;
-        let spacing = THEME.with(|t| t.borrow().cosmic().spacing);
+        let spacing = THEME.lock().unwrap().cosmic().spacing;
         let mut inner = column![
             // segmented buttons
             segmented_control::horizontal(self.model)
@@ -595,7 +595,7 @@ where
         let bounds = canvas_layout.bounds();
         // Draw the handle on the saturation value canvas
 
-        let t = THEME.with(|t| t.borrow().clone());
+        let t = THEME.lock().unwrap().clone();
         let t = t.cosmic();
         let handle_radius = f32::from(t.space_xs()) / 2.0;
         let (x, y) = (
@@ -779,7 +779,7 @@ pub fn color_button<'a, Message: 'static>(
     color: Option<Color>,
     icon_portion: Length,
 ) -> crate::widget::Button<'a, Message> {
-    let spacing = THEME.with(|t| t.borrow().cosmic().spacing);
+    let spacing = THEME.lock().unwrap().cosmic().spacing;
 
     button(if color.is_some() {
         Element::from(vertical_space(Length::Fixed(f32::from(spacing.space_s))))

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -67,11 +67,7 @@ impl<'a, Message: Clone + 'static> From<Dialog<'a, Message>> for Element<'a, Mes
             space_s,
             space_xxs,
             ..
-        } = theme::THEME.with(|theme_cell| {
-            let theme = theme_cell.borrow();
-            let theme = theme.cosmic();
-            theme.spacing
-        });
+        } = theme::THEME.lock().unwrap().cosmic().spacing;
 
         let mut content_col = widget::column::with_capacity(3 + dialog.controls.len() * 2);
         content_col = content_col.push(widget::text::title3(dialog.title));

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -1361,7 +1361,7 @@ where
                 bounds.y = bounds.y + bounds.height - width;
                 bounds.height = width;
 
-                let rad_0 = THEME.with(|t| t.borrow().cosmic().corner_radii.radius_0);
+                let rad_0 = THEME.lock().unwrap().cosmic().corner_radii.radius_0;
                 renderer.fill_quad(
                     renderer::Quad {
                         bounds,

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -92,7 +92,7 @@ pub fn search_input<'a, Message>(
 where
     Message: Clone + 'static,
 {
-    let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+    let spacing = THEME.lock().unwrap().cosmic().space_xxs();
 
     TextInput::new(placeholder, value)
         .padding([0, spacing, 0, spacing])
@@ -117,7 +117,7 @@ pub fn secure_input<'a, Message>(
 where
     Message: Clone + 'static,
 {
-    let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+    let spacing = THEME.lock().unwrap().cosmic().space_xxs();
     let mut input = TextInput::new(placeholder, value)
         .padding([0, spacing, 0, spacing])
         .style(crate::theme::TextInput::Default)
@@ -156,7 +156,7 @@ pub fn inline_input<'a, Message>(
 where
     Message: Clone + 'static,
 {
-    let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+    let spacing = THEME.lock().unwrap().cosmic().space_xxs();
 
     TextInput::new(placeholder, value)
         .style(crate::theme::TextInput::Inline)
@@ -223,7 +223,7 @@ where
     /// - a placeholder,
     /// - the current value
     pub fn new(placeholder: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> Self {
-        let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+        let spacing = THEME.lock().unwrap().cosmic().space_xxs();
 
         let v: Cow<'a, str> = value.into();
         TextInput {
@@ -486,7 +486,7 @@ where
     }
 
     pub fn on_clear(self, on_clear: Message) -> Self {
-        let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+        let spacing = THEME.lock().unwrap().cosmic().space_xxs();
 
         self.trailing_icon(
             crate::widget::icon::from_name("edit-clear-symbolic")
@@ -992,7 +992,7 @@ pub fn layout<Message>(
     tree: &mut Tree,
 ) -> layout::Node {
     let limits = limits.width(width);
-    let spacing = THEME.with(|t| t.borrow().cosmic().space_xxs());
+    let spacing = THEME.lock().unwrap().cosmic().space_xxs();
     let mut nodes = Vec::with_capacity(3);
 
     let text_pos = if let Some(label) = label {
@@ -2186,9 +2186,7 @@ pub fn draw<'a, Message>(
     let font = font.unwrap_or_else(|| renderer.default_font());
     let size = size.unwrap_or_else(|| renderer.default_size().0);
 
-    let radius_0 = THEME
-        .with(|t| t.borrow().cosmic().corner_radii.radius_0)
-        .into();
+    let radius_0 = THEME.lock().unwrap().cosmic().corner_radii.radius_0.into();
     let (cursor, offset) = if let Some(focus) = &state.is_focused {
         match state.cursor.state(value) {
             cursor::State::Index(position) => {


### PR DESCRIPTION
Better support for multi-threaded applications, especially cosmic-comp rendering in parallel on multiple threads, each potentially accessing global configurations such as the active theme, icon_theme and more...

This is already causing issues like https://github.com/pop-os/cosmic-comp/issues/671

Note: Leaves the SUBSURFACE-thread-local untouched. It is not part of the public api and looking at it, I am not sure it is possible to have access to this from multiple threads. cosmic-comp also has no business with iced-sctk, so this a non-issue for the cases I want to fix here. (Ping @ids1024 on this specifically.)