### PR TITLE
Add rotation field into COSMIC icon

### DIFF
--- a/src/widget/icon/mod.rs
+++ b/src/widget/icon/mod.rs
@@ -16,6 +16,7 @@ use crate::Element;
 use derive_setters::Setters;
 use iced::widget::{Image, Svg};
 use iced::{ContentFit, Length, Rectangle};
+use iced_core::Rotation;
 
 /// Create an [`Icon`] from a pre-existing [`Handle`]
 pub fn icon(handle: Handle) -> Icon {
@@ -25,6 +26,7 @@ pub fn icon(handle: Handle) -> Icon {
         height: None,
         size: 16,
         class: crate::theme::Svg::default(),
+        rotation: None,
         width: None,
     }
 }
@@ -47,6 +49,8 @@ pub struct Icon {
     width: Option<Length>,
     #[setters(strip_option)]
     height: Option<Length>,
+    #[setters(strip_option)]
+    rotation: Option<Rotation>,
 }
 
 impl Icon {
@@ -80,6 +84,7 @@ impl Icon {
                     self.height
                         .unwrap_or_else(|| Length::Fixed(f32::from(self.size))),
                 )
+                .rotation(self.rotation.unwrap_or(Rotation::default()))
                 .content_fit(self.content_fit)
                 .into()
         };
@@ -95,6 +100,7 @@ impl Icon {
                     self.height
                         .unwrap_or_else(|| Length::Fixed(f32::from(self.size))),
                 )
+                .rotation(self.rotation.unwrap_or(Rotation::default()))
                 .content_fit(self.content_fit)
                 .symbolic(self.handle.symbolic)
                 .into()

--- a/src/widget/icon/mod.rs
+++ b/src/widget/icon/mod.rs
@@ -84,7 +84,7 @@ impl Icon {
                     self.height
                         .unwrap_or_else(|| Length::Fixed(f32::from(self.size))),
                 )
-                .rotation(self.rotation.unwrap_or(Rotation::default()))
+                .rotation(self.rotation.unwrap_or_else(Rotation::default))
                 .content_fit(self.content_fit)
                 .into()
         };
@@ -100,7 +100,7 @@ impl Icon {
                     self.height
                         .unwrap_or_else(|| Length::Fixed(f32::from(self.size))),
                 )
-                .rotation(self.rotation.unwrap_or(Rotation::default()))
+                .rotation(self.rotation.unwrap_or_else(Rotation::default))
                 .content_fit(self.content_fit)
                 .symbolic(self.handle.symbolic)
                 .into()


### PR DESCRIPTION
This PR exposes a field `rotation` to COSMIC icons to allow you to, well, rotate an icon.

This feature already exists in `iced_core`, for both image and SVG icons, so we're simply exposing the field.

example:
```rust
use cosmic::widget::{self, settings, icon};
use std::f32::consts::PI;
use cosmic::iced_core::Rotation;

widget::column::column()
    .push(
    settings::section()
        .add(settings::item("no rot", icon::from_name("folder-download-symbolic").size(32).icon()))
        .add(settings::item("0 deg | (0pi) rad", icon::from_name("folder-download-symbolic").size(32).icon().rotation(Rotation::from(0.0))))
        .add(settings::item("90 deg | (pi / 2) rad", icon::from_name("folder-download-symbolic").size(32).icon().rotation(Rotation::from(PI / 2.0))))
        .add(settings::item("180 deg | (pi) rad", icon::from_name("folder-download-symbolic").size(32).icon().rotation(Rotation::from(PI))))
        .add(settings::item("270 deg | (3pi / 2) rad", icon::from_name("folder-download-symbolic").size(32).icon().rotation(Rotation::from((3.0 * PI) / 2.0))))
        .add(settings::item("360 deg | (2pi) rad", icon::from_name("folder-download-symbolic").size(32).icon().rotation(Rotation::from((2.0 * PI)))))
    )
```

Produces:
![image](https://github.com/user-attachments/assets/e9f51e63-6080-4bb5-b6cb-17259a2458f7)

Using an `Option<Rotation>` and falling back to `Rotation::default()` (which is what iced uses anyways) means that there is no change to the API unless you're actively seeking it out.

It may be an idea to add the changes to `icon::named` too, but I'm unsure how best to handle this atm.