### PR TITLE
fix: switch to cosmic fork of freedesktop-icons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ slotmap = "1.0.6"
 smol = { version = "2.0.0", optional = true }
 thiserror = "1.0.44"
 tokio = { version = "1.24.2", optional = true }
-tracing = "0.1"
+tracing = "0.1.41"
 unicode-segmentation = "1.6"
 url = "2.4.0"
 ustr = { version = "1.0.0", features = ["serde"] }
 zbus = { version = "4.2.1", default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
-freedesktop-icons = "0.2.5"
+freedesktop-icons = { package = "cosmic-freedesktop-icons", git = "https://github.com/pop-os/freedesktop-icons" }
 freedesktop-desktop-entry = { version = "0.5.1", optional = true }
 shlex = { version = "1.3.0", optional = true }
 


### PR DESCRIPTION
Switch to a fork that we maintain, which contains a few fixes that haven't been merged upstream yet.

https://github.com/pop-os/freedesktop-icons/commits/main/