### PR TITLE
[Context Drawer] Add actions to header

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -469,6 +469,11 @@ where
         None
     }
 
+    /// App-specific actions at the start of the context drawer header
+    fn context_header_actions(&self) -> Vec<Element<Message<Self::Message>>> {
+        Vec::new()
+    }
+
     /// Displays a dialog in the center of the application window when `Some`.
     fn dialog(&self) -> Option<Element<Self::Message>> {
         None
@@ -834,6 +839,7 @@ impl<App: Application> ApplicationExt for App {
                         widgets.push(
                             context_drawer(
                                 &core.window.context_title,
+                                self.context_header_actions(),
                                 Message::Cosmic(cosmic::Message::ContextDrawer(false)),
                                 main_content,
                                 context.map(Message::App),
@@ -867,6 +873,7 @@ impl<App: Application> ApplicationExt for App {
                         widgets.push(
                             crate::widget::ContextDrawer::new_inner(
                                 &core.window.context_title,
+                                self.context_header_actions(),
                                 context.map(Message::App),
                                 Message::Cosmic(cosmic::Message::ContextDrawer(false)),
                                 context_width,

--- a/src/widget/context_drawer/mod.rs
+++ b/src/widget/context_drawer/mod.rs
@@ -12,7 +12,8 @@ use crate::Element;
 
 /// An overlayed widget that attaches a toggleable context drawer to the view.
 pub fn context_drawer<'a, Message: Clone + 'static, Content, Drawer>(
-    header: &'a str,
+    title: &'a str,
+    actions: Vec<Element<'a, Message>>,
     on_close: Message,
     content: Content,
     drawer: Drawer,
@@ -22,5 +23,5 @@ where
     Content: Into<Element<'a, Message>>,
     Drawer: Into<Element<'a, Message>>,
 {
-    ContextDrawer::new(header, content, drawer, on_close, max_width)
+    ContextDrawer::new(title, actions, content, drawer, on_close, max_width)
 }

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -67,7 +67,6 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
 
         let pane = column::with_capacity(2).push(header).push(
             container(drawer.into())
-                .padding([0, space_l, space_l, space_l])
                 .height(Length::Fill)
                 .width(Length::Shrink),
         );

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -1,9 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::widget::{
-    button, column, container, icon, row, scrollable, text, LayerContainer, Space,
-};
+use crate::widget::{button, column, container, icon, row, text, LayerContainer};
 use crate::{Apply, Element, Renderer, Theme};
 
 use super::overlay::Overlay;
@@ -26,7 +24,8 @@ pub struct ContextDrawer<'a, Message> {
 
 impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
     pub fn new_inner<Drawer>(
-        header: &'a str,
+        title: &'a str,
+        actions: Vec<Element<'a, Message>>,
         drawer: Drawer,
         on_close: Message,
         max_width: f32,
@@ -35,15 +34,28 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
         Drawer: Into<Element<'a, Message>>,
     {
         let cosmic_theme::Spacing {
-            space_m, space_l, ..
+            space_xxs,
+            space_m,
+            space_l,
+            ..
         } = crate::theme::active().cosmic().spacing;
+
+        let title_opt = if title.is_empty() {
+            None
+        } else {
+            Some(text::heading(title).width(Length::FillPortion(1)).center())
+        };
 
         let header = row::with_capacity(3)
             .width(Length::Fixed(480.0))
             .align_y(Alignment::Center)
             .padding([space_m, space_l])
-            .push(Space::new(Length::FillPortion(1), Length::Fixed(0.0)))
-            .push(text::heading(header).width(Length::FillPortion(1)).center())
+            .push(
+                row::with_children(actions)
+                    .spacing(space_xxs)
+                    .width(Length::FillPortion(1)),
+            )
+            .push_maybe(title_opt)
             .push(
                 button::text("Close")
                     .trailing_icon(icon::from_name("go-next-symbolic"))
@@ -78,7 +90,8 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
 
     /// Creates an empty [`ContextDrawer`].
     pub fn new<Content, Drawer>(
-        header: &'a str,
+        title: &'a str,
+        actions: Vec<Element<'a, Message>>,
         content: Content,
         drawer: Drawer,
         on_close: Message,
@@ -88,7 +101,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
         Content: Into<Element<'a, Message>>,
         Drawer: Into<Element<'a, Message>>,
     {
-        let drawer = Self::new_inner(header, drawer, on_close, max_width);
+        let drawer = Self::new_inner(title, actions, drawer, on_close, max_width);
 
         ContextDrawer {
             id: None,


### PR DESCRIPTION
This adds configurable actions to the left side of the context drawer header. Not sure if it would be better to make the title optional, since it needs to be wrapped in `text::heading()`, so it would need a similar check regardless.
Maybe fixes #625.
![screenshot-2024-11-09-19-37-20](https://github.com/user-attachments/assets/fca968eb-f98b-4e08-b52a-c2f236273fba)

Not quite sure why the scrollable for context drawer content was removed, since even those with only 1 item have to have a scrollbar at minimum vertical size. Every app will now have to also add `.padding([0, space_l, space_l, space_l])` to the content being added to a context drawer for each context drawer, in order for the scrollbar (if present) to be next to the edge of the drawer.
The second commit removes the built-in padding.