### PR TITLE
Add more examples to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,16 @@ jobs:
       fail-fast: false
       matrix:
         examples:
+          - "applet"
           - "application"
-          - "open-dialog"
+          - "calendar"
+          - "config"
           - "context-menu"
+          - "image-button"
+          - "menu"
           - "nav-context"
+          - "open-dialog"
+          - "text-input"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Some of the examples had not been added to the CI. This means that they can break silently if the API changes. This change makes it more obvious if they are broken.

I've left out the multi-window example since that was broken recently.