### PR TITLE
Fix multi-window example

### DIFF
--- a/examples/multi-window/src/window.rs
+++ b/examples/multi-window/src/window.rs
@@ -136,7 +136,7 @@ impl cosmic::Application for MultiWindow {
             .focused_window()
             .map(|i| i == id)
             .unwrap_or_default();
-        let new_window_button = button(text("New Window")).on_press(Message::NewWindow);
+        let new_window_button = button::custom(text("New Window")).on_press(Message::NewWindow);
 
         let content = scrollable(
             column![input, new_window_button]


### PR DESCRIPTION
It looks like the multi-window example was recently broken by f12de01. The `button` function was renamed to `custom` but the code didn't get updated.

This fixes issue #616