### PR TITLE
fix: remove non-existent cosmic-time feature from cosmic example

### DIFF
--- a/examples/cosmic/Cargo.toml
+++ b/examples/cosmic/Cargo.toml
@@ -17,4 +17,4 @@ log = "0.4.17"
 [dependencies.cosmic-time]
 git = "https://github.com/pop-os/cosmic-time"
 default-features = false
-features = ["libcosmic", "once_cell"]
+features = ["once_cell"]


### PR DESCRIPTION
Removes the "libcosmic" feature of cosmic-time from the cosmic example. This feature appears to no longer exist as of [cosmic-time commit 07f7d5b](https://github.com/pop-os/cosmic-time/commit/07f7d5b48d4be5bf88904768ee0151287dc2a1e4).

I know this example is noted as "depreciated" in the readme, but right now this prevents libcosmic from building.