### PR TITLE
Fix image-button example

### DIFF
--- a/examples/image-button/Cargo.toml
+++ b/examples/image-button/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cosmic-image-button"
+name = "image-button"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,4 +10,4 @@ tracing-subscriber = "0.3.17"
 [dependencies.libcosmic]
 path = "../../"
 default-features = false
-features = ["debug", "wayland", "tokio"]
+features = ["debug", "winit", "tokio"]


### PR DESCRIPTION
The image-button example did not work with `just run image-button`. The first problem was that the package name was `cosmic-image-button` and not `image-button`. It was defined as `image-button` in the justfile.

The second problem was that the `wayland` feature defines the `set_window_title` as taking an `Id`. The easiest solution was to just use the `winit` feature instead. We can alternatively pass `window::Id::MAIN` if needed.