### PR TITLE
fix(list_column): broken sliders and flex row in cosmic-settings

### DIFF
--- a/src/widget/list/column.rs
+++ b/src/widget/list/column.rs
@@ -42,7 +42,7 @@ impl<'a, Message: 'static> ListColumn<'a, Message> {
 
         // Ensure a minimum height of 32.
         let list_item = iced::widget::row![
-            item.into(),
+            crate::widget::container(item).align_y(iced::Alignment::Center),
             crate::widget::vertical_space().height(iced::Length::Fixed(32.))
         ]
         .align_y(iced::Alignment::Center);


### PR DESCRIPTION
Fixes sliders and flex row widgets in cosmic-settings

Reference https://github.com/pop-os/cosmic-settings/pull/764