### PR TITLE
Remove design-demo example again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = iced
 	url = https://github.com/pop-os/iced.git
 	branch = master
-[submodule "examples/design-demo"]
-	path = examples/design-demo
-	url = https://github.com/pop-os/cosmic-design-demo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ members = [
     "cosmic-theme",
     "examples/*",
 ]
-exclude = ["examples/design-demo", "iced"]
+exclude = ["iced"]
 
 [workspace.dependencies]
 dirs = "5.0.1"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,11 @@
-## `design-demo`
-
-Showcase of all widgets and their styled variations for the purpose of demonstrating and
-fine-tuning our design system.
-
-```sh
-just run cosmic-design demo
-```
+# Examples
 
 ## `application`
 
 Start here as a template for creating an application with libcosmic's application API.
 
 ```sh
-just run cosmic-design demo
+just run application
 ```
 
 ## `open-dialog`


### PR DESCRIPTION
The design-demo example was removed in the commit f0bfa87. The submodule was then added back by @wash2 in the commit f9af93c. The commit was about was about updating iced so I suspect it got added back by accident.

In issue #374 @mmstick said about it: "The project is not maintained right now. It should be removed."

I have removed the design-demo example again along with some other leftover parts. I also fixed the examples README.md file.

This closes issue #374