### PR TITLE
Make use of systemd scopes optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ desktop = [
     "dep:freedesktop-desktop-entry",
     "dep:mime",
     "dep:shlex",
+    "tokio?/io-util",
+    "tokio?/net",
+]
+# Enables launching desktop files inside systemd scopes
+desktop-systemd-scope = [
+    "desktop",
     "dep:zbus",
 ]
 # Enables keycode serialization


### PR DESCRIPTION
With this change, anything wanting to launch desktop files in systemd scopes must use the desktop-systemd-scope feature. I'm open to alternatives, my primary use case for this is avoiding a zbus dependency when enabling the desktop feature