### PR TITLE
Fixed issue #700 where multi-window was required for window header to be interactable

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -142,6 +142,7 @@ pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Res
     let (settings, mut flags, window_settings) = iced_settings::<App>(settings, flags);
     #[cfg(not(feature = "multi-window"))]
     {
+        flags.0.main_window = Some(iced::window::Id::RESERVED);
         iced::application(
             cosmic::Cosmic::title,
             cosmic::Cosmic::update,


### PR DESCRIPTION
It seems that the reason behind issue #700 is that when iced_settings is being called in app::run, in the multi-window version it sets the main_window flag in the iced settings but it wasn't doing that in the standard version