### PR TITLE
Fix app padding

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -792,11 +792,18 @@ impl<App: Application> ApplicationExt for App {
         // TODO: More granularity might be needed for different resize border
         // and window border handling of maximized and tiled windows
         let sharp_corners = core.window.sharp_corners;
+        let content_container = core.window.content_container;
+        let nav_bar_active = core.nav_bar_active();
         let focused = core
             .focused_window()
             .is_some_and(|i| Some(i) == self.core().main_window_id());
-        let main_content_padding = if core.window.content_container {
-            [0, 8, 8, 8]
+
+        let main_content_padding = if content_container {
+            if nav_bar_active {
+                [0, 8, 8, 0]
+            } else {
+                [0, 8, 8, 8]
+            }
         } else {
             [0, 0, 0, 0]
         };
@@ -837,7 +844,11 @@ impl<App: Application> ApplicationExt for App {
                                 ))
                             })
                             .apply(container)
-                            .padding([0, 8, 8, 0])
+                            .padding(if content_container {
+                                [0, 8, 8, 0]
+                            } else {
+                                [0, 0, 0, 0]
+                            })
                             .into(),
                         );
                     } else {
@@ -867,7 +878,11 @@ impl<App: Application> ApplicationExt for App {
                                 ))
                             })
                             .apply(container)
-                            .padding([0, 8, 8, 0])
+                            .padding(if content_container {
+                                [0, 8, 8, 0]
+                            } else {
+                                [0, 0, 0, 0]
+                            })
                             .into(),
                         )
                     } else {
@@ -880,8 +895,6 @@ impl<App: Application> ApplicationExt for App {
             widgets
         });
         let content_col = crate::widget::column::with_capacity(2)
-            //TODO: Add back when the `resize_border` is moved to not cover window content
-            //.spacing(8)
             .push(content_row)
             .push_maybe(
                 self.footer()

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -12,8 +12,8 @@ use iced_core::event::{self, Event};
 use iced_core::widget::{Operation, Tree};
 use iced_core::Alignment;
 use iced_core::{
-    layout, mouse, overlay as iced_overlay, renderer, Clipboard, Layout, Length, Padding,
-    Rectangle, Shell, Vector, Widget,
+    layout, mouse, overlay as iced_overlay, renderer, Clipboard, Layout, Length, Rectangle, Shell,
+    Vector, Widget,
 };
 
 #[must_use]
@@ -34,46 +34,30 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
     where
         Drawer: Into<Element<'a, Message>>,
     {
+        let cosmic_theme::Spacing {
+            space_m, space_l, ..
+        } = crate::theme::active().cosmic().spacing;
+
         let header = row::with_capacity(3)
-            .padding(Padding {
-                top: 0.0,
-                bottom: 0.0,
-                left: 32.0,
-                right: 32.0,
-            })
+            .padding([space_m, space_l])
             .push(Space::new(Length::FillPortion(1), Length::Fixed(0.0)))
-            .push(
-                text::heading(header)
-                    .width(Length::FillPortion(1))
-                    .height(Length::Fill)
-                    .align_x(Alignment::Center)
-                    .align_y(Alignment::Center),
-            )
+            .push(text::heading(header).width(Length::FillPortion(1)).center())
             .push(
                 button::text("Close")
                     .trailing_icon(icon::from_name("go-next-symbolic"))
                     .on_press(on_close)
                     .apply(container)
                     .width(Length::FillPortion(1))
-                    .align_x(Alignment::End)
-                    .center_y(Length::Fill),
+                    .align_x(Alignment::End),
             )
             // XXX must be done after pushing elements or it may be overwritten by size hints from contents
-            .height(Length::Fixed(80.0))
             .width(Length::Fixed(480.0));
 
-        let pane = column::with_capacity(2)
-            .push(header.height(Length::Fixed(80.)))
-            .push(
-                scrollable(container(drawer.into()).padding(Padding {
-                    top: 0.0,
-                    left: 32.0,
-                    right: 32.0,
-                    bottom: 32.0,
-                }))
+        let pane = column::with_capacity(2).push(header).push(
+            scrollable(container(drawer.into()).padding([0, space_l, space_l, space_l]))
                 .height(Length::Fill)
                 .width(Length::Shrink),
-            );
+        );
 
         // XXX new limits do not exactly handle the max width well for containers
         // XXX this is a hack to get around that


### PR DESCRIPTION
This fixes the cosmic-term terminal_box becoming cropped when opening a context drawer.

Also fixes the misalignment for main content caused by #687 and makes the context drawers use spacing variables.