### PR TITLE
Changed cosmic::command to cosmic::task, and made cosmic::Task consistent with cosmic::app::Task

### DIFF
--- a/examples/about/src/main.rs
+++ b/examples/about/src/main.rs
@@ -61,7 +61,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _flags: Self::Flags) -> (Self, Task<Self::Message>) {
         let nav_model = nav_bar::Model::default();
 

--- a/examples/application/src/main.rs
+++ b/examples/application/src/main.rs
@@ -89,7 +89,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, input: Self::Flags) -> (Self, Task<Self::Message>) {
         let mut nav_model = nav_bar::Model::default();
 

--- a/examples/calendar/src/main.rs
+++ b/examples/calendar/src/main.rs
@@ -49,7 +49,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let now = Local::now();
 

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -64,7 +64,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let mut app = App {
             core,

--- a/examples/image-button/src/main.rs
+++ b/examples/image-button/src/main.rs
@@ -50,7 +50,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let mut app = App {
             core,

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -96,7 +96,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let app = App {
             core,

--- a/examples/nav-context/src/main.rs
+++ b/examples/nav-context/src/main.rs
@@ -105,7 +105,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, input: Self::Flags) -> (Self, Task<Self::Message>) {
         let mut nav_model = nav_bar::Model::default();
 

--- a/examples/open-dialog/src/main.rs
+++ b/examples/open-dialog/src/main.rs
@@ -65,7 +65,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let id = core.main_window_id().unwrap();
         let mut app = App {
@@ -109,7 +109,7 @@ impl cosmic::Application for App {
                 self.set_header_title(url.to_string());
 
                 // Reads the selected file into memory.
-                return cosmic::command::future(async move {
+                return cosmic::task::future(async move {
                     // Check if its a valid local file path.
                     let path = match url.scheme() {
                         "file" => url.to_file_path().unwrap(),
@@ -145,7 +145,7 @@ impl cosmic::Application for App {
 
             // Creates a new open dialog.
             Message::OpenFile => {
-                return cosmic::command::future(async move {
+                return cosmic::task::future(async move {
                     eprintln!("opening new dialog");
 
                     #[cfg(feature = "rfd")]

--- a/examples/text-input/src/main.rs
+++ b/examples/text-input/src/main.rs
@@ -54,7 +54,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
         let mut app = App {
             core,

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -9,19 +9,19 @@ use super::Message;
 /// Commands for COSMIC applications.
 pub type Task<M> = iced::Task<Message<M>>;
 
-/// Creates a command which yields a [`crate::app::Message`].
+/// Creates a task which yields a [`crate::app::Message`].
 pub fn message<M: Send + 'static>(message: Message<M>) -> Task<M> {
-    crate::command::message(message)
+    crate::task::message(message)
 }
 
 /// Convenience methods for building message-based commands.
 pub mod message {
-    /// Creates a command which yields an application message.
+    /// Creates a task which yields an application message.
     pub fn app<M: Send + 'static>(message: M) -> crate::app::Task<M> {
         super::message(super::Message::App(message))
     }
 
-    /// Creates a command which yields a cosmic message.
+    /// Creates a task which yields a cosmic message.
     pub fn cosmic<M: Send + 'static>(message: crate::app::cosmic::Message) -> crate::app::Task<M> {
         super::message(super::Message::Cosmic(message))
     }
@@ -32,7 +32,7 @@ impl crate::app::Core {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::drag(id).map(Message::Cosmic)
+        crate::task::drag(id).map(Message::Cosmic)
     }
 
     pub fn maximize<M: Send + 'static>(
@@ -43,14 +43,14 @@ impl crate::app::Core {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::maximize(id, maximized).map(Message::Cosmic)
+        crate::task::maximize(id, maximized).map(Message::Cosmic)
     }
 
     pub fn minimize<M: Send + 'static>(&self, id: Option<window::Id>) -> iced::Task<Message<M>> {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::minimize(id).map(Message::Cosmic)
+        crate::task::minimize(id).map(Message::Cosmic)
     }
 
     pub fn set_scaling_factor<M: Send + 'static>(&self, factor: f32) -> iced::Task<Message<M>> {
@@ -65,7 +65,7 @@ impl crate::app::Core {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::set_title(id, title).map(Message::Cosmic)
+        crate::task::set_title(id, title).map(Message::Cosmic)
     }
 
     pub fn set_windowed<M: Send + 'static>(
@@ -75,7 +75,7 @@ impl crate::app::Core {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::set_windowed(id).map(Message::Cosmic)
+        crate::task::set_windowed(id).map(Message::Cosmic)
     }
 
     pub fn toggle_maximize<M: Send + 'static>(
@@ -85,7 +85,7 @@ impl crate::app::Core {
         let Some(id) = id.or(self.main_window) else {
             return iced::Task::none();
         };
-        crate::command::toggle_maximize(id).map(Message::Cosmic)
+        crate::task::toggle_maximize(id).map(Message::Cosmic)
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -452,7 +452,7 @@ where
     /// Grants access to the COSMIC Core.
     fn core_mut(&mut self) -> &mut Core;
 
-    /// Creates the application, and optionally emits command on initialize.
+    /// Creates the application, and optionally emits task on initialize.
     fn init(core: Core, flags: Self::Flags) -> (Self, Task<Self::Message>);
 
     /// Displays a context drawer on the side of the application window when `Some`.

--- a/src/dialog/file_chooser/mod.rs
+++ b/src/dialog/file_chooser/mod.rs
@@ -11,7 +11,7 @@
 //! # Open a file
 //!
 //! ```no_run
-//! cosmic::command::future(async {
+//! cosmic::task::future(async {
 //!     use cosmic::dialog::file_chooser;
 //!
 //!     let dialog = file_chooser::open::Dialog::new()
@@ -30,7 +30,7 @@
 //! # Open multiple files
 //!
 //! ```no_run
-//! cosmic::command::future(async {
+//! cosmic::task::future(async {
 //!     use cosmic::dialog::file_chooser;
 //!
 //!     let dialog = file_chooser::open::Dialog::new()
@@ -49,7 +49,7 @@
 //! # Open a folder
 //!
 //! ```no_run
-//! cosmic::command::future(async {
+//! cosmic::task::future(async {
 //!     use cosmic::dialog::file_chooser;
 //!
 //!     let dialog = file_chooser::open::Dialog::new()
@@ -68,7 +68,7 @@
 //! # Open multiple folders
 //!
 //! ```no_run
-//! cosmic::command::future(async {
+//! cosmic::task::future(async {
 //!     use cosmic::dialog::file_chooser;
 //!
 //!     let dialog = file_chooser::open::Dialog::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ pub use app::{Application, ApplicationExt};
 #[cfg(feature = "applet")]
 pub mod applet;
 
+#[cfg(feature = "winit")]
 pub use app::Task;
+
 pub mod task;
 
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ pub use app::{Application, ApplicationExt};
 #[cfg(feature = "applet")]
 pub mod applet;
 
-pub use iced::Task;
-pub mod command;
+pub use app::Task;
+pub mod task;
 
 pub mod config;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,19 +9,19 @@ use iced_core::window::Mode;
 use iced_runtime::{task, Action};
 use std::future::Future;
 
-/// Yields a command which contains a batch of commands.
+/// Yields a task which contains a batch of tasks.
 pub fn batch<X: Send + 'static + Into<Y>, Y: Send + 'static>(
-    commands: impl IntoIterator<Item = Task<X>>,
+    tasks: impl IntoIterator<Item = Task<X>>,
 ) -> Task<Y> {
-    Task::batch(commands).map(Into::into)
+    Task::batch(tasks).map(Into::into)
 }
 
-/// Yields a command which will run the future on the runtime executor.
+/// Yields a task which will run the future on the runtime executor.
 pub fn future<X: Into<Y>, Y: 'static>(future: impl Future<Output = X> + Send + 'static) -> Task<Y> {
     Task::future(async move { future.await.into() })
 }
 
-/// Yields a command which will return a message.
+/// Yields a task which will return a message.
 pub fn message<X: Send + 'static + Into<Y>, Y: 'static>(message: X) -> Task<Y> {
     future(async move { message.into() })
 }

--- a/src/widget/toaster/mod.rs
+++ b/src/widget/toaster/mod.rs
@@ -193,7 +193,7 @@ impl<Message: Clone + Send + 'static> Toasts<Message> {
         #[cfg(feature = "tokio")]
         {
             let on_close = self.on_close;
-            crate::command::future(async move {
+            crate::task::future(async move {
                 tokio::time::sleep(duration).await;
                 on_close(id)
             })


### PR DESCRIPTION
This changes the cosmic::command module to cosmic::task ever since the change from Command to Task, and also fixes an inconsistency where cosmic::Task was a re-export of iced::Task while cosmic::app::Task was a different type alias