### PR TITLE
feat: ContextDrawer struct in Application trait

### DIFF
--- a/examples/about/Cargo.toml
+++ b/examples/about/Cargo.toml
@@ -24,4 +24,5 @@ features = [
     "wgpu",
     "single-instance",
     "multi-window",
+    "about",
 ]

--- a/examples/about/src/main.rs
+++ b/examples/about/src/main.rs
@@ -3,7 +3,7 @@
 
 //! Application API example
 
-use cosmic::app::context_drawer::{self, context_drawer, ContextDrawer};
+use cosmic::app::context_drawer::{self, ContextDrawer};
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::widget::column;
 use cosmic::iced_core::Size;

--- a/examples/about/src/main.rs
+++ b/examples/about/src/main.rs
@@ -110,8 +110,7 @@ impl cosmic::Application for App {
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
             Message::ToggleAbout => {
-                self.core.window.show_context = !self.core.window.show_context;
-                self.core.set_show_context(self.core.window.show_context);
+                self.set_show_context(!self.core.window.show_context);
                 self.show_about = !self.show_about;
             }
             Message::Open(url) => match open::that_detached(url) {

--- a/examples/about/src/main.rs
+++ b/examples/about/src/main.rs
@@ -3,6 +3,7 @@
 
 //! Application API example
 
+use cosmic::app::context_drawer::{context_drawer, ContextDrawer};
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::widget::column;
 use cosmic::iced_core::Size;
@@ -35,6 +36,7 @@ pub struct App {
     core: Core,
     nav_model: nav_bar::Model,
     about: About,
+    show_about: bool,
 }
 
 /// Implement [`cosmic::Application`] to integrate with COSMIC.
@@ -80,6 +82,7 @@ impl cosmic::Application for App {
             core,
             nav_model,
             about,
+            show_about: false,
         };
 
         let command = app.update_title();
@@ -98,20 +101,18 @@ impl cosmic::Application for App {
         self.update_title()
     }
 
-    fn context_drawer(&self) -> Option<Element<Self::Message>> {
-        if !self.core.window.show_context {
-            return None;
+    fn context_drawer(&self) -> Option<ContextDrawer<Self::Message>> {
+        match self.show_about {
+            true => Some(context_drawer(widget::about(&self.about, Message::Open), Message::ToggleAbout)),
+            false => None,
         }
-
-        Some(widget::about(&self.about, Message::Open))
     }
 
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
             Message::ToggleAbout => {
-                self.core.window.show_context = !self.core.window.show_context;
-                self.core.set_show_context(self.core.window.show_context)
+                self.show_about = !self.show_about;
             }
             Message::Open(url) => match open::that_detached(url) {
                 Ok(_) => (),

--- a/examples/about/src/main.rs
+++ b/examples/about/src/main.rs
@@ -3,7 +3,7 @@
 
 //! Application API example
 
-use cosmic::app::context_drawer::{context_drawer, ContextDrawer};
+use cosmic::app::context_drawer::{self, context_drawer, ContextDrawer};
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::widget::column;
 use cosmic::iced_core::Size;
@@ -102,16 +102,16 @@ impl cosmic::Application for App {
     }
 
     fn context_drawer(&self) -> Option<ContextDrawer<Self::Message>> {
-        match self.show_about {
-            true => Some(context_drawer(widget::about(&self.about, Message::Open), Message::ToggleAbout)),
-            false => None,
-        }
+        self.show_about
+            .then(|| context_drawer::about(&self.about, Message::Open, Message::ToggleAbout))
     }
 
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
             Message::ToggleAbout => {
+                self.core.window.show_context = !self.core.window.show_context;
+                self.core.set_show_context(self.core.window.show_context);
                 self.show_about = !self.show_about;
             }
             Message::Open(url) => match open::that_detached(url) {

--- a/src/app/context_drawer.rs
+++ b/src/app/context_drawer.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use crate::Element;
+
+pub struct ContextDrawer<'a, Message: Clone + 'static> {
+    pub title: Option<Cow<'a, str>>,
+    pub header_actions: Vec<Element<'a, Message>>,
+    pub header: Option<Element<'a, Message>>,
+    pub content: Element<'a, Message>,
+    pub footer: Option<Element<'a, Message>>,
+    pub on_close: Message,
+}
+
+pub fn context_drawer<'a, Message: Clone + 'static>(
+    content: impl Into<Element<'a, Message>>,
+    on_close: Message,
+) -> ContextDrawer<'a, Message> {
+    ContextDrawer {
+        title: None,
+        content: content.into(),
+        header_actions: vec![],
+        footer: None,
+        on_close,
+        header: None,
+    }
+}
+
+impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
+    /// Set a context drawer header title
+    pub fn title(mut self, title: impl Into<Cow<'a, str>>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+    /// App-specific actions at the start of the context drawer header
+    pub fn header_actions<E: Into<Element<'a, Message>>>(
+        mut self,
+        header_actions: impl IntoIterator<Item = E>,
+    ) -> Self {
+        self.header_actions = header_actions.into_iter().map(|a| a.into()).collect();
+        self
+    }
+    /// Non-scrolling elements placed below the context drawer title row
+    pub fn header(mut self, header: impl Into<Element<'a, Message>>) -> Self {
+        self.header = Some(header.into());
+        self
+    }
+
+    /// Elements placed below the context drawer scrollable
+    pub fn footer(mut self, footer: impl Into<Element<'a, Message>>) -> Self {
+        self.footer = Some(footer.into());
+        self
+    }
+}

--- a/src/app/context_drawer.rs
+++ b/src/app/context_drawer.rs
@@ -11,6 +11,15 @@ pub struct ContextDrawer<'a, Message: Clone + 'static> {
     pub on_close: Message,
 }
 
+#[cfg(feature = "about")]
+pub fn about<'a, Message: Clone + 'static>(
+    about: &'a crate::widget::about::About,
+    on_url_press: impl Fn(String) -> Message,
+    on_close: Message,
+) -> ContextDrawer<'a, Message> {
+    context_drawer(crate::widget::about(about, on_url_press), on_close)
+}
+
 pub fn context_drawer<'a, Message: Clone + 'static>(
     content: impl Into<Element<'a, Message>>,
     on_close: Message,

--- a/src/app/context_drawer.rs
+++ b/src/app/context_drawer.rs
@@ -41,9 +41,9 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
         self
     }
     /// App-specific actions at the start of the context drawer header
-    pub fn header_actions<E: Into<Element<'a, Message>>>(
+    pub fn header_actions(
         mut self,
-        header_actions: impl IntoIterator<Item = E>,
+        header_actions: impl IntoIterator<Item = Element<'a, Message>>,
     ) -> Self {
         self.header_actions = header_actions.into_iter().map(|a| a.into()).collect();
         self

--- a/src/app/context_drawer.rs
+++ b/src/app/context_drawer.rs
@@ -45,7 +45,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
         mut self,
         header_actions: impl IntoIterator<Item = Element<'a, Message>>,
     ) -> Self {
-        self.header_actions = header_actions.into_iter().map(|a| a.into()).collect();
+        self.header_actions = header_actions.into_iter().collect();
         self
     }
     /// Non-scrolling elements placed below the context drawer title row

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -26,8 +26,6 @@ pub struct NavBar {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone)]
 pub struct Window {
-    /// Label to display as context drawer title.
-    pub context_title: String,
     /// Label to display as header bar title.
     pub header_title: String,
     pub use_template: bool,
@@ -127,7 +125,6 @@ impl Default for Core {
                 })
                 .unwrap_or_default(),
             window: Window {
-                context_title: String::new(),
                 header_title: String::new(),
                 use_template: true,
                 content_container: true,
@@ -186,11 +183,6 @@ impl Core {
     pub(crate) fn set_scale_factor(&mut self, factor: f32) {
         self.scale_factor = factor;
         self.is_condensed_update();
-    }
-
-    /// Set context drawer header title
-    pub fn set_context_title(&mut self, title: String) {
-        self.window.context_title = title;
     }
 
     /// Set header bar title

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -454,6 +454,7 @@ where
     fn init(core: Core, flags: Self::Flags) -> (Self, Task<Self::Message>);
 
     /// Displays a context drawer on the side of the application window when `Some`.
+    /// Use the [`ApplicationExt::set_show_context`] function for this to take effect.
     fn context_drawer(&self) -> Option<ContextDrawer<Self::Message>> {
         None
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -733,30 +733,29 @@ impl<App: Application> ApplicationExt for App {
                 if core.window.context_is_overlay && core.window.show_context {
                     if let Some(context) = self.context_drawer() {
                         widgets.push(
-                            Element::from(
-                                crate::widget::context_drawer(
-                                    context.title,
-                                    context.header_actions,
-                                    context.header,
-                                    context.footer,
-                                    context.on_close,
-                                    main_content,
-                                    context.content,
-                                    context_width,
-                                )
-                                .apply(|drawer| {
-                                    Element::from(id_container(
-                                        drawer,
-                                        iced_core::id::Id::new("COSMIC_context_drawer"),
-                                    ))
-                                })
-                                .apply(container)
-                                .padding(if content_container {
-                                    [0, 8, 8, 0]
-                                } else {
-                                    [0, 0, 0, 0]
-                                }),
+                            crate::widget::context_drawer(
+                                context.title,
+                                context.header_actions,
+                                context.header,
+                                context.footer,
+                                context.on_close,
+                                main_content,
+                                context.content,
+                                context_width,
                             )
+                            .apply(|drawer| {
+                                Element::from(id_container(
+                                    drawer,
+                                    iced_core::id::Id::new("COSMIC_context_drawer"),
+                                ))
+                            })
+                            .apply(container)
+                            .padding(if content_container {
+                                [0, 8, 8, 0]
+                            } else {
+                                [0, 0, 0, 0]
+                            })
+                            .apply(Element::from)
                             .map(Message::App),
                         );
                     } else {
@@ -779,7 +778,7 @@ impl<App: Application> ApplicationExt for App {
                     );
                     if let Some(context) = self.context_drawer() {
                         widgets.push(
-                            Element::from(crate::widget::ContextDrawer::new_inner(
+                            crate::widget::ContextDrawer::new_inner(
                                 context.title,
                                 context.header_actions,
                                 context.header,
@@ -787,7 +786,8 @@ impl<App: Application> ApplicationExt for App {
                                 context.content,
                                 context.on_close,
                                 context_width,
-                            ))
+                            )
+                            .apply(Element::from)
                             .map(Message::App)
                             .apply(container)
                             .width(context_width)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -729,7 +729,7 @@ impl<App: Application> ApplicationExt for App {
 
                 //TODO: reduce duplication
                 let context_width = core.context_width(has_nav);
-                if core.window.context_is_overlay {
+                if core.window.context_is_overlay && core.window.show_context {
                     if let Some(context) = self.context_drawer() {
                         widgets.push(
                             Element::from(

--- a/src/widget/context_drawer/mod.rs
+++ b/src/widget/context_drawer/mod.rs
@@ -6,13 +6,15 @@
 mod overlay;
 
 mod widget;
+use std::borrow::Cow;
+
 pub use widget::ContextDrawer;
 
 use crate::Element;
 
 /// An overlayed widget that attaches a toggleable context drawer to the view.
 pub fn context_drawer<'a, Message: Clone + 'static, Content, Drawer>(
-    title: &'a str,
+    title: Option<Cow<'a, str>>,
     header_actions: Vec<Element<'a, Message>>,
     header_opt: Option<Element<'a, Message>>,
     footer_opt: Option<Element<'a, Message>>,

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use std::borrow::Cow;
+
 use crate::widget::{button, column, container, icon, row, scrollable, text, LayerContainer};
 use crate::{Apply, Element, Renderer, Theme};
 
@@ -24,7 +26,7 @@ pub struct ContextDrawer<'a, Message> {
 
 impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
     pub fn new_inner<Drawer>(
-        title: &'a str,
+        title: Option<Cow<'a, str>>,
         header_actions: Vec<Element<'a, Message>>,
         header_opt: Option<Element<'a, Message>>,
         footer_opt: Option<Element<'a, Message>>,
@@ -44,12 +46,6 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
             ..
         } = crate::theme::active().cosmic().spacing;
 
-        let title_opt = if title.is_empty() {
-            None
-        } else {
-            Some(text::heading(title).width(Length::FillPortion(1)).center())
-        };
-
         let horizontal_padding = if max_width < 392.0 { space_s } else { space_l };
 
         let header_row = row::with_capacity(3)
@@ -60,7 +56,9 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
                     .spacing(space_xxs)
                     .width(Length::FillPortion(1)),
             )
-            .push_maybe(title_opt)
+            .push_maybe(
+                title.map(|title| text::heading(title).width(Length::FillPortion(1)).center()),
+            )
             .push(
                 button::text("Close")
                     .trailing_icon(icon::from_name("go-next-symbolic"))
@@ -114,7 +112,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
 
     /// Creates an empty [`ContextDrawer`].
     pub fn new<Content, Drawer>(
-        title: &'a str,
+        title: Option<Cow<'a, str>>,
         header_actions: Vec<Element<'a, Message>>,
         header_opt: Option<Element<'a, Message>>,
         footer_opt: Option<Element<'a, Message>>,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -119,9 +119,9 @@ pub use color_picker::{ColorPicker, ColorPickerModel};
 #[doc(inline)]
 pub use iced::widget::qr_code;
 
-pub mod context_drawer;
+pub(crate) mod context_drawer;
 #[doc(inline)]
-pub use context_drawer::{context_drawer, ContextDrawer};
+pub(crate) use context_drawer::{context_drawer, ContextDrawer};
 
 #[doc(inline)]
 pub use column::{column, Column};

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -119,9 +119,9 @@ pub use color_picker::{ColorPicker, ColorPickerModel};
 #[doc(inline)]
 pub use iced::widget::qr_code;
 
-pub(crate) mod context_drawer;
+pub mod context_drawer;
 #[doc(inline)]
-pub(crate) use context_drawer::{context_drawer, ContextDrawer};
+pub use context_drawer::{context_drawer, ContextDrawer};
 
 #[doc(inline)]
 pub use column::{column, Column};


### PR DESCRIPTION
This pr implement the design from this comment https://github.com/pop-os/libcosmic/pull/699#issuecomment-2466828302.

It seems to works as expected, but i think it will cause problem, because in this design, the field `core.windows.show_context` is not meant to be changed. It is used in some calculation for responsiveness if i understand correctly.

Notably:
```rs
/// Call this whenever the scaling factor or window width has changed.
    #[allow(clippy::cast_precision_loss)]
    fn is_condensed_update(&mut self) {
        // Nav bar (280px) + padding (8px) + content (360px)
        let mut breakpoint = 280.0 + 8.0 + 360.0;
        //TODO: the app may return None from the context_drawer function even if show_context is true
        if self.window.show_context && !self.window.context_is_overlay {
            // Context drawer min width (344px) + padding (8px)
            breakpoint += 344.0 + 8.0;
        };
        self.is_condensed = (breakpoint * self.scale_factor) > self.window.width as f32;
        self.nav_bar_update();
    }
```

```rs
fn condensed_conflict(&self) -> bool {
        // There is a conflict if the view is condensed and both the nav bar and context drawer are open on the same layer
        self.is_condensed
            && self.nav_bar.toggled_condensed
            && self.window.show_context
            && !self.window.context_is_overlay
    }
```
and others.

I think it should be possible to only rely on the return type of `fn context_drawer(&self)` and `fn nav_bar(&self)` (and potentially others), to know how thing should be shown on screen, by moving this calculation in the view function.

cc @wash2 (i think some of this code come from you)