### PR TITLE
Add standard derive attributes to CalendarModel

### DIFF
--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -42,6 +42,7 @@ pub fn set_day(date_selected: NaiveDate, day: u32) -> NaiveDate {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct CalendarModel {
     pub selected: NaiveDate,
     visible: NaiveDate,


### PR DESCRIPTION
This pull request adds several standard derived traits to the `CalendarModel` struct to allow more flexibility.