### PR TITLE
fix(popover): modal popover handling broken

### DIFF
--- a/src/widget/table/mod.rs
+++ b/src/widget/table/mod.rs
@@ -3,10 +3,10 @@
 
 pub mod model;
 pub use model::{
+    Entity, Model,
     category::ItemCategory,
     category::ItemInterface,
     selection::{MultiSelect, SingleSelect},
-    Entity, Model,
 };
 pub mod widget;
 pub use widget::compact::CompactTableView;

--- a/src/widget/table/model/entity.rs
+++ b/src/widget/table/model/entity.rs
@@ -4,8 +4,8 @@
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 
 use super::{
-    category::{ItemCategory, ItemInterface},
     Entity, Model, Selectable,
+    category::{ItemCategory, ItemInterface},
 };
 
 /// A newly-inserted item which may have additional actions applied to it.

--- a/src/widget/table/model/selection.rs
+++ b/src/widget/table/model/selection.rs
@@ -4,8 +4,8 @@
 //! Describes logic specific to the single-select and multi-select modes of a model.
 
 use super::{
-    category::{ItemCategory, ItemInterface},
     Entity, Model,
+    category::{ItemCategory, ItemInterface},
 };
 use std::collections::HashSet;
 

--- a/src/widget/table/widget/compact.rs
+++ b/src/widget/table/widget/compact.rs
@@ -1,14 +1,13 @@
 use derive_setters::Setters;
 
 use crate::widget::table::model::{
+    Entity, Model,
     category::{ItemCategory, ItemInterface},
     selection::Selectable,
-    Entity, Model,
 };
 use crate::{
-    theme,
+    Apply, Element, theme,
     widget::{self, container, menu},
-    Apply, Element,
 };
 use iced::{Alignment, Border, Padding};
 

--- a/src/widget/table/widget/standard.rs
+++ b/src/widget/table/widget/standard.rs
@@ -1,14 +1,13 @@
 use derive_setters::Setters;
 
 use crate::widget::table::model::{
+    Entity, Model,
     category::{ItemCategory, ItemInterface},
     selection::Selectable,
-    Entity, Model,
 };
 use crate::{
-    theme,
+    Apply, Element, theme,
     widget::{self, container, divider, menu},
-    Apply, Element,
 };
 use iced::{Alignment, Border, Length, Padding};
 
@@ -132,10 +131,12 @@ where
             .apply(Element::from);
         // Build the items
         let items_full = if val.model.items.is_empty() {
-            vec![divider::horizontal::default()
-                .apply(container)
-                .padding(val.divider_padding)
-                .apply(Element::from)]
+            vec![
+                divider::horizontal::default()
+                    .apply(container)
+                    .padding(val.divider_padding)
+                    .apply(Element::from),
+            ]
         } else {
             val.model
                 .iter()


### PR DESCRIPTION
- Removed local `State` because its only `is_over` property was never actually correct
- A popover is always considered to be open whenever a popup element is attached.
- Modal popovers now correctly block clicks outside of the popup overlay while open