### PR TITLE
chore: Update MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcosmic"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.80"
 
 [lib]
 name = "cosmic"


### PR DESCRIPTION
https://github.com/pop-os/libcosmic/pull/557 uses `std::sync::LazyLock`, which was only introduced in the latest stable release.