### PR TITLE
Segmented button model - add convenience method to get number of items in the model.

### DIFF
--- a/src/widget/segmented_button/model/mod.rs
+++ b/src/widget/segmented_button/model/mod.rs
@@ -310,6 +310,11 @@ where
         self.items.get(id).map_or(false, |e| e.enabled)
     }
 
+    /// Get number of items in the model.
+    pub fn len(&self) -> usize {
+        self.order.len()
+    }
+
     /// Iterates across items in the model in the order that they are displayed.
     pub fn iter(&self) -> impl Iterator<Item = Entity> + '_ {
         self.order.iter().copied()


### PR DESCRIPTION
The only way to get number of items in the model right now is to do
`nav.iter().count()` which is unnecessarily costly. Therefore I have added a simple method to get the length of the deque.