### PR TITLE
Fixes for context menu for segmented button

### DIFF
--- a/src/widget/menu/menu_inner.rs
+++ b/src/widget/menu/menu_inner.rs
@@ -579,7 +579,7 @@ where
                 .merge(menu_status)
             }
 
-            Mouse(ButtonReleased(Left)) | Touch(FingerLifted { .. }) => {
+            Mouse(ButtonReleased(_)) | Touch(FingerLifted { .. }) => {
                 let state = self.tree.state.downcast_mut::<MenuBarState>();
                 state.pressed = false;
 
@@ -596,7 +596,13 @@ where
                         .iter()
                         .any(|ms| ms.menu_bounds.check_bounds.contains(overlay_cursor));
 
-                    if self.close_condition.click_inside && is_inside {
+                    if self.close_condition.click_inside
+                        && is_inside
+                        && matches!(
+                            event,
+                            Mouse(ButtonReleased(Left)) | Touch(FingerLifted { .. })
+                        )
+                    {
                         state.reset();
                         return Captured;
                     }

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -910,6 +910,13 @@ where
                             }
                         }
 
+                        if let Event::Mouse(mouse::Event::ButtonReleased(_))
+                        | Event::Touch(touch::Event::FingerLifted { .. }) = event
+                        {
+                            state.focused = false;
+                            state.focused_item = Item::None;
+                        }
+
                         if let Some(on_activate) = self.on_activate.as_ref() {
                             if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
                             | Event::Touch(touch::Event::FingerLifted { .. }) = event
@@ -928,8 +935,6 @@ where
                                     state.show_context = Some(key);
                                     state.context_cursor =
                                         cursor_position.position().unwrap_or_default();
-                                    state.focused = true;
-                                    state.focused_item = Item::Tab(key);
 
                                     let menu_state =
                                         tree.children[0].state.downcast_mut::<MenuBarState>();
@@ -1321,13 +1326,17 @@ where
 
             let center_y = bounds.center_y();
 
+            let menu_open = !tree.children.is_empty()
+                && tree.children[0].state.downcast_ref::<MenuBarState>().open;
+
             let key_is_active = self.model.is_active(key);
             let key_is_hovered = self.button_is_hovered(state, key);
+            let key_has_context_menu_open = menu_open && state.show_context == Some(key);
             let status_appearance = if self.button_is_focused(state, key) {
                 appearance.focus
             } else if key_is_active {
                 appearance.active
-            } else if key_is_hovered {
+            } else if key_is_hovered || key_has_context_menu_open {
                 appearance.hover
             } else {
                 appearance.inactive


### PR DESCRIPTION
Fixes navbar context menu issue in Cosmic Files:
https://github.com/pop-os/cosmic-files/issues/381

It also makes it so clicking out of a menu with right and middle mouse buttons closes the context menu, just like left-clicking does.