### PR TITLE
fix: dont omit default preference for light theme

### DIFF
--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -527,7 +527,7 @@ impl Theme {
         if let Ok(cmd) = cmd {
             let color_scheme = String::from_utf8_lossy(&cmd.stdout);
 
-            if color_scheme.trim().contains("light") {
+            if color_scheme.trim().contains("default") || color_scheme.trim().contains("light") {
                 return Self::light_default();
             }
         };


### PR DESCRIPTION
Hello,

Some time ago I made PR where we could read gsettings values for preferred color scheme.
I assumed it will be `prefer-light` for light theme, but GNOME has also `default` value for light theme (basically it's "mixed" theme (?)) so we should read this value also and treat it as light theme I guess, which is a thing in Ubuntu for example.