### PR TITLE
feat: export markdown iced feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ winit_wgpu = ["winit", "wgpu"]
 # Enables XDG portal integrations
 xdg-portal = ["ashpd"]
 qr_code = ["iced/qr_code"]
+markdown = ["iced/markdown"]
 
 [dependencies]
 apply = "0.3.0"

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -6,6 +6,7 @@
 use crate::theme::{CosmicComponent, Theme, TRANSPARENT_COMPONENT};
 use cosmic_theme::composite::over;
 use iced::{
+    border, color,
     overlay::menu,
     widget::{
         button as iced_button, checkbox as iced_checkbox, container as iced_container, pane_grid,
@@ -1471,5 +1472,17 @@ impl iced_widget::text_editor::Catalog for Theme {
                 selection,
             },
         }
+    }
+}
+
+#[cfg(feature = "markdown")]
+impl iced_widget::markdown::Catalog for Theme {
+    fn code_block<'a>() -> <Self as iced_container::Catalog>::Class<'a> {
+        Container::custom(|_| iced_container::Style {
+            background: Some(color!(0x111111).into()),
+            text_color: Some(Color::WHITE),
+            border: border::rounded(2),
+            ..iced_container::Style::default()
+        })
     }
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -361,3 +361,7 @@ pub mod tooltip {
 pub mod warning;
 #[doc(inline)]
 pub use warning::*;
+
+#[cfg(feature = "markdown")]
+#[doc(inline)]
+pub use iced::widget::markdown;


### PR DESCRIPTION
The `Catalog` implementation was copied from Iced (the `Catalog` api is a nightmare to understand)

Here is a screenshot of fan-control showcasing this feature

![Capture d’écran du 2024-11-07 01-14-32](https://github.com/user-attachments/assets/dabc095b-44d3-4243-bf8e-c07bd9cc3c6a)
