### PR TITLE
Fix footer corner radius

### DIFF
--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -6,7 +6,6 @@
 use crate::theme::{CosmicComponent, Theme, TRANSPARENT_COMPONENT};
 use cosmic_theme::composite::over;
 use iced::{
-    border, color,
     overlay::menu,
     widget::{
         button as iced_button, checkbox as iced_checkbox, container as iced_container, pane_grid,
@@ -14,7 +13,6 @@ use iced::{
         slider::{self, Rail},
         svg, toggler,
     },
-    Gradient,
 };
 use iced_core::{Background, Border, Color, Shadow, Vector};
 use iced_widget::{pane_grid::Highlight, text_editor, text_input};
@@ -411,7 +409,7 @@ impl<'a> Container<'a> {
             text_color: Some(Color::from(theme.background.on)),
             background: Some(iced::Background::Color(theme.background.base.into())),
             border: Border {
-                radius: theme.corner_radii.radius_xs.into(),
+                radius: theme.corner_radii.radius_s.into(),
                 ..Default::default()
             },
             shadow: Shadow::default(),
@@ -425,7 +423,7 @@ impl<'a> Container<'a> {
             text_color: Some(Color::from(theme.primary.on)),
             background: Some(iced::Background::Color(theme.primary.base.into())),
             border: Border {
-                radius: theme.corner_radii.radius_xs.into(),
+                radius: theme.corner_radii.radius_s.into(),
                 ..Default::default()
             },
             shadow: Shadow::default(),
@@ -439,7 +437,7 @@ impl<'a> Container<'a> {
             text_color: Some(Color::from(theme.secondary.on)),
             background: Some(iced::Background::Color(theme.secondary.base.into())),
             border: Border {
-                radius: theme.corner_radii.radius_xs.into(),
+                radius: theme.corner_radii.radius_s.into(),
                 ..Default::default()
             },
             shadow: Shadow::default(),
@@ -531,13 +529,7 @@ impl iced_container::Catalog for Theme {
             }
 
             Container::ContextDrawer => {
-                let mut appearance = crate::style::Container::primary(cosmic);
-
-                appearance.border = Border {
-                    color: cosmic.primary.divider.into(),
-                    width: 0.0,
-                    radius: cosmic.corner_radii.radius_s.into(),
-                };
+                let mut appearance = Container::primary(cosmic);
 
                 appearance.shadow = Shadow {
                     color: cosmic.shade.into(),

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -39,7 +39,6 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
     {
         let cosmic_theme::Spacing {
             space_xxs,
-            space_xs,
             space_s,
             space_m,
             space_l,
@@ -78,7 +77,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
             container(element)
                 .width(Length::Fixed(480.0))
                 .align_y(Alignment::Center)
-                .padding([space_xs, horizontal_padding])
+                .padding([space_xxs, horizontal_padding])
         });
         let pane = column::with_capacity(3)
             .push(header)


### PR DESCRIPTION
This makes the primary container style use `radius_s`, instead of `radius_xs`, which matches the radius of the footer to the designs.
Also fixes the vertical padding of the `context_drawer` footer.

Since other container styles also used `radius_xs`, I also changed them for consistency.
Testing with `cosmic-files`, I didn't notice anything unusual from this change, but not sure if this should be done, or if the footer should use a custom style (though there isn't a `Custom` Layer enum).