### PR TITLE
Move about widget to new about feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ name = "cosmic"
 default = ["multi-window"]
 # Accessibility support
 a11y = ["iced/a11y", "iced_accessibility"]
+# Enable about widget
+about = ["desktop", "dep:license"]
 # Builds support for animated images
 animated-image = ["image", "dep:async-fs", "tokio?/io-util", "tokio?/fs"]
 # XXX autosize should not be used on winit windows unless dialogs
@@ -40,7 +42,6 @@ desktop = [
     "process",
     "dep:freedesktop-desktop-entry",
     "dep:mime",
-    "dep:license",
     "dep:shlex",
     "tokio?/io-util",
     "tokio?/net",

--- a/src/widget/about.rs
+++ b/src/widget/about.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "desktop")]
 use {
     crate::{
         iced::{Alignment, Length},

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -366,8 +366,8 @@ pub use warning::*;
 #[doc(inline)]
 pub use iced::widget::markdown;
 
-#[cfg(feature = "desktop")]
+#[cfg(feature = "about")]
 pub mod about;
-#[cfg(feature = "desktop")]
+#[cfg(feature = "about")]
 #[doc(inline)]
 pub use about::about;


### PR DESCRIPTION
#697 added the license dependency, which requires `error_in_core`, which was only added in rust 1.82 released less than a month ago. Libcosmic targets a minimum rust version of 1.80. This PR makes a new about feature that brings in the license dependency, rather than having it part of the desktop feature.