### PR TITLE
Document examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,13 @@
 # Examples
 
+## `applet`
+
+Demonstrates how to create an applet.
+
+```sh
+just run applet
+```
+
 ## `application`
 
 Start here as a template for creating an application with libcosmic's application API.
@@ -8,10 +16,75 @@ Start here as a template for creating an application with libcosmic's applicatio
 just run application
 ```
 
+## `calendar`
+
+Demonstrates how to use the calendar widget.
+
+```sh
+just run calendar
+```
+
+## `config`
+
+Demonstrates how to use the configuration system. There is no GUI in this
+example.
+
+```sh
+just run config
+```
+
+## `context-menu`
+
+Demonstrates how to use the context menu widget.
+
+```sh
+just run context-menu
+```
+
+## `image-button`
+
+Demonstrates how to use the image-button widget.
+
+```sh
+just run image-button
+```
+
+## `menu`
+
+Demonstrates how use the menu widget.
+
+```sh
+just run menu
+```
+
+## `multi-window`
+
+Demonstrates how to open multiple windows.
+
+```sh
+just run multi-window
+```
+
+## `nav-context`
+
+Demonstrates how to use the navigation bar widget.
+
+```sh
+just run nav-context
+```
+
 ## `open-dialog`
 
 Demonstrates how to create an open file dialog
 
 ```sh
 just run open-dialog
+```
+
+## `text-input`
+
+Demonstrates how to use the text input widgets.
+
+```sh
+just run text-input
 ```


### PR DESCRIPTION
The documentation was missing for some of the examples. This adds documentation for the other examples, except `cosmic` which is deprecated and currently not compiling.