### PR TITLE
refactor: add is_daemon setting

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -160,7 +160,7 @@ where
                     return Some(Message::WindowResize(id, width, height));
                 }
                 iced::Event::Window(window::Event::Closed) => {
-                    return Some(Message::SurfaceClosed(id))
+                    return Some(Message::SurfaceClosed(id));
                 }
                 iced::Event::Window(window::Event::Focused) => return Some(Message::Focus(id)),
                 iced::Event::Window(window::Event::Unfocused) => return Some(Message::Unfocus(id)),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -102,7 +102,8 @@ pub(crate) fn iced_settings<App: Application>(
     iced.default_font = settings.default_font;
     iced.default_text_size = iced::Pixels(settings.default_text_size);
     let exit_on_close = settings.exit_on_close;
-    iced.exit_on_close_request = exit_on_close;
+    iced.is_daemon = false;
+    iced.exit_on_close_request = settings.is_daemon;
     let mut window_settings = iced::window::Settings::default();
     window_settings.exit_on_close_request = exit_on_close;
     iced.id = Some(App::APP_ID.to_owned());

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -57,8 +57,11 @@ pub struct Settings {
     /// Whether the window should be transparent.
     pub(crate) transparent: bool,
 
-    /// Whether the application should exit when there are no open windows
+    /// Whether the application window should close when the exit button is pressed
     pub(crate) exit_on_close: bool,
+
+    /// Whether the application should act as a daemon
+    pub(crate) is_daemon: bool,
 }
 
 impl Settings {
@@ -92,6 +95,7 @@ impl Default for Settings {
             theme: crate::theme::system_preference(),
             transparent: true,
             exit_on_close: true,
+            is_daemon: true,
         }
     }
 }


### PR DESCRIPTION
The app can request to be treated by iced as a daemon so it can perform cleanup when its main window is closed.

This is necessary for the settings app at the moment.