### PR TITLE
Fix segmented button model index out of bounds when setting position

### DIFF
--- a/src/widget/segmented_button/model/mod.rs
+++ b/src/widget/segmented_button/model/mod.rs
@@ -355,9 +355,10 @@ where
             return None;
         };
 
+        self.order.remove(index as usize);
+        
         let position = self.order.len().min(position as usize);
 
-        self.order.remove(index as usize);
         self.order.insert(position, id);
         Some(position)
     }

--- a/src/widget/segmented_button/model/mod.rs
+++ b/src/widget/segmented_button/model/mod.rs
@@ -356,7 +356,7 @@ where
         };
 
         self.order.remove(index as usize);
-        
+
         let position = self.order.len().min(position as usize);
 
         self.order.insert(position, id);


### PR DESCRIPTION
When trying to set position greater then length of the Deque, the method fallbacks to position equal to the Deque length. However, that value changes immediately after getting this fallbacked position with removal of the item (to prepare it for re-instert) and as a result the code panics with index out of bounds error.

Reordering of the code fixes this issue.