### PR TITLE
perf: set static mmap threshold on gnu target env by default

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -138,7 +138,11 @@ pub(crate) fn iced_settings<App: Application>(
 ///
 /// Returns error on application failure.
 pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Result {
-    let default_font = settings.default_font;
+    #[cfg(target_env = "gnu")]
+    if let Some(threshold) = settings.default_mmap_threshold {
+        crate::malloc::limit_mmap_threshold(threshold);
+    }
+
     let (settings, mut flags, window_settings) = iced_settings::<App>(settings, flags);
     #[cfg(not(feature = "multi-window"))]
     {

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -38,6 +38,9 @@ pub struct Settings {
     /// Default size of fonts.
     pub(crate) default_text_size: f32,
 
+    /// Set the default mmap threshold for malloc with mallopt.
+    pub(crate) default_mmap_threshold: Option<i32>,
+
     /// Whether the window should be resizable or not.
     /// and the size of the window border which can be dragged for a resize
     pub(crate) resizable: Option<f64>,
@@ -85,6 +88,7 @@ impl Default for Settings {
             default_font: font::default(),
             default_icon_theme: None,
             default_text_size: 14.0,
+            default_mmap_threshold: Some(128 * 1024),
             resizable: Some(8.0),
             scale_factor: std::env::var("COSMIC_SCALE")
                 .ok()

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -153,7 +153,6 @@ impl Context {
         self.size = Size::Hardcoded((width, height));
     }
 
-    #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn window_settings(&self) -> crate::app::Settings {
         let (width, height) = self.suggested_size(true);
@@ -183,7 +182,6 @@ impl Context {
         matches!(self.anchor, PanelAnchor::Top | PanelAnchor::Bottom)
     }
 
-    #[must_use]
     pub fn icon_button_from_handle<'a, Message: 'static>(
         &self,
         icon: widget::icon::Handle,
@@ -213,7 +211,6 @@ impl Context {
         .class(Button::AppletIcon)
     }
 
-    #[must_use]
     pub fn icon_button<'a, Message: 'static>(
         &self,
         icon_name: &'a str,
@@ -384,6 +381,11 @@ pub fn run<App: Application>(flags: App::Flags) -> iced::Result {
 
     let mut settings = helper.window_settings();
     settings.resizable = None;
+
+    #[cfg(target_env = "gnu")]
+    if let Some(threshold) = settings.default_mmap_threshold {
+        crate::malloc::limit_mmap_threshold(threshold);
+    }
 
     if let Some(icon_theme) = settings.default_icon_theme.clone() {
         crate::icon_theme::set_default(icon_theme);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub use cosmic_config;
 #[doc(inline)]
 pub use cosmic_theme;
 
+#[cfg(feature = "desktop")]
+pub mod desktop;
+
 #[cfg(any(feature = "xdg-portal", feature = "rfd"))]
 pub mod dialog;
 
@@ -73,8 +76,9 @@ pub use iced_wgpu;
 pub mod icon_theme;
 pub mod keyboard_nav;
 
-#[cfg(feature = "desktop")]
-pub mod desktop;
+#[cfg(target_env = "gnu")]
+pub(crate) mod malloc;
+
 #[cfg(all(feature = "process", not(windows)))]
 pub mod process;
 

--- a/src/malloc.rs
+++ b/src/malloc.rs
@@ -1,0 +1,14 @@
+use std::os::raw::c_int;
+
+const M_MMAP_THRESHOLD: c_int = -3;
+
+extern "C" {
+    fn mallopt(param: c_int, value: c_int) -> c_int;
+}
+
+/// Prevents glibc from hoarding memory via memory fragmentation.
+pub fn limit_mmap_threshold(threshold: i32) {
+    unsafe {
+        mallopt(M_MMAP_THRESHOLD, threshold as c_int);
+    }
+}


### PR DESCRIPTION
When compiling for the `gnu` target environment, a static mmap threshold value will be set to 128 KB to prevent GNU libc from dynamically allocating larger allocations in the process heap. May be disabled or altered by setting the value for `app::Settings::default_mmap_threshold` before running the app or applet.