### PR TITLE
Fix color of horizontal segmented button divider

### DIFF
--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -186,7 +186,9 @@ impl Theme {
     #[allow(clippy::doc_markdown)]
     /// get @small_widget_divider
     pub fn small_widget_divider(&self) -> Srgba {
-        self.palette.neutral_9
+        let mut neutral_9 = self.palette.neutral_9;
+        neutral_9.alpha = 0.2;
+        neutral_9
     }
 
     // Containers


### PR DESCRIPTION
This makes the `small_widget_divider` color match the designs, and thus fixes the divider color in the horizontal `segmented_button`. Also tweaks the values of `neutral_9` to match the designs (the diff is a bit hard to see).

The background color of the horizontal segmented button doesn't match designs, but I haven't been able to figure out where the color of the `small_widget` is set.
It can mostly match if doing something like the following, but it should use the `small_widget` color:
```
SegmentedButton::Control => {
                let cosmic = self.cosmic();
                let mut color = cosmic.palette.neutral_7;
                color.alpha = 0.1;
                let active = horizontal::selection_active(cosmic, &container.component);
                let rad_m = cosmic.corner_radii.radius_m;
                let rad_0 = cosmic.corner_radii.radius_0;
                Appearance {
                    background: Some(Background::Color(color.into())),
```