### PR TITLE
feat: better a11y support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.80"
 name = "cosmic"
 
 [features]
-default = ["multi-window"]
+default = ["multi-window", "a11y"]
 # Accessibility support
 a11y = ["iced/a11y", "iced_accessibility"]
 # Enable about widget

--- a/src/widget/aspect_ratio.rs
+++ b/src/widget/aspect_ratio.rs
@@ -252,6 +252,17 @@ where
     ) -> Option<overlay::Element<'b, Message, crate::Theme, Renderer>> {
         self.container.overlay(tree, layout, renderer, translation)
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        self.container.a11y_nodes(layout, state, p)
+    }
 }
 
 impl<'a, Message, Renderer> From<AspectRatio<'a, Message, Renderer>>

--- a/src/widget/autosize.rs
+++ b/src/widget/autosize.rs
@@ -230,12 +230,9 @@ where
         renderer: &Renderer,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.content.as_widget_mut().overlay(
-            &mut tree.children[0],
-            layout.children().next().unwrap(),
-            renderer,
-            translation,
-        )
+        self.content
+            .as_widget_mut()
+            .overlay(&mut tree.children[0], layout, renderer, translation)
     }
 
     fn drag_destinations(
@@ -260,6 +257,19 @@ where
 
     fn set_id(&mut self, id: crate::widget::Id) {
         self.id = id;
+    }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_layout = layout.children().next().unwrap();
+        let c_state = &state.children[0];
+        self.content.as_widget().a11y_nodes(c_layout, c_state, p)
     }
 }
 

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -284,9 +284,8 @@ impl<'a, Message: Clone> Widget<Message, crate::Theme, Renderer> for ContextDraw
         state: &Tree,
         p: mouse::Cursor,
     ) -> iced_accessibility::A11yTree {
-        let c_layout = layout.children().next().unwrap();
         let c_state = &state.children[0];
-        self.content.as_widget().a11y_nodes(c_layout, c_state, p)
+        self.content.as_widget().a11y_nodes(layout, c_state, p)
     }
 
     fn drag_destinations(

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -251,6 +251,18 @@ impl<'a, Message: Clone> Widget<Message, crate::Theme, crate::Renderer>
             .overlay(),
         )
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: iced_core::Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_state = &state.children[0];
+        self.content.as_widget().a11y_nodes(layout, c_state, p)
+    }
 }
 
 impl<'a, Message: Clone + 'a> From<ContextMenu<'a, Message>> for crate::Element<'a, Message> {

--- a/src/widget/dnd_destination.rs
+++ b/src/widget/dnd_destination.rs
@@ -541,6 +541,18 @@ impl<'a, Message: 'static> Widget<Message, crate::Theme, crate::Renderer>
     fn set_id(&mut self, id: Id) {
         self.id = id;
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: iced_core::Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_state = &state.children[0];
+        self.container.as_widget().a11y_nodes(layout, c_state, p)
+    }
 }
 
 #[derive(Default)]

--- a/src/widget/dnd_source.rs
+++ b/src/widget/dnd_source.rs
@@ -381,6 +381,18 @@ impl<
     fn set_id(&mut self, id: Id) {
         self.id = id;
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: iced_core::Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_state = &state.children[0];
+        self.container.as_widget().a11y_nodes(layout, c_state, p)
+    }
 }
 
 impl<

--- a/src/widget/dropdown/widget.rs
+++ b/src/widget/dropdown/widget.rs
@@ -246,6 +246,17 @@ impl<'a, S: AsRef<str>, Message: 'a> Widget<Message, crate::Theme, crate::Render
             translation,
         )
     }
+
+    // #[cfg(feature = "a11y")]
+    // /// get the a11y nodes for the widget
+    // fn a11y_nodes(
+    //     &self,
+    //     layout: Layout<'_>,
+    //     state: &Tree,
+    //     p: mouse::Cursor,
+    // ) -> iced_accessibility::A11yTree {
+    //     // TODO
+    // }
 }
 
 impl<'a, S: AsRef<str>, Message: 'a> From<Dropdown<'a, S, Message>>

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -265,6 +265,23 @@ impl<'a, Message: Clone + 'static> Widget<Message, crate::Theme, crate::Renderer
             );
         }
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: iced_core::Layout<'_>,
+        state: &tree::Tree,
+        p: iced::mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_layout = layout.children().next().unwrap();
+        let c_state = &state.children[0];
+        let ret = self
+            .header_bar_inner
+            .as_widget()
+            .a11y_nodes(c_layout, c_state, p);
+        ret
+    }
 }
 
 impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {

--- a/src/widget/id_container.rs
+++ b/src/widget/id_container.rs
@@ -165,12 +165,9 @@ where
         renderer: &Renderer,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.content.as_widget_mut().overlay(
-            &mut tree.children[0],
-            layout.children().next().unwrap(),
-            renderer,
-            translation,
-        )
+        self.content
+            .as_widget_mut()
+            .overlay(&mut tree.children[0], layout, renderer, translation)
     }
 
     fn drag_destinations(
@@ -195,6 +192,19 @@ where
 
     fn set_id(&mut self, id: crate::widget::Id) {
         self.id = id;
+    }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_layout = layout.children().next().unwrap();
+        let c_state = &state.children[0];
+        self.content.as_widget().a11y_nodes(c_layout, c_state, p)
     }
 }
 

--- a/src/widget/layer_container.rs
+++ b/src/widget/layer_container.rs
@@ -274,6 +274,17 @@ where
     fn set_id(&mut self, id: crate::widget::Id) {
         self.container.set_id(id);
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: iced_core::Layout<'_>,
+        state: &Tree,
+        p: iced::mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        self.container.a11y_nodes(layout, state, p)
+    }
 }
 
 impl<'a, Message, Renderer> From<LayerContainer<'a, Message, Renderer>>

--- a/src/widget/popover.rs
+++ b/src/widget/popover.rs
@@ -273,6 +273,18 @@ where
             dnd_rectangles,
         );
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        let c_state = &state.children[0];
+        self.content.as_widget().a11y_nodes(layout, c_state, p)
+    }
 }
 
 impl<'a, Message, Renderer> From<Popover<'a, Message, Renderer>>

--- a/src/widget/rectangle_tracker/mod.rs
+++ b/src/widget/rectangle_tracker/mod.rs
@@ -309,6 +309,17 @@ where
         self.container
             .drag_destinations(state, layout, renderer, dnd_rectangles);
     }
+
+    #[cfg(feature = "a11y")]
+    /// get the a11y nodes for the widget
+    fn a11y_nodes(
+        &self,
+        layout: Layout<'_>,
+        state: &Tree,
+        p: mouse::Cursor,
+    ) -> iced_accessibility::A11yTree {
+        self.container.a11y_nodes(layout, state, p)
+    }
 }
 
 impl<'a, Message, Renderer, I> From<RectangleTrackingContainer<'a, Message, Renderer, I>>


### PR DESCRIPTION
This adds implementations to most libcosmic widgets missing them, and includes an iced fix that should allow libcosmic apps to produce a proper accessibility tree again.