### PR TITLE
Add set_handle method

### DIFF
--- a/examples/image/Cargo.toml
+++ b/examples/image/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "image"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+
+[dependencies.libcosmic]
+path = "../../"
+default-features = false
+features = ["debug", "winit", "wgpu", "tokio"]

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -1,0 +1,105 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Application API example
+
+use cosmic::app::{Core, Settings, Task};
+use cosmic::{executor, iced, widget, ApplicationExt, Element};
+
+/// Runs application with these settings
+#[rustfmt::skip]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cosmic::app::run::<App>(Settings::default(), ())?;
+
+    Ok(())
+}
+
+/// Messages that are used specifically by our [`App`].
+#[derive(Clone, Debug)]
+pub enum Message {
+    SetAlternateHandle,
+}
+
+/// The [`App`] stores application-specific state.
+pub struct App {
+    core: Core,
+}
+
+/// Implement [`cosmic::Application`] to integrate with COSMIC.
+impl cosmic::Application for App {
+    /// Default async executor to use with the app.
+    type Executor = executor::Default;
+
+    /// Argument received [`cosmic::Application::new`].
+    type Flags = ();
+
+    /// Message type specific to our [`App`].
+    type Message = Message;
+
+    /// The unique application ID to supply to the window manager.
+    const APP_ID: &'static str = "org.cosmic.AppDemo";
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    /// Creates the application, and optionally emits task on initialize.
+    fn init(core: Core, _input: Self::Flags) -> (Self, Task<Self::Message>) {
+        let mut app = App { core };
+
+        let command = app.update_title();
+
+        (app, command)
+    }
+
+    /// Handle application events here.
+    fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
+        match message {
+            Message::SetAlternateHandle => {
+                let path = "/usr/share/backgrounds/pop/nick-nazzaro-ice-cave.png";
+                Task::batch(vec![cosmic::widget::image::set_handle(
+                    widget::Id::new(path.clone()),
+                    path,
+                )])
+            }
+        }
+    }
+
+    /// Creates a view after each update.
+    fn view(&self) -> Element<Self::Message> {
+        let mut content = cosmic::widget::column().spacing(12);
+        let path = "/usr/share/backgrounds/pop/kait-herzog-8242.jpg";
+        content = content.push(
+            cosmic::widget::button::custom(
+                cosmic::widget::image::image(path).id(widget::Id::new(path.clone())),
+            )
+            .width(300.0),
+        );
+
+        content = content.push(
+            widget::button::text("Set alternate handle").on_press(Message::SetAlternateHandle),
+        );
+
+        let centered = cosmic::widget::container(content)
+            .width(iced::Length::Fill)
+            .height(iced::Length::Shrink)
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center);
+
+        Element::from(centered)
+    }
+}
+
+impl App
+where
+    Self: cosmic::Application,
+{
+    fn update_title(&mut self) -> Task<Message> {
+        self.set_header_title(String::from("Image Button Demo"));
+        self.set_window_title(String::from("Image Button Demo"))
+    }
+}

--- a/src/widget/button/image.rs
+++ b/src/widget/button/image.rs
@@ -14,7 +14,7 @@ pub type Button<'a, Message> = Builder<'a, Message, Image<'a, Handle, Message>>;
 /// A button constructed from an image handle, using image button styling.
 pub fn image<'a, Message>(handle: impl Into<Handle> + 'a) -> Button<'a, Message> {
     Button::new(Image {
-        image: widget::image(handle).border_radius([9.0; 4]),
+        image: widget::image::image(handle).border_radius([9.0; 4]),
         selected: false,
         on_remove: None,
     })
@@ -22,7 +22,7 @@ pub fn image<'a, Message>(handle: impl Into<Handle> + 'a) -> Button<'a, Message>
 
 /// The image variant of a button.
 pub struct Image<'a, Handle, Message> {
-    image: widget::Image<'a, Handle>,
+    image: widget::image::Image<'a, Handle>,
     selected: bool,
     on_remove: Option<Message>,
 }

--- a/src/widget/image.rs
+++ b/src/widget/image.rs
@@ -1,0 +1,19 @@
+#[doc(inline)]
+pub use iced::widget::{image, image::*, Image};
+
+#[cfg(feature = "winit")]
+use {
+    crate::app::Task,
+    iced_accessibility::Id,
+    iced_core::widget::operation,
+    iced_runtime::{task, Action},
+};
+
+#[cfg(feature = "winit")]
+/// Produces a [`Task`] that sets a new [`Handle`] to the [`Image`] with the given [`Id`].
+pub fn set_handle<Message: 'static>(id: Id, handle: impl Into<image::Handle>) -> Task<Message> {
+    task::effect(Action::widget(operation::image::set_handle(
+        id,
+        handle.into(),
+    )))
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -62,8 +62,7 @@ pub use iced::widget::{container, Container};
 #[doc(inline)]
 pub use iced::widget::{horizontal_space, vertical_space, Space};
 
-#[doc(inline)]
-pub use iced::widget::{image, Image};
+pub mod image;
 
 #[doc(inline)]
 pub use iced::widget::{lazy, Lazy};


### PR DESCRIPTION
This pull request includes the addition of a new task for setting image handles.

* [`src/widget/image.rs`](diffhunk://#diff-6eed5740c84d386755bd8cbcfdaf7e7b648d05299a2e2930f21e3283ad66412eR1-R19): Added a new function `set_handle` that produces a `Task` to set a new `Handle` to the `Image` with the given `Id`.
* [`src/widget/mod.rs`](diffhunk://#diff-3eb28120d4163ba7585d5973ad960bf586a58fe056ce2a1ffad561547704cc74L65-R65): Moved the `image` module to its own sub-module to add `set_handle`.

Must be merged after https://github.com/pop-os/iced/pull/199 and rebased iced changes.