### PR TITLE
Set non-linux window control icons as symbolic

### DIFF
--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -370,6 +370,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                         $name,
                         ".svg"
                     )))
+                    .symbolic(true)
                     .apply(widget::button::icon)
                 };
 


### PR DESCRIPTION
Fix for #559 (credit to @wiiznokes for the fix).