### PR TITLE
fix(menu): Ignore Key::Character case when matching KeyBind

### DIFF
--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -38,7 +38,12 @@ impl KeyBind {
     ///
     /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
     pub fn matches(&self, modifiers: Modifiers, key: &Key) -> bool {
-        key == &self.key
+        let key_eq = match (key, &self.key) {
+            // CapsLock and Shift change the case of Key::Character, so we compare these in a case insensitive way
+            (Key::Character(a), Key::Character(b)) => a.eq_ignore_ascii_case(&b),
+            (a, b) => a.eq(b),
+        };
+        key_eq
             && modifiers.logo() == self.modifiers.contains(&Modifier::Super)
             && modifiers.control() == self.modifiers.contains(&Modifier::Ctrl)
             && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)


### PR DESCRIPTION
This will fix https://github.com/pop-os/cosmic-files/issues/286 and https://github.com/pop-os/cosmic-term/issues/317 in a simpler way than https://github.com/pop-os/cosmic-files/pull/428