### PR TITLE
Make `Toggle` handle and border radius concentric

### DIFF
--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -823,6 +823,7 @@ impl toggler::StyleSheet for Theme {
 
     fn active(&self, _style: &Self::Style, is_active: bool) -> toggler::Appearance {
         let theme = self.cosmic();
+        const HANDLE_MARGIN: f32 = 2.0;
         toggler::Appearance {
             background: if is_active {
                 theme.accent.base.into()
@@ -833,8 +834,11 @@ impl toggler::StyleSheet for Theme {
             foreground: theme.palette.neutral_2.into(),
             foreground_border: None,
             border_radius: theme.radius_xl().into(),
-            handle_radius: theme.radius_xl().into(),
-            handle_margin: 2.0,
+            handle_radius: theme
+                .radius_xl()
+                .map(|x| (x - HANDLE_MARGIN).max(0.0))
+                .into(),
+            handle_margin: HANDLE_MARGIN,
         }
     }
 


### PR DESCRIPTION
Very minor thing at this point. This makes the Toggle widget radius more pleasing by making the radii concentric. Most noticeable with the "Slightly round" style, as indicated in the application to the right, with the current look in the settings panel to the left. It is subtle, but something people will notice at least subconsciously.



![screenshot-2024-08-03-12-01-22](https://github.com/user-attachments/assets/24be8768-c9e9-41b7-af98-6291d383500c)
