### PR TITLE
[Context drawer] Add optional header and footer element

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -71,13 +71,6 @@ use {
     zbus::{interface, proxy, zvariant::Value},
 };
 
-#[cfg(feature = "desktop")]
-use {
-    crate::widget,
-    iced::{alignment::Vertical, Alignment},
-    std::collections::BTreeMap,
-};
-
 pub(crate) fn iced_settings<App: Application>(
     settings: Settings,
     flags: App::Flags,
@@ -470,6 +463,16 @@ where
         Vec::new()
     }
 
+    /// Non-scrolling elements placed below the context drawer title row
+    fn context_drawer_header(&self) -> Option<Element<Message<Self::Message>>> {
+        None
+    }
+
+    /// Elements placed below the context drawer scrollable
+    fn context_drawer_footer(&self) -> Option<Element<Message<Self::Message>>> {
+        None
+    }
+
     /// Displays a dialog in the center of the application window when `Some`.
     fn dialog(&self) -> Option<Element<Self::Message>> {
         None
@@ -752,6 +755,8 @@ impl<App: Application> ApplicationExt for App {
                             context_drawer(
                                 &core.window.context_title,
                                 self.context_header_actions(),
+                                self.context_drawer_header(),
+                                self.context_drawer_footer(),
                                 Message::Cosmic(cosmic::Message::ContextDrawer(false)),
                                 main_content,
                                 context.map(Message::App),
@@ -786,6 +791,8 @@ impl<App: Application> ApplicationExt for App {
                             crate::widget::ContextDrawer::new_inner(
                                 &core.window.context_title,
                                 self.context_header_actions(),
+                                self.context_drawer_header(),
+                                self.context_drawer_footer(),
                                 context.map(Message::App),
                                 Message::Cosmic(cosmic::Message::ContextDrawer(false)),
                                 context_width,

--- a/src/widget/about.rs
+++ b/src/widget/about.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "desktop")]
 use {
     crate::{
-        iced::{alignment::Vertical, Alignment, Length},
+        iced::{Alignment, Length},
         widget::{self, horizontal_space},
         Element,
     },
@@ -124,7 +124,11 @@ pub fn about<'a, Message: Clone + 'static>(
     about: &'a About,
     on_url_press: impl Fn(String) -> Message,
 ) -> Element<'a, Message> {
-    let spacing = crate::theme::active().cosmic().spacing;
+    let cosmic_theme::Spacing {
+        space_xxs,
+        space_xs,
+        ..
+    } = crate::theme::active().cosmic().spacing;
 
     let section = |list: &'a Vec<(String, String)>, title: &'a str| {
         (!list.is_empty()).then_some({
@@ -138,8 +142,8 @@ pub fn about<'a, Message: Clone + 'static>(
                                 .push_maybe((!url.is_empty()).then_some(
                                     crate::widget::icon::from_name("link-symbolic").icon(),
                                 ))
-                                .padding(spacing.space_xxs)
-                                .align_y(Vertical::Center),
+                                .padding(space_xxs)
+                                .align_y(Alignment::Center),
                         )
                         .class(crate::theme::Button::Text)
                         .on_press(on_url_press(url.clone()))
@@ -176,8 +180,8 @@ pub fn about<'a, Message: Clone + 'static>(
                         url.is_some()
                             .then_some(crate::widget::icon::from_name("link-symbolic").icon()),
                     )
-                    .padding(spacing.space_xxs)
-                    .align_y(Vertical::Center),
+                    .padding(space_xxs)
+                    .align_y(Alignment::Center),
             )
             .class(crate::theme::Button::Text)
             .on_press(on_url_press(url.unwrap_or(String::new())))
@@ -187,25 +191,22 @@ pub fn about<'a, Message: Clone + 'static>(
     let copyright = about.copyright.as_ref().map(widget::text::body);
     let comments = about.comments.as_ref().map(widget::text::body);
 
-    widget::scrollable(
-        widget::column()
-            .push_maybe(application_icon)
-            .push_maybe(application_name)
-            .push_maybe(author)
-            .push_maybe(version)
-            .push_maybe(license)
-            .push_maybe(links_section)
-            .push_maybe(developers_section)
-            .push_maybe(designers_section)
-            .push_maybe(artists_section)
-            .push_maybe(translators_section)
-            .push_maybe(documenters_section)
-            .push_maybe(comments)
-            .push_maybe(copyright)
-            .align_x(Alignment::Center)
-            .spacing(spacing.space_xs)
-            .width(Length::Fill),
-    )
-    .spacing(spacing.space_xxxs)
-    .into()
+    widget::column()
+        .push_maybe(application_icon)
+        .push_maybe(application_name)
+        .push_maybe(author)
+        .push_maybe(version)
+        .push_maybe(license)
+        .push_maybe(links_section)
+        .push_maybe(developers_section)
+        .push_maybe(designers_section)
+        .push_maybe(artists_section)
+        .push_maybe(translators_section)
+        .push_maybe(documenters_section)
+        .push_maybe(comments)
+        .push_maybe(copyright)
+        .align_x(Alignment::Center)
+        .spacing(space_xs)
+        .width(Length::Fill)
+        .into()
 }

--- a/src/widget/context_drawer/mod.rs
+++ b/src/widget/context_drawer/mod.rs
@@ -13,7 +13,9 @@ use crate::Element;
 /// An overlayed widget that attaches a toggleable context drawer to the view.
 pub fn context_drawer<'a, Message: Clone + 'static, Content, Drawer>(
     title: &'a str,
-    actions: Vec<Element<'a, Message>>,
+    header_actions: Vec<Element<'a, Message>>,
+    header_opt: Option<Element<'a, Message>>,
+    footer_opt: Option<Element<'a, Message>>,
     on_close: Message,
     content: Content,
     drawer: Drawer,
@@ -23,5 +25,14 @@ where
     Content: Into<Element<'a, Message>>,
     Drawer: Into<Element<'a, Message>>,
 {
-    ContextDrawer::new(title, actions, content, drawer, on_close, max_width)
+    ContextDrawer::new(
+        title,
+        header_actions,
+        header_opt,
+        footer_opt,
+        content,
+        drawer,
+        on_close,
+        max_width,
+    )
 }


### PR DESCRIPTION
This adds an optional element placed below the title row, so that the rest of the content can be wrapped in a scrollable.
Example of the current (likely suboptimal) API:
```
fn context_header_opt(&self) -> Option<Element<message::Message<Self::Message>>> {
        match self.context_page {
            ContextPage::NetworkDrive => Some(
                widget::column::with_capacity(2)
                    .spacing(space_m)
                    .push(widget::text_input(
                        fl!("enter-server-address"),
                        &self.network_drive_input,
                    ))
                    .push(widget::text(fl!("network-drive-description")))
                    .into(),
            ),
            _ => None,
        }
    }
```
Draft until a possibly better API is devised, if feasible.