### PR TITLE
(chore) Various broken examples fixes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         examples:
           - "application"
           - "open-dialog"
+          - "context-menu"
+          - "nav-context"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -134,7 +134,7 @@ pub enum ContextMenuAction {
 
 impl menu::Action for ContextMenuAction {
     type Message = Message;
-    fn message(&self, _entity_opt: Option<segmented_button::Entity>) -> Self::Message {
+    fn message(&self) -> Self::Message {
         match self {
             ContextMenuAction::WindowClose => Message::WindowClose,
             ContextMenuAction::ToggleHideContent => Message::ToggleHideContent,

--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -446,7 +446,6 @@ impl Application for Window {
 
             Message::CondensedViewToggle => {}
             Message::KeyboardNav(message) => match message {
-                keyboard_nav::Message::Unfocus => ret = keyboard_nav::unfocus(),
                 keyboard_nav::Message::FocusNext => ret = widget::focus_next(),
                 keyboard_nav::Message::FocusPrevious => ret = widget::focus_previous(),
                 _ => (),

--- a/examples/nav-context/src/main.rs
+++ b/examples/nav-context/src/main.rs
@@ -72,7 +72,7 @@ pub enum NavMenuAction {
 impl menu::Action for NavMenuAction {
     type Message = cosmic::app::Message<Message>;
 
-    fn message(&self, _entity: Option<cosmic::widget::segmented_button::Entity>) -> Self::Message {
+    fn message(&self) -> Self::Message {
         cosmic::app::Message::App(Message::NavMenuAction(*self))
     }
 }


### PR DESCRIPTION
There were changes like these: 1) https://github.com/pop-os/libcosmic/commit/547423279 2) https://github.com/pop-os/libcosmic/commit/31ea71d , that have broken some of the examples since we do not test all of them in CI here: https://github.com/pop-os/libcosmic/blob/master/.github/workflows/ci.yml#L79-L81
I was looking at the repo and just found them, i think there might be more.

e.g. : 
![screenshot-2024-09-01-18-10-22](https://github.com/user-attachments/assets/4d08ba08-606f-4aa2-b953-e7894dd3c8a0)
