### PR TITLE
fixup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some examples are included in the [examples](./examples) directory to to kicksta
 COSMIC adventure. To run them, you need to clone the repository with the following commands:
 
 ```sh
-git clone https://github.com/pop-os/libcosmic
+git clone --recurse-submodules https://github.com/pop-os/libcosmic
 cd libcosmic
 ```
 


### PR DESCRIPTION
If you just blindly copy and paste from the README, you get errors. That's annoying. Better if it just works.
```
tyler@HOST:~/libcosmic$ just check
cargo clippy --no-deps --features="wayland,tokio,xdg-portal"  -- -W clippy::all -W clippy::pedantic
    Updating crates.io index
    Updating git repository `https://github.com/jackpot51/rust-atomicwrites`
    Updating git repository `https://github.com/pop-os/dbus-settings-bindings`
error: failed to get `iced` as a dependency of package `cosmic-config v0.1.0 (/home/tyler/libcosmic/cosmic-config)`

Caused by:
  failed to load source for dependency `iced`

Caused by:
  Unable to update /home/tyler/libcosmic/iced

Caused by:
  failed to read `/home/tyler/libcosmic/iced/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
error: Recipe `check-wayland` failed on line 14 with exit code 101
```