### PR TITLE
Partially undo #732

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -882,30 +882,7 @@ impl<App: Application> ApplicationExt for App {
                         header = header.end(element.map(Message::App));
                     }
 
-                    header
-                        // Needed for apps without a content container, but with a header bar
-                        .apply(container)
-                        .style(move |theme| container::Style {
-                            background: if content_container {
-                                None
-                            } else {
-                                Some(iced::Background::Color(
-                                    theme.cosmic().background.base.into(),
-                                ))
-                            },
-                            border: iced::Border {
-                                radius: [
-                                    theme.cosmic().radius_s()[0] - 1.0,
-                                    theme.cosmic().radius_s()[1] - 1.0,
-                                    theme.cosmic().radius_0()[2],
-                                    theme.cosmic().radius_0()[3],
-                                ]
-                                .into(),
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                        .apply(|w| id_container(w, iced_core::id::Id::new("COSMIC_header")))
+                    header.apply(|w| id_container(w, iced_core::id::Id::new("COSMIC_header")))
                 })
             } else {
                 None

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -469,8 +469,17 @@ impl iced_container::Catalog for Theme {
             Container::WindowBackground => iced_container::Style {
                 icon_color: Some(Color::from(cosmic.background.on)),
                 text_color: Some(Color::from(cosmic.background.on)),
-                background: None,
-                border: Border::default(),
+                background: Some(iced::Background::Color(cosmic.background.base.into())),
+                border: Border {
+                    radius: [
+                        cosmic.corner_radii.radius_0[0],
+                        cosmic.corner_radii.radius_0[1],
+                        cosmic.corner_radii.radius_s[2],
+                        cosmic.corner_radii.radius_s[3],
+                    ]
+                    .into(),
+                    ..Default::default()
+                },
                 shadow: Shadow::default(),
             },
 
@@ -504,8 +513,17 @@ impl iced_container::Catalog for Theme {
                 iced_container::Style {
                     icon_color: Some(icon_color),
                     text_color: Some(text_color),
-                    background: None,
-                    border: Border::default(),
+                    background: Some(iced::Background::Color(cosmic.background.base.into())),
+                    border: Border {
+                        radius: [
+                            cosmic.corner_radii.radius_s[0],
+                            cosmic.corner_radii.radius_s[1],
+                            cosmic.corner_radii.radius_0[2],
+                            cosmic.corner_radii.radius_0[3],
+                        ]
+                        .into(),
+                        ..Default::default()
+                    },
                     shadow: Shadow::default(),
                 }
             }


### PR DESCRIPTION
This undoes the style changes in #732, since they aren't necessary, and makes stuff less messy and less of a breaking change in some cases (like `cosmic-files-applet` windows).
The added background for the app container is enough to make the borders look good.

Not sure what to call the commit, so I just called it `fix`.