### PR TITLE
fix: filter out tab events with control modifier

### DIFF
--- a/src/keyboard_nav.rs
+++ b/src/keyboard_nav.rs
@@ -28,7 +28,7 @@ pub fn subscription() -> Subscription<Message> {
                 modifiers,
                 ..
             }) => match key {
-                Named::Tab => {
+                Named::Tab if !modifiers.control() => {
                     return Some(if modifiers.shift() {
                         Message::FocusPrevious
                     } else {


### PR DESCRIPTION
fixes https://github.com/pop-os/libcosmic/issues/787