### PR TITLE
Add window border

### DIFF
--- a/examples/application/src/main.rs
+++ b/examples/application/src/main.rs
@@ -169,12 +169,12 @@ impl cosmic::Application for App {
             ]
             .width(iced::Length::Fill)
             .height(iced::Length::Shrink)
-            .align_x(iced::alignment::Horizontal::Center),
+            .align_x(iced::Alignment::Center),
         )
         .width(iced::Length::Fill)
         .height(iced::Length::Shrink)
-        .align_x(iced::alignment::Horizontal::Center)
-        .align_y(iced::alignment::Vertical::Center);
+        .align_x(iced::Alignment::Center)
+        .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/examples/calendar/src/main.rs
+++ b/examples/calendar/src/main.rs
@@ -88,8 +88,8 @@ impl cosmic::Application for App {
         let centered = cosmic::widget::container(content)
             .width(iced::Length::Fill)
             .height(iced::Length::Shrink)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Center);
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -96,8 +96,8 @@ impl cosmic::Application for App {
         let centered = cosmic::widget::container(widget)
             .width(iced::Length::Fill)
             .height(iced::Length::Fill)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Center);
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/examples/cosmic/src/window.rs
+++ b/examples/cosmic/src/window.rs
@@ -564,12 +564,9 @@ impl Application for Window {
             };
 
             widgets.push(
-                scrollable(
-                    container(content.debug(self.debug))
-                        .align_x(iced::alignment::Horizontal::Center),
-                )
-                .width(Length::Fill)
-                .into(),
+                scrollable(container(content.debug(self.debug)).align_x(iced::Alignment::Center))
+                    .width(Length::Fill)
+                    .into(),
             );
         }
 

--- a/examples/image-button/src/main.rs
+++ b/examples/image-button/src/main.rs
@@ -95,8 +95,8 @@ impl cosmic::Application for App {
         let centered = cosmic::widget::container(content)
             .width(iced::Length::Fill)
             .height(iced::Length::Shrink)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Center);
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/examples/nav-context/src/main.rs
+++ b/examples/nav-context/src/main.rs
@@ -183,8 +183,8 @@ impl cosmic::Application for App {
         let centered = cosmic::widget::container(text)
             .width(iced::Length::Fill)
             .height(iced::Length::Shrink)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Center);
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/examples/open-dialog/src/main.rs
+++ b/examples/open-dialog/src/main.rs
@@ -233,7 +233,7 @@ fn center<'a>(input: impl Into<Element<'a, Message>> + 'a) -> Element<'a, Messag
     iced::widget::container(input.into())
         .width(iced::Length::Fill)
         .height(iced::Length::Fill)
-        .align_x(iced::alignment::Horizontal::Center)
-        .align_y(iced::alignment::Vertical::Center)
+        .align_x(iced::Alignment::Center)
+        .align_y(iced::Alignment::Center)
         .into()
 }

--- a/examples/text-input/src/main.rs
+++ b/examples/text-input/src/main.rs
@@ -104,8 +104,8 @@ impl cosmic::Application for App {
         let centered = cosmic::widget::container(column.width(200))
             .width(iced::Length::Fill)
             .height(iced::Length::Shrink)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Center);
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
 
         Element::from(centered)
     }

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -206,10 +206,7 @@ impl Context {
                     .width(Length::Fixed(suggested.0 as f32))
                     .height(Length::Fixed(suggested.1 as f32)),
             )
-            .align_x(Horizontal::Center)
-            .align_y(Vertical::Center)
-            .width(Length::Fill)
-            .height(Length::Fill),
+            .center(Length::Fill),
         )
         .width(Length::Fixed((suggested.0 + 2 * applet_padding) as f32))
         .height(Length::Fixed((suggested.1 + 2 * applet_padding) as f32))

--- a/src/widget/aspect_ratio.rs
+++ b/src/widget/aspect_ratio.rs
@@ -2,14 +2,15 @@
 
 use iced::widget::Container;
 use iced::Size;
-use iced_core::alignment;
 use iced_core::event::{self, Event};
 use iced_core::layout;
 use iced_core::mouse;
 use iced_core::overlay;
 use iced_core::renderer;
 use iced_core::widget::Tree;
-use iced_core::{Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Vector, Widget};
+use iced_core::{
+    Alignment, Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Vector, Widget,
+};
 
 use iced_widget::container;
 pub use iced_widget::container::{Catalog, Style};
@@ -104,14 +105,14 @@ where
 
     /// Sets the content alignment for the horizontal axis of the [`Container`].
     #[must_use]
-    pub fn align_x(mut self, alignment: alignment::Horizontal) -> Self {
+    pub fn align_x(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_x(alignment);
         self
     }
 
     /// Sets the content alignment for the vertical axis of the [`Container`].
     #[must_use]
-    pub fn align_y(mut self, alignment: alignment::Vertical) -> Self {
+    pub fn align_y(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_y(alignment);
         self
     }
@@ -127,6 +128,13 @@ where
     #[must_use]
     pub fn center_y(mut self, height: Length) -> Self {
         self.container = self.container.center_y(height);
+        self
+    }
+
+    /// Centers the contents in the horizontal and vertical axis of the [`Container`].
+    #[must_use]
+    pub fn center(mut self, length: Length) -> Self {
+        self.container = self.container.center(length);
         self
     }
 

--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -5,10 +5,9 @@
 
 use std::cmp;
 
-use crate::iced_core::{Length, Padding};
+use crate::iced_core::{Alignment, Length, Padding};
 use crate::widget::{button, column, grid, icon, row, text, Grid};
 use chrono::{Datelike, Days, Months, NaiveDate, Weekday};
-use iced::alignment::{Horizontal, Vertical};
 
 /// A widget that displays an interactive calendar.
 pub fn calendar<M>(
@@ -62,7 +61,7 @@ where
 {
     fn from(this: Calendar<'a, Message>) -> Self {
         let date = text(this.selected.format("%B %-d, %Y").to_string()).size(18);
-        let day_of_week = text(this.selected.format("%A").to_string()).size(14);
+        let day_of_week = text::body(this.selected.format("%A").to_string());
 
         let month_controls = row::with_capacity(2)
             .push(
@@ -86,7 +85,7 @@ where
                 text(first_day_of_week.to_string())
                     .size(12)
                     .width(Length::Fixed(36.0))
-                    .align_x(Horizontal::Center),
+                    .align_x(Alignment::Center),
             );
 
             first_day_of_week = first_day_of_week.succ();
@@ -143,14 +142,10 @@ fn date_button<Message>(
         button::ButtonClass::Text
     };
 
-    let button = button::custom(
-        text(format!("{}", date.day()))
-            .align_x(Horizontal::Center)
-            .align_y(Vertical::Center),
-    )
-    .class(style)
-    .height(Length::Fixed(36.0))
-    .width(Length::Fixed(36.0));
+    let button = button::custom(text(format!("{}", date.day())).center())
+        .class(style)
+        .height(Length::Fixed(36.0))
+        .width(Length::Fixed(36.0));
 
     if is_month {
         button.on_press((on_select)(set_day(date, date.day())))

--- a/src/widget/color_picker/mod.rs
+++ b/src/widget/color_picker/mod.rs
@@ -558,7 +558,7 @@ where
                     button::custom(
                         text(reset_to_default)
                             .width(self.width)
-                            .align_x(iced_core::alignment::Horizontal::Center)
+                            .align_x(iced_core::Alignment::Center)
                     )
                     .width(self.width)
                     .on_press(on_update(ColorPickerUpdate::Reset))
@@ -574,14 +574,14 @@ where
                     button::custom(
                         text(cancel)
                             .width(self.width)
-                            .align_x(iced_core::alignment::Horizontal::Center)
+                            .align_x(iced_core::Alignment::Center)
                     )
                     .width(self.width)
                     .on_press(on_update(ColorPickerUpdate::Cancel)),
                     button::custom(
                         text(save)
                             .width(self.width)
-                            .align_x(iced_core::alignment::Horizontal::Center)
+                            .align_x(iced_core::Alignment::Center)
                     )
                     .width(self.width)
                     .on_press(on_update(ColorPickerUpdate::AppliedColor))

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -8,9 +8,9 @@ use crate::{Apply, Element, Renderer, Theme};
 
 use super::overlay::Overlay;
 
-use iced_core::alignment;
 use iced_core::event::{self, Event};
 use iced_core::widget::{Operation, Tree};
+use iced_core::Alignment;
 use iced_core::{
     layout, mouse, overlay as iced_overlay, renderer, Clipboard, Layout, Length, Padding,
     Rectangle, Shell, Vector, Widget,
@@ -46,18 +46,16 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
                 text::heading(header)
                     .width(Length::FillPortion(1))
                     .height(Length::Fill)
-                    .align_x(alignment::Horizontal::Center)
-                    .align_y(alignment::Vertical::Center),
+                    .align_x(Alignment::Center)
+                    .align_y(Alignment::Center),
             )
             .push(
                 button::text("Close")
                     .trailing_icon(icon::from_name("go-next-symbolic"))
                     .on_press(on_close)
-                    .class(crate::theme::Button::Link)
                     .apply(container)
                     .width(Length::FillPortion(1))
-                    .height(Length::Fill)
-                    .align_x(alignment::Horizontal::Right)
+                    .align_x(Alignment::End)
                     .center_y(Length::Fill),
             )
             // XXX must be done after pushing elements or it may be overwritten by size hints from contents
@@ -89,7 +87,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
         )
         .width(Length::Fill)
         .height(Length::Fill)
-        .align_x(alignment::Horizontal::Right)
+        .align_x(Alignment::End)
         .into()
     }
 

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -292,7 +292,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                 widget::row::with_children(start)
                     .align_y(iced::Alignment::Center)
                     .apply(widget::container)
-                    .align_x(iced::alignment::Horizontal::Left)
+                    .align_x(iced::Alignment::Start)
                     .width(Length::Shrink),
             )
             // If elements exist in the center region, use them here.
@@ -301,8 +301,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                 widget::row::with_children(center)
                     .align_y(iced::Alignment::Center)
                     .apply(widget::container)
-                    .align_x(iced::alignment::Horizontal::Center)
-                    .width(Length::Fill)
+                    .center_x(Length::Fill)
                     .into()
             } else if self.title.is_empty() {
                 widget::horizontal_space().width(Length::Fill).into()
@@ -313,7 +312,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                 widget::row::with_children(end)
                     .align_y(iced::Alignment::Center)
                     .apply(widget::container)
-                    .align_x(iced::alignment::Horizontal::Right)
+                    .align_x(iced::Alignment::End)
                     .width(Length::Shrink),
             )
             .align_y(iced::Alignment::Center)

--- a/src/widget/layer_container.rs
+++ b/src/widget/layer_container.rs
@@ -1,14 +1,15 @@
 use crate::Theme;
 use cosmic_theme::LayeredTheme;
 use iced::widget::Container;
-use iced_core::alignment;
 use iced_core::event::{self, Event};
 use iced_core::layout;
 use iced_core::mouse;
 use iced_core::overlay;
 use iced_core::renderer;
 use iced_core::widget::Tree;
-use iced_core::{Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Vector, Widget};
+use iced_core::{
+    Alignment, Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Vector, Widget,
+};
 pub use iced_widget::container::{Catalog, Style};
 
 pub fn layer_container<'a, Message: 'static, E>(
@@ -96,14 +97,14 @@ where
 
     /// Sets the content alignment for the horizontal axis of the [`LayerContainer`].
     #[must_use]
-    pub fn align_x(mut self, alignment: alignment::Horizontal) -> Self {
+    pub fn align_x(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_x(alignment);
         self
     }
 
     /// Sets the content alignment for the vertical axis of the [`LayerContainer`].
     #[must_use]
-    pub fn align_y(mut self, alignment: alignment::Vertical) -> Self {
+    pub fn align_y(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_y(alignment);
         self
     }
@@ -119,6 +120,13 @@ where
     #[must_use]
     pub fn center_y(mut self, height: Length) -> Self {
         self.container = self.container.center_y(height);
+        self
+    }
+
+    /// Centers the contents in the horizontal and vertical axis of the [`Container`].
+    #[must_use]
+    pub fn center(mut self, length: Length) -> Self {
+        self.container = self.container.center(length);
         self
     }
 

--- a/src/widget/list/column.rs
+++ b/src/widget/list/column.rs
@@ -42,10 +42,10 @@ impl<'a, Message: 'static> ListColumn<'a, Message> {
 
         // Ensure a minimum height of 32.
         let container = iced::widget::row![
-            crate::widget::container(item).align_y(iced::alignment::Vertical::Center),
+            crate::widget::container(item).align_y(iced::Alignment::Center),
             crate::widget::vertical_space().height(iced::Length::Fixed(32.))
         ]
-        .align_y(iced::alignment::Vertical::Center);
+        .align_y(iced::Alignment::Center);
 
         self.children.push(container.into());
         self

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -281,9 +281,7 @@ where
                                 widget::Space::with_width(Length::Fixed(16.0)).into()
                             },
                             widget::Space::with_width(Length::Fixed(8.0)).into(),
-                            widget::text(label)
-                                .align_x(iced::alignment::Horizontal::Left)
-                                .into(),
+                            widget::text(label).align_x(iced::Alignment::Start).into(),
                             widget::horizontal_space().width(Length::Fill).into(),
                             widget::text(key).into(),
                         ])

--- a/src/widget/nav_bar.rs
+++ b/src/widget/nav_bar.rs
@@ -146,11 +146,12 @@ impl<'a, Message: Clone + 'static> From<NavBar<'a, Message>>
             .button_spacing(space_xxs)
             .spacing(space_xxs)
             .style(crate::theme::SegmentedButton::TabBar)
+            .apply(container)
+            .padding(space_xxs)
             .apply(scrollable)
             .class(crate::style::iced::Scrollable::Minimal)
             .height(Length::Fill)
             .apply(container)
-            .padding(space_xxs)
             .height(Length::Fill)
             .class(theme::Container::custom(nav_bar_style))
     }

--- a/src/widget/rectangle_tracker/mod.rs
+++ b/src/widget/rectangle_tracker/mod.rs
@@ -5,14 +5,13 @@ use iced::widget::Container;
 use iced::Vector;
 pub use subscription::*;
 
-use iced_core::alignment;
 use iced_core::event::{self, Event};
 use iced_core::layout;
 use iced_core::mouse;
 use iced_core::overlay;
 use iced_core::renderer;
 use iced_core::widget::Tree;
-use iced_core::{Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Widget};
+use iced_core::{Alignment, Clipboard, Element, Layout, Length, Padding, Rectangle, Shell, Widget};
 use std::{fmt::Debug, hash::Hash};
 
 pub use iced_widget::container::{Catalog, Style};
@@ -133,14 +132,14 @@ where
 
     /// Sets the content alignment for the horizontal axis of the [`Container`].
     #[must_use]
-    pub fn align_x(mut self, alignment: alignment::Horizontal) -> Self {
+    pub fn align_x(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_x(alignment);
         self
     }
 
     /// Sets the content alignment for the vertical axis of the [`Container`].
     #[must_use]
-    pub fn align_y(mut self, alignment: alignment::Vertical) -> Self {
+    pub fn align_y(mut self, alignment: Alignment) -> Self {
         self.container = self.container.align_y(alignment);
         self
     }
@@ -156,6 +155,13 @@ where
     #[must_use]
     pub fn center_y(mut self, height: Length) -> Self {
         self.container = self.container.center_y(height);
+        self
+    }
+
+    /// Centers the contents in the horizontal and vertical axis of the [`Container`].
+    #[must_use]
+    pub fn center(mut self, length: Length) -> Self {
+        self.container = self.container.center(length);
         self
     }
 

--- a/src/widget/scrollable.rs
+++ b/src/widget/scrollable.rs
@@ -8,6 +8,4 @@ pub fn scrollable<'a, Message>(
     element: impl Into<Element<'a, Message>>,
 ) -> widget::Scrollable<'a, Message, crate::Theme, Renderer> {
     widget::scrollable(element)
-    // .scrollbar_width(8) TODO add these back
-    // .scroller_width(8)
 }

--- a/src/widget/settings/item.rs
+++ b/src/widget/settings/item.rs
@@ -114,8 +114,8 @@ impl<'a, Message: 'static> Item<'a, Message> {
         if let Some(description) = self.description {
             let column = column::with_capacity(2)
                 .spacing(2)
-                .push(text(self.title).wrapping(Wrapping::Word))
-                .push(text(description).wrapping(Wrapping::Word).size(10))
+                .push(text::body(self.title).wrapping(Wrapping::Word))
+                .push(text::caption(description).wrapping(Wrapping::Word))
                 .width(Length::Fill);
 
             contents.push(column.into());

--- a/src/widget/settings/mod.rs
+++ b/src/widget/settings/mod.rs
@@ -5,7 +5,7 @@ pub mod item;
 pub mod section;
 
 pub use self::item::{flex_item, flex_item_row, item, item_row};
-pub use self::section::{section, view_section, Section};
+pub use self::section::{section, Section};
 
 use crate::widget::{column, Column};
 use crate::{theme, Element};
@@ -13,8 +13,8 @@ use crate::{theme, Element};
 /// A column with a predefined style for creating a settings panel
 #[must_use]
 pub fn view_column<Message: 'static>(children: Vec<Element<Message>>) -> Column<Message> {
-    let spacing = theme::THEME.lock().unwrap().cosmic().spacing;
+    let space_m = theme::THEME.lock().unwrap().cosmic().spacing.space_m;
     column::with_children(children)
-        .spacing(spacing.space_m)
-        .padding([0, spacing.space_m])
+        .spacing(space_m)
+        .padding([0, space_m])
 }

--- a/src/widget/spin_button/mod.rs
+++ b/src/widget/spin_button/mod.rs
@@ -11,10 +11,7 @@ pub use self::model::{Message, Model};
 use crate::widget::{button, container, icon, row, text};
 use crate::{theme, Element};
 use apply::Apply;
-use iced::{
-    alignment::{Horizontal, Vertical},
-    Alignment, Length,
-};
+use iced::{Alignment, Length};
 use iced_core::{Border, Shadow};
 
 pub struct SpinButton<'a, Message> {
@@ -49,10 +46,7 @@ impl<'a, Message: 'static> SpinButton<'a, Message> {
                 icon::from_name("list-remove-symbolic")
                     .size(16)
                     .apply(container)
-                    .width(Length::Fixed(32.0))
-                    .height(Length::Fixed(32.0))
-                    .align_x(Horizontal::Center)
-                    .align_y(Vertical::Center)
+                    .center(Length::Fixed(32.0))
                     .apply(button::custom)
                     .width(Length::Fixed(32.0))
                     .height(Length::Fixed(32.0))
@@ -61,17 +55,13 @@ impl<'a, Message: 'static> SpinButton<'a, Message> {
                     .into(),
                 text::title4(label)
                     .apply(container)
-                    .width(Length::Fixed(48.0))
-                    .align_x(Horizontal::Center)
-                    .align_y(Vertical::Center)
+                    .center_x(Length::Fixed(48.0))
+                    .align_y(Alignment::Center)
                     .into(),
                 icon::from_name("list-add-symbolic")
                     .size(16)
                     .apply(container)
-                    .width(Length::Fixed(32.0))
-                    .height(Length::Fixed(32.0))
-                    .align_x(Horizontal::Center)
-                    .align_y(Vertical::Center)
+                    .center(Length::Fixed(32.0))
                     .apply(button::custom)
                     .width(Length::Fixed(32.0))
                     .height(Length::Fixed(32.0))
@@ -83,9 +73,8 @@ impl<'a, Message: 'static> SpinButton<'a, Message> {
             .height(Length::Fixed(32.0))
             .align_y(Alignment::Center),
         )
-        .align_y(Vertical::Center)
         .width(Length::Shrink)
-        .height(Length::Fixed(32.0))
+        .center_y(Length::Fixed(32.0))
         .class(theme::Container::custom(container_style))
         .apply(Element::from)
         .map(on_change)

--- a/src/widget/warning.rs
+++ b/src/widget/warning.rs
@@ -4,7 +4,7 @@
 use super::icon;
 use crate::{theme, widget, Element, Renderer, Theme};
 use apply::Apply;
-use iced::{alignment, Alignment, Background, Color, Length};
+use iced::{Alignment, Background, Color, Length};
 use iced_core::{Border, Shadow};
 use std::borrow::Cow;
 
@@ -45,7 +45,7 @@ impl<'a, Message: 'static + Clone> Warning<'a, Message> {
             .apply(widget::container)
             .class(theme::Container::custom(warning_container))
             .padding(10)
-            .align_y(alignment::Vertical::Center)
+            .align_y(Alignment::Center)
             .width(Length::Fill)
     }
 }


### PR DESCRIPTION
This adds a border around windows, and removes the 8px padding around the content, allowing the scrollbar to go to the edge (to match designs).
Also adds some invisible padding around non-maximized windows, so that the `resize_border` is more outside the window, to not interfere with the scrollbar.
This significantly improves the floating window resize UX, but currently also adds padding around tiled windows, so it should maybe be removed until there's a way to differently handle tiled windows (might already exist, but I haven't been able to find it), or if it's planned to do it in a better way than adding invisible padding (so that resize indicators don't show up when the cursor is at the edges of maximized windows, as they do now).
I tried to also add a window shadow, but it looked quite janky and artifacty, so that isn't here.

Moves the NavBar scroller to the edge of the NavBar, so that it doesn't overlap the buttons (at least when not Compact, so maybe the padding should be made fixed; or the scroller could be made similar to the one in `cosmic-edit` that reduces in width when not hovered over).

Setting the width of the scrollbar/scroller in the libcosmic `scrollable` seems to be hard to do properly, so maybe the default width should be updated in the Iced fork (diverging from upstream is a bit unfortunate, but it's a really small change).

This is `cosmic-files` with these changes (needs a few more changes in the app to match designs), and an updated scrollbar/scroller width in Iced:
![screenshot-2024-11-03-23-19-25](https://github.com/user-attachments/assets/da79d8ae-8782-49db-9424-b6c453ec9424)
