### PR TITLE
Add transparency and blur support

### DIFF
--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -92,3 +92,14 @@ impl crate::app::Core {
 pub fn set_theme<M: Send + 'static>(theme: crate::Theme) -> iced::Task<Message<M>> {
     message::cosmic(super::cosmic::Message::AppThemeChange(theme))
 }
+
+pub fn set_transparent<M: Send + 'static>(
+    theme: cosmic_theme::Theme,
+    alpha: f32,
+) -> iced::Task<Message<M>> {
+    message::cosmic(super::cosmic::Message::EnableTransparency(theme, alpha))
+}
+
+pub fn enable_blur<M: Send + 'static>() -> iced::Task<Message<M>> {
+    message::cosmic(super::cosmic::Message::EnableBlur)
+}

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -25,6 +25,10 @@ use palette::color_difference::EuclideanDistance;
 pub enum Message {
     /// Application requests theme change.
     AppThemeChange(Theme),
+    /// Enables blur support.
+    EnableBlur,
+    /// Enables transparency.
+    EnableTransparency(cosmic_theme::Theme, f32),
     /// Requests to close the window.
     Close,
     /// Closes or shows the context drawer.
@@ -429,7 +433,17 @@ impl<T: Application> Cosmic<T> {
 
                 THEME.lock().unwrap().set_theme(theme.theme_type);
             }
-
+            Message::EnableBlur => {
+                if let Some(id) = self.app.core().main_window_id() {
+                    return Task::batch(vec![iced::runtime::window::enable_blur(id)]);
+                }
+            }
+            Message::EnableTransparency(mut theme, alpha) => {
+                theme.background.base.alpha *= alpha;
+                return self.cosmic_update(Message::AppThemeChange(crate::Theme::custom(
+                    std::sync::Arc::new(theme),
+                )));
+            }
             Message::SystemThemeChange(keys, theme) => {
                 let cur_is_dark = THEME.lock().unwrap().theme_type.is_dark();
                 // Ignore updates if the current theme mode does not match.


### PR DESCRIPTION
This PR adds both transparency and blur support in supported platforms, currently tested in KDE Plasma.

![image](https://github.com/user-attachments/assets/f77ebb73-9520-4f6c-9c33-8922289d6b34)

cc @wash2 