### PR TITLE
Ignore ButtonRelease / FingerLifted events on nav model when dragged out of target

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -920,10 +920,12 @@ where
 
                         if let Some(on_activate) = self.on_activate.as_ref() {
                             if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-                                | Event::Touch(touch::Event::FingerPressed { .. }) = event {
+                            | Event::Touch(touch::Event::FingerPressed { .. }) = event
+                            {
                                 state.pressed_item = Some(Item::Tab(key));
-                            }
-                            else if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+                            } else if let Event::Mouse(mouse::Event::ButtonReleased(
+                                mouse::Button::Left,
+                            ))
                             | Event::Touch(touch::Event::FingerLifted { .. }) = event
                             {
                                 let mut can_activate = true;

--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -592,6 +592,7 @@ where
             wheel_timestamp: Default::default(),
             dnd_state: Default::default(),
             fingers_pressed: Default::default(),
+            pressed_item: None,
         })
     }
 
@@ -918,11 +919,23 @@ where
                         }
 
                         if let Some(on_activate) = self.on_activate.as_ref() {
-                            if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+                            if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+                                | Event::Touch(touch::Event::FingerPressed { .. }) = event {
+                                state.pressed_item = Some(Item::Tab(key));
+                            }
+                            else if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
                             | Event::Touch(touch::Event::FingerLifted { .. }) = event
                             {
-                                shell.publish(on_activate(key));
-                                return event::Status::Captured;
+                                let mut can_activate = true;
+                                if state.pressed_item != Some(Item::Tab(key)) {
+                                    can_activate = false;
+                                }
+
+                                if can_activate {
+                                    shell.publish(on_activate(key));
+                                    state.pressed_item = None;
+                                    return event::Status::Captured;
+                                }
                             }
                         }
 
@@ -1666,6 +1679,8 @@ pub struct LocalState {
     pub dnd_state: crate::widget::dnd_destination::State<Option<Entity>>,
     /// Tracks multi-touch events
     fingers_pressed: HashSet<Finger>,
+    /// The currently pressed item
+    pressed_item: Option<Item>,
 }
 
 #[derive(Debug, Default, PartialEq)]


### PR DESCRIPTION
this fixes an interesting bit of behaviour in `cosmic-edit` where , if you try to select some text and end up highlighting an entry in the project view, you end up opening the entry (rather than ignoring / eating the event, which is standard across other similar products)


https://github.com/user-attachments/assets/66501781-f0ba-4194-8e5b-6bb4214ef09e

as an aside, this code can also be used as the basis to add a new `on_move(a, b)` event, which could be used to easily move files in `cosmic-edit` or rearrange your favourites in `cosmic-files` (i'm happy to implement this, just don't want to step on any toes!)

this should also fix a similar bit of interesting behaviour where, if the file selector extension dropdown overlaps an entry in the nav, and you select a dropdown entry, it process both a click on the dropdown _and_ a click on the nav entry (in my case, i often accidentally mount drives when trying to select a specific image type) - i'm not so sure how to easily test this however

i'm unsure if segmented buttons are used with an `on_activate` elsewhere in core apps where i can test to make sure behaviour matches 1:1?
