### PR TITLE
[list_column] Match container padding to list spacing

### DIFF
--- a/src/widget/list/column.rs
+++ b/src/widget/list/column.rs
@@ -66,6 +66,7 @@ impl<'a, Message: 'static> ListColumn<'a, Message> {
             .spacing(self.spacing)
             .padding(self.padding)
             .apply(super::container)
+            .padding([self.spacing, 0])
             .style(self.style)
             .into()
     }


### PR DESCRIPTION
This ensures that the vertical space between the top/bottom list items and the edges of the container remains the same as the spacing between items, when the `list_column` spacing is changed from default.
Needed to match the spacing from the designs for list columns on some Settings pages.

Another issue is that dividers (e.g. `divider::horizontal::light()`) seem to have around 2 px of vertical padding (which `horizontal_rule` doesn't have), which makes things at the ends of a list off-center, but I haven't been able to find where that padding comes from.
Not sure if the padding should be removed, or `horizontal_rule` used in places where that padding isn't desirable.