### PR TITLE
feat(app): allow context drawer to be laid out next to content

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -385,7 +385,7 @@ impl<T: Application> Cosmic<T> {
             },
 
             Message::ContextDrawer(show) => {
-                self.app.core_mut().window.show_context = show;
+                self.app.core_mut().set_show_context(show);
                 return self.app.on_context_drawer();
             }
 


### PR DESCRIPTION
This is in order to support https://github.com/pop-os/cosmic-files/issues/109. There are some small hacks but it is a relatively small change and functional.