### PR TITLE
fix: Don't enable rfd/async-std by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde-keycode = ["iced_core/serde"]
 # Prevents multiple separate process instances.
 single-instance = ["dep:zbus", "ron"]
 # smol async runtime
-smol = ["dep:smol", "iced/smol", "zbus?/async-io"]
+smol = ["dep:smol", "iced/smol", "zbus?/async-io", "rfd?/async-std"]
 tokio = [
     "dep:tokio",
     "ashpd?/tokio",
@@ -101,7 +101,7 @@ libc = { version = "0.2.155", optional = true }
 license = { version = "3.5.1", optional = true }
 mime = { version = "0.3.17", optional = true }
 palette = "0.7.3"
-rfd = { version = "0.14.0", optional = true }
+rfd = { version = "0.14.0", default-features = false, features = ["xdg-portal"], optional = true }
 rustix = { version = "0.38.34", features = [
     "pipe",
     "process",


### PR DESCRIPTION
rfd enables the 'async-std' feature by default, which causes a compile error when the 'tokio' feature is also enabled. This PR changes the libcosmic dependencies so that rfd only has 'xdg-portal' enabled by default (rfd only imports ashpd conditionally based on compile target, so this feature should be fine to leave always enabled) and enables the 'async-std' feature of rfd if the libcosmic 'smol' feature is enabled.