### PR TITLE
Use `radius_s` for NavBar toggle

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -703,11 +703,14 @@ impl<App: Application> ApplicationExt for App {
             .focused_window()
             .is_some_and(|i| Some(i) == self.core().main_window_id());
 
+        // Offset for the window border
+        let window_padding = if sharp_corners { 8 } else { 7 };
+
         let main_content_padding = if content_container {
             if nav_bar_active {
-                [0, 8, 8, 0]
+                [0, window_padding, window_padding, 0]
             } else {
-                [0, 8, 8, 8]
+                [0, window_padding, window_padding, window_padding]
             }
         } else {
             [0, 0, 0, 0]
@@ -721,7 +724,11 @@ impl<App: Application> ApplicationExt for App {
                 .nav_bar()
                 .map(|nav| id_container(nav, iced_core::id::Id::new("COSMIC_nav_bar")))
             {
-                widgets.push(container(nav).padding([0, 8, 8, 8]).into());
+                widgets.push(
+                    container(nav)
+                        .padding([0, window_padding, window_padding, window_padding])
+                        .into(),
+                );
                 true
             } else {
                 false
@@ -753,7 +760,7 @@ impl<App: Application> ApplicationExt for App {
                             })
                             .apply(container)
                             .padding(if content_container {
-                                [0, 8, 8, 0]
+                                [0, window_padding, window_padding, 0]
                             } else {
                                 [0, 0, 0, 0]
                             })
@@ -801,7 +808,7 @@ impl<App: Application> ApplicationExt for App {
                             })
                             .apply(container)
                             .padding(if content_container {
-                                [0, 8, 8, 0]
+                                [0, window_padding, window_padding, 0]
                             } else {
                                 [0, 0, 0, 0]
                             })
@@ -818,10 +825,14 @@ impl<App: Application> ApplicationExt for App {
         });
         let content_col = crate::widget::column::with_capacity(2)
             .push(content_row)
-            .push_maybe(
-                self.footer()
-                    .map(|footer| container(footer.map(Message::App)).padding([0, 8, 8, 8])),
-            );
+            .push_maybe(self.footer().map(|footer| {
+                container(footer.map(Message::App)).padding([
+                    0,
+                    window_padding,
+                    window_padding,
+                    window_padding,
+                ])
+            }));
         let content: Element<_> = if core.window.content_container {
             content_col
                 .apply(container)
@@ -840,6 +851,7 @@ impl<App: Application> ApplicationExt for App {
                     let mut header = crate::widget::header_bar()
                         .focused(focused)
                         .title(&core.window.header_title)
+                        .horizontal_padding(window_padding)
                         .on_drag(Message::Cosmic(cosmic::Message::Drag))
                         .on_right_click(Message::Cosmic(cosmic::Message::ShowWindowMenu))
                         .on_double_click(Message::Cosmic(cosmic::Message::Maximize));
@@ -852,8 +864,7 @@ impl<App: Application> ApplicationExt for App {
                                 Message::Cosmic(cosmic::Message::ToggleNavBarCondensed)
                             } else {
                                 Message::Cosmic(cosmic::Message::ToggleNavBar)
-                            })
-                            .class(crate::theme::Button::HeaderBar);
+                            });
 
                         header = header.start(toggle);
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -703,14 +703,11 @@ impl<App: Application> ApplicationExt for App {
             .focused_window()
             .is_some_and(|i| Some(i) == self.core().main_window_id());
 
-        // Offset for the window border
-        let window_padding = if sharp_corners { 8 } else { 7 };
-
         let main_content_padding = if content_container {
             if nav_bar_active {
-                [0, window_padding, window_padding, 0]
+                [0, 8, 8, 0]
             } else {
-                [0, window_padding, window_padding, window_padding]
+                [0, 8, 8, 8]
             }
         } else {
             [0, 0, 0, 0]
@@ -724,11 +721,7 @@ impl<App: Application> ApplicationExt for App {
                 .nav_bar()
                 .map(|nav| id_container(nav, iced_core::id::Id::new("COSMIC_nav_bar")))
             {
-                widgets.push(
-                    container(nav)
-                        .padding([0, window_padding, window_padding, window_padding])
-                        .into(),
-                );
+                widgets.push(container(nav).padding([0, 8, 8, 8]).into());
                 true
             } else {
                 false
@@ -760,7 +753,7 @@ impl<App: Application> ApplicationExt for App {
                             })
                             .apply(container)
                             .padding(if content_container {
-                                [0, window_padding, window_padding, 0]
+                                [0, 8, 8, 0]
                             } else {
                                 [0, 0, 0, 0]
                             })
@@ -808,7 +801,7 @@ impl<App: Application> ApplicationExt for App {
                             })
                             .apply(container)
                             .padding(if content_container {
-                                [0, window_padding, window_padding, 0]
+                                [0, 8, 8, 0]
                             } else {
                                 [0, 0, 0, 0]
                             })
@@ -825,14 +818,10 @@ impl<App: Application> ApplicationExt for App {
         });
         let content_col = crate::widget::column::with_capacity(2)
             .push(content_row)
-            .push_maybe(self.footer().map(|footer| {
-                container(footer.map(Message::App)).padding([
-                    0,
-                    window_padding,
-                    window_padding,
-                    window_padding,
-                ])
-            }));
+            .push_maybe(
+                self.footer()
+                    .map(|footer| container(footer.map(Message::App)).padding([0, 8, 8, 8])),
+            );
         let content: Element<_> = if core.window.content_container {
             content_col
                 .apply(container)
@@ -851,7 +840,6 @@ impl<App: Application> ApplicationExt for App {
                     let mut header = crate::widget::header_bar()
                         .focused(focused)
                         .title(&core.window.header_title)
-                        .horizontal_padding(window_padding)
                         .on_drag(Message::Cosmic(cosmic::Message::Drag))
                         .on_right_click(Message::Cosmic(cosmic::Message::ShowWindowMenu))
                         .on_double_click(Message::Cosmic(cosmic::Message::Maximize));

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -14,13 +14,13 @@ use crate::{
 #[derive(Default)]
 pub enum Button {
     AppletIcon,
+    AppletMenu,
     Custom {
         active: Box<dyn Fn(bool, &crate::Theme) -> Style>,
         disabled: Box<dyn Fn(&crate::Theme) -> Style>,
         hovered: Box<dyn Fn(bool, &crate::Theme) -> Style>,
         pressed: Box<dyn Fn(bool, &crate::Theme) -> Style>,
     },
-    AppletMenu,
     Destructive,
     HeaderBar,
     Icon,
@@ -31,6 +31,7 @@ pub enum Button {
     MenuFolder,
     MenuItem,
     MenuRoot,
+    NavToggle,
     #[default]
     Standard,
     Suggested,
@@ -73,7 +74,7 @@ pub fn appearance(
             }
         }
 
-        Button::Icon | Button::IconVertical | Button::HeaderBar => {
+        Button::Icon | Button::IconVertical | Button::HeaderBar | Button::NavToggle => {
             if matches!(style, Button::IconVertical) {
                 corner_radii = &cosmic.corner_radii.radius_m;
                 if selected {
@@ -81,6 +82,9 @@ pub fn appearance(
                         cosmic.icon_button.selected_state_color(),
                     )));
                 }
+            }
+            if matches!(style, Button::NavToggle) {
+                corner_radii = &cosmic.corner_radii.radius_s;
             }
 
             let (background, text, icon) = color(&cosmic.icon_button);

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -528,17 +528,7 @@ impl iced_container::Catalog for Theme {
                 }
             }
 
-            Container::ContextDrawer => {
-                let mut appearance = Container::primary(cosmic);
-
-                appearance.shadow = Shadow {
-                    color: cosmic.shade.into(),
-                    offset: Vector::new(0.0, 0.0),
-                    blur_radius: 16.0,
-                };
-
-                appearance
-            }
+            Container::ContextDrawer => Container::primary(cosmic),
 
             Container::Background => Container::background(cosmic),
 

--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -536,20 +536,17 @@ impl iced_container::Catalog for Theme {
 
             Container::Secondary => Container::secondary(cosmic),
 
-            Container::Dropdown => {
-                let theme = self.cosmic();
-
-                iced_container::Style {
-                    icon_color: None,
-                    text_color: None,
-                    background: Some(iced::Background::Color(theme.primary.base.into())),
-                    border: Border {
-                        radius: cosmic.corner_radii.radius_xs.into(),
-                        ..Default::default()
-                    },
-                    shadow: Shadow::default(),
-                }
-            }
+            Container::Dropdown => iced_container::Style {
+                icon_color: None,
+                text_color: None,
+                background: Some(iced::Background::Color(cosmic.bg_component_color().into())),
+                border: Border {
+                    color: cosmic.bg_component_divider().into(),
+                    width: 1.0,
+                    radius: cosmic.corner_radii.radius_s.into(),
+                },
+                shadow: Shadow::default(),
+            },
 
             Container::Tooltip => iced_container::Style {
                 icon_color: None,

--- a/src/widget/dropdown/menu/mod.rs
+++ b/src/widget/dropdown/menu/mod.rs
@@ -156,21 +156,21 @@ impl<'a, Message: 'a> Overlay<'a, Message> {
             style,
         } = menu;
 
-        let mut container = Container::new(Scrollable::new(List {
-            options,
-            icons,
-            hovered_option,
-            selected_option,
-            on_selected,
-            on_option_hovered,
-            text_size,
-            text_line_height,
-            padding,
-        }));
-
-        container = container
-            .padding(padding)
-            .class(crate::style::Container::Dropdown);
+        let mut container = Container::new(Scrollable::new(
+            Container::new(List {
+                options,
+                icons,
+                hovered_option,
+                selected_option,
+                on_selected,
+                on_option_hovered,
+                text_size,
+                text_line_height,
+                padding,
+            })
+            .padding(padding),
+        ))
+        .class(crate::style::Container::Dropdown);
 
         state.tree.diff(&mut container as &mut dyn Widget<_, _, _>);
 

--- a/src/widget/dropdown/multi/menu.rs
+++ b/src/widget/dropdown/multi/menu.rs
@@ -152,20 +152,20 @@ impl<'a, Message: 'a> Overlay<'a, Message> {
             style,
         } = menu;
 
-        let mut container = Container::new(Scrollable::new(InnerList {
-            options,
-            hovered_option,
-            selected_option,
-            on_selected,
-            on_option_hovered,
-            padding,
-            text_size,
-            text_line_height,
-        }));
-
-        container = container
-            .padding(padding)
-            .class(crate::style::Container::Dropdown);
+        let mut container = Container::new(Scrollable::new(
+            Container::new(InnerList {
+                options,
+                hovered_option,
+                selected_option,
+                on_selected,
+                on_option_hovered,
+                padding,
+                text_size,
+                text_line_height,
+            })
+            .padding(padding),
+        ))
+        .class(crate::style::Container::Dropdown);
 
         state.tree.diff(&mut container as &mut dyn Widget<_, _, _>);
 

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -22,7 +22,6 @@ pub fn header_bar<'a, Message>() -> HeaderBar<'a, Message> {
         center: Vec::new(),
         end: Vec::new(),
         density: None,
-        horizontal_padding: 8,
         focused: false,
         on_double_click: None,
     }
@@ -74,9 +73,6 @@ pub struct HeaderBar<'a, Message> {
     /// Controls the density of the headerbar.
     #[setters(strip_option)]
     density: Option<Density>,
-
-    /// Horizontal padding of the headerbar
-    horizontal_padding: u16,
 
     /// Focused state of the window
     focused: bool,
@@ -346,7 +342,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             )
             .align_y(iced::Alignment::Center)
             .height(Length::Fixed(height))
-            .padding([0, self.horizontal_padding])
+            .padding([0, 8])
             .spacing(8)
             .apply(widget::container)
             .class(crate::theme::Container::HeaderBar {

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -22,6 +22,7 @@ pub fn header_bar<'a, Message>() -> HeaderBar<'a, Message> {
         center: Vec::new(),
         end: Vec::new(),
         density: None,
+        horizontal_padding: 8,
         focused: false,
         on_double_click: None,
     }
@@ -73,6 +74,9 @@ pub struct HeaderBar<'a, Message> {
     /// Controls the density of the headerbar.
     #[setters(strip_option)]
     density: Option<Density>,
+
+    /// Horizontal padding of the headerbar
+    horizontal_padding: u16,
 
     /// Focused state of the window
     focused: bool,
@@ -299,7 +303,6 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
         let mut end = std::mem::take(&mut self.end);
 
         // Also packs the window controls at the very end.
-        end.push(widget::horizontal_space().width(Length::Fixed(12.0)).into());
         end.push(self.window_controls());
 
         let height = match self.density.unwrap_or_else(crate::config::header_size) {
@@ -343,7 +346,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             )
             .align_y(iced::Alignment::Center)
             .height(Length::Fixed(height))
-            .padding([0, 8])
+            .padding([0, self.horizontal_padding])
             .spacing(8)
             .apply(widget::container)
             .class(crate::theme::Container::HeaderBar {

--- a/src/widget/nav_bar_toggle.rs
+++ b/src/widget/nav_bar_toggle.rs
@@ -20,7 +20,7 @@ pub fn nav_bar_toggle<Message>() -> NavBarToggle<Message> {
     NavBarToggle {
         active: false,
         on_toggle: None,
-        class: crate::theme::Button::Text,
+        class: crate::theme::Button::NavToggle,
         selected: false,
     }
 }


### PR DESCRIPTION
This makes the NavBar toggle use `radius_s` for the button radius, to match designs. Adding a new enum value just for that feels a bit messy, but using Button::Custom feels potentially messier (and I'm not entirely sure how to do it). This could be removed if it's decided to use `radius_s` for all header bar buttons in the future.
~~Introduces a `horizontal_padding` field to the header bar, which is needed for the padding offset, but can also be used by `cosmic-comp` to make window controls more centered in the SSD corners. Though this can be removed if it'll be eventually possible to set the borders on individual container sides, which would remove the need for the offset, and if SSDs should have the same horizontal padding of 8 as apps.~~ I removed this, since it caused the header elements to be off-center at the corners.

Also fixes #743.

Edit: Also makes the styling of the dropdown closer to designs.