### PR TITLE
Fix entering text with compose key

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -1742,9 +1742,11 @@ where
                         {
                             let mut editor = Editor::new(unsecured_value, &mut state.cursor);
 
-                            editor.insert(
-                                text.unwrap_or_default().chars().next().unwrap_or_default(),
-                            );
+                            let character =
+                                text.unwrap_or_default().chars().next().unwrap_or_default();
+                            if !character.is_control() {
+                                editor.insert(character);
+                            }
                             let contents = editor.contents();
                             let unsecured_value = Value::new(&contents);
                             let message = (on_input)(contents);


### PR DESCRIPTION
Previously entering text in text inputs with the compose key would insert one or more NUL bytes before the inserted character.

Fixes an issue in Cosmic Files when creating or renaming files and the Compose key is used to enter special characters.
https://github.com/pop-os/cosmic-files/issues/681