### PR TITLE
chore: Update ron to 0.9

### DIFF
--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -15,7 +15,7 @@ zbus = { version = "4.2.1", default-features = false, optional = true }
 atomicwrites = { git = "https://github.com/jackpot51/rust-atomicwrites" }
 calloop = { version = "0.14.0", optional = true }
 notify = "6.0.0"
-ron = "0.8.0"
+ron = "0.9.0-alpha.0"
 serde = "1.0.152"
 cosmic-config-derive = { path = "../cosmic-config-derive/", optional = true }
 iced = { path = "../iced/", default-features = false, optional = true }

--- a/cosmic-theme/Cargo.toml
+++ b/cosmic-theme/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.129", features = ["derive"] }
 serde_json = { version = "1.0.64", optional = true, features = [
     "preserve_order",
 ] }
-ron = "0.8"
+ron = "0.9.0-alpha.0"
 lazy_static = "1.4.0"
 csscolorparser = { version = "0.6.2", features = ["serde"] }
 cosmic-config = { path = "../cosmic-config/", default-features = false, features = [

--- a/examples/config/Cargo.toml
+++ b/examples/config/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 cosmic-config = { path = "../../cosmic-config" }
-ron = "0.8.0"
+ron = "0.9.0-alpha.0"


### PR DESCRIPTION
Ron 0.9 has been in the works for years at this point (0.8 the latest stable was tagged in August 2023), but sadly has stalled quite a bit: https://github.com/ron-rs/ron/issues/496

It adds a bunch of really nice features, like support for tagged or untagged enum variants, but more importantly it has a new `RawValue` type (similar to `serde_json::RawValue`), which allows us to address a few shortcomings like: https://github.com/pop-os/cosmic-settings-daemon/pull/68

I say, lets bite the bullet and try the alpha-version of it. It seems remaining issues are only around `#[serde(flatten)`, which we don't use: https://github.com/search?q=org%3Apop-os%20%23%5Bserde(flatten)%5D&type=code