### PR TITLE
Add horizontal padding to menu divider

### DIFF
--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -9,6 +9,7 @@ use iced_widget::core::{renderer, Element};
 use iced_widget::horizontal_rule;
 
 use crate::iced_core::{Alignment, Length};
+use crate::widget::container;
 use crate::widget::menu::action::MenuAction;
 use crate::widget::menu::key_bind::KeyBind;
 use crate::{theme, widget};
@@ -288,7 +289,9 @@ where
                 }
                 MenuItem::Divider => {
                     if i != size - 1 {
-                        trees.push(MenuTree::<Message, Renderer>::new(horizontal_rule(1)));
+                        trees.push(MenuTree::<Message, Renderer>::new(
+                            container(horizontal_rule(1)).padding([0, 8]),
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
Adds a horizontal padding of 8 to the menu divider, to match designs.