### PR TITLE
Match About widget section spacing to designs

### DIFF
--- a/examples/spin-button/src/main.rs
+++ b/examples/spin-button/src/main.rs
@@ -131,7 +131,7 @@ impl Application for SpinButtonExamplApp {
     }
 
     fn view(&self) -> Element<Self::Message> {
-        let space_xs = cosmic::theme::active().cosmic().spacing.space_xs;
+        let space_xs = cosmic::theme::spacing().space_xs;
 
         let vert_spinner_row = iced::widget::row![
             spin_button::vertical(&self.i8_str, self.i8_num, 1, -5, 5, Message::UpdateI8),

--- a/src/widget/about.rs
+++ b/src/widget/about.rs
@@ -15,7 +15,7 @@ pub struct About {
     name: Option<String>,
     /// The application's icon name.
     icon: Option<String>,
-    /// The application’s version.
+    /// The application's version.
     version: Option<String>,
     /// Name of the application's author.
     author: Option<String>,
@@ -45,76 +45,61 @@ pub struct About {
     links: Vec<(String, String)>,
 }
 
+fn add_contributors(contributors: Vec<(&str, &str)>) -> Vec<(String, String)> {
+    contributors
+        .into_iter()
+        .map(|(name, email)| (name.to_string(), format!("mailto:{email}")))
+        .collect()
+}
+
 impl<'a> About {
     /// Artists who contributed to the application.
     pub fn artists(mut self, artists: impl Into<Vec<(&'a str, &'a str)>>) -> Self {
-        let artists: Vec<(&'a str, &'a str)> = artists.into();
-        self.artists = artists
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), format!("mailto:{v}")))
-            .collect();
+        self.artists = add_contributors(artists.into());
         self
     }
 
     /// Designers who contributed to the application.
     pub fn designers(mut self, designers: impl Into<Vec<(&'a str, &'a str)>>) -> Self {
-        let designers: Vec<(&'a str, &'a str)> = designers.into();
-        self.designers = designers
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), format!("mailto:{v}")))
-            .collect();
+        self.designers = add_contributors(designers.into());
         self
     }
 
     /// Developers who contributed to the application.
     pub fn developers(mut self, developers: impl Into<Vec<(&'a str, &'a str)>>) -> Self {
-        let developers: Vec<(&'a str, &'a str)> = developers.into();
-        self.developers = developers
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), format!("mailto:{v}")))
-            .collect();
+        self.developers = add_contributors(developers.into());
         self
     }
 
     /// Documenters who contributed to the application.
     pub fn documenters(mut self, documenters: impl Into<Vec<(&'a str, &'a str)>>) -> Self {
-        let documenters: Vec<(&'a str, &'a str)> = documenters.into();
-        self.documenters = documenters
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), format!("mailto:{v}")))
-            .collect();
+        self.documenters = add_contributors(documenters.into());
         self
     }
 
     /// Translators who contributed to the application.
     pub fn translators(mut self, translators: impl Into<Vec<(&'a str, &'a str)>>) -> Self {
-        let translators: Vec<(&'a str, &'a str)> = translators.into();
-        self.translators = translators
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), format!("mailto:{v}")))
-            .collect();
+        self.translators = add_contributors(translators.into());
         self
     }
 
     /// Links associated with the application.
-    pub fn links<T: Into<String>>(mut self, links: impl Into<Vec<(T, &'a str)>>) -> Self {
-        let links: Vec<(T, &'a str)> = links.into();
+    pub fn links<K: Into<String>, V: Into<String>>(
+        mut self,
+        links: impl IntoIterator<Item = (K, V)>,
+    ) -> Self {
         self.links = links
             .into_iter()
-            .map(|(k, v)| (k.into(), v.to_string()))
+            .map(|(name, url)| (name.into(), url.into()))
             .collect();
         self
     }
 
     fn license_url(&self) -> Option<String> {
-        let license: &dyn License = match self.license.as_ref() {
-            Some(license) => license.parse().ok()?,
-            None => return None,
-        };
-
-        self.license
-            .as_ref()
-            .map(|_| format!("https://spdx.org/licenses/{}.html", license.id()))
+        self.license.as_ref().and_then(|license_str| {
+            let license: &dyn License = license_str.parse().ok()?;
+            Some(format!("https://spdx.org/licenses/{}.html", license.id()))
+        })
     }
 }
 
@@ -124,14 +109,12 @@ pub fn about<'a, Message: Clone + 'static>(
     on_url_press: impl Fn(String) -> Message,
 ) -> Element<'a, Message> {
     let cosmic_theme::Spacing {
-        space_xxs,
-        space_xs,
-        ..
-    } = crate::theme::active().cosmic().spacing;
+        space_xxs, space_m, ..
+    } = crate::theme::spacing();
 
     let section = |list: &'a Vec<(String, String)>, title: &'a str| {
         (!list.is_empty()).then_some({
-            let developers: Vec<Element<Message>> =
+            let items: Vec<Element<Message>> =
                 list.iter()
                     .map(|(name, url)| {
                         widget::button::custom(
@@ -141,16 +124,15 @@ pub fn about<'a, Message: Clone + 'static>(
                                 .push_maybe((!url.is_empty()).then_some(
                                     crate::widget::icon::from_name("link-symbolic").icon(),
                                 ))
-                                .padding(space_xxs)
                                 .align_y(Alignment::Center),
                         )
-                        .class(crate::theme::Button::Text)
+                        .class(crate::theme::Button::Link)
                         .on_press(on_url_press(url.clone()))
                         .width(Length::Fill)
                         .into()
                     })
                     .collect();
-            widget::settings::section().title(title).extend(developers)
+            widget::settings::section().title(title).extend(items)
         })
     };
 
@@ -159,15 +141,14 @@ pub fn about<'a, Message: Clone + 'static>(
         .icon
         .as_ref()
         .map(|icon| crate::desktop::IconSource::Name(icon.clone()).as_cosmic_icon());
-
+    let author = about.author.as_ref().map(widget::text::body);
+    let version = about.version.as_ref().map(widget::button::standard);
     let links_section = section(&about.links, "Links");
     let developers_section = section(&about.developers, "Developers");
     let designers_section = section(&about.designers, "Designers");
     let artists_section = section(&about.artists, "Artists");
     let translators_section = section(&about.translators, "Translators");
     let documenters_section = section(&about.documenters, "Documenters");
-    let author = about.author.as_ref().map(widget::text);
-    let version = about.version.as_ref().map(widget::button::standard);
     let license = about.license.as_ref().map(|license| {
         let url = about.license_url();
         widget::settings::section().title("License").add(
@@ -179,10 +160,9 @@ pub fn about<'a, Message: Clone + 'static>(
                         url.is_some()
                             .then_some(crate::widget::icon::from_name("link-symbolic").icon()),
                     )
-                    .padding(space_xxs)
                     .align_y(Alignment::Center),
             )
-            .class(crate::theme::Button::Text)
+            .class(crate::theme::Button::Link)
             .on_press(on_url_press(url.unwrap_or_default()))
             .width(Length::Fill),
         )
@@ -191,10 +171,15 @@ pub fn about<'a, Message: Clone + 'static>(
     let comments = about.comments.as_ref().map(widget::text::body);
 
     widget::column()
-        .push_maybe(application_icon)
-        .push_maybe(application_name)
-        .push_maybe(author)
-        .push_maybe(version)
+        .push(
+            widget::column()
+                .push_maybe(application_icon)
+                .push_maybe(application_name)
+                .push_maybe(author)
+                .push_maybe(version)
+                .align_x(Alignment::Center)
+                .spacing(space_xxs),
+        )
         .push_maybe(license)
         .push_maybe(links_section)
         .push_maybe(developers_section)
@@ -205,7 +190,7 @@ pub fn about<'a, Message: Clone + 'static>(
         .push_maybe(comments)
         .push_maybe(copyright)
         .align_x(Alignment::Center)
-        .spacing(space_xs)
+        .spacing(space_m)
         .width(Length::Fill)
         .into()
 }

--- a/src/widget/context_drawer/widget.rs
+++ b/src/widget/context_drawer/widget.rs
@@ -53,7 +53,7 @@ impl<'a, Message: Clone + 'static> ContextDrawer<'a, Message> {
                 space_m,
                 space_l,
                 ..
-            } = crate::theme::active().cosmic().spacing;
+            } = crate::theme::spacing();
 
             let horizontal_padding = if max_width < 392.0 { space_s } else { space_l };
 

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -292,7 +292,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             space_xxxs,
             space_xxs,
             ..
-        } = theme::active().cosmic().spacing;
+        } = theme::spacing();
 
         // Take ownership of the regions to be packed.
         let start = std::mem::take(&mut self.start);
@@ -434,7 +434,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                     .take()
                     .map(|m| icon!("window-close-symbolic", 16, m)),
             )
-            .spacing(theme::active().cosmic().space_xxs())
+            .spacing(theme::spacing().space_xxs)
             .apply(widget::container)
             .center_y(Length::Fill)
             .into()

--- a/src/widget/list/column.rs
+++ b/src/widget/list/column.rs
@@ -28,7 +28,7 @@ impl<Message: 'static> Default for ListColumn<'_, Message> {
     fn default() -> Self {
         let cosmic_theme::Spacing {
             space_xxs, space_m, ..
-        } = theme::active().cosmic().spacing;
+        } = theme::spacing();
 
         Self {
             spacing: 0,

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -240,7 +240,7 @@ where
         .enumerate()
         .flat_map(|(i, item)| {
             let mut trees = vec![];
-            let spacing = crate::theme::active().cosmic().spacing;
+            let spacing = crate::theme::spacing();
 
             match item {
                 MenuItem::Button(label, icon, action) => {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! const REPOSITORY: &str = "https://github.com/pop-os/libcosmic";
 //!
-//! let cosmic_theme::Spacing { space_xxs, .. } = theme::active().cosmic().spacing;
+//! let cosmic_theme::Spacing { space_xxs, .. } = theme::spacing();
 //!
 //! let link = widget::button::link(REPOSITORY)
 //!     .on_press(Message::LaunchUrl(REPOSITORY))
@@ -364,7 +364,7 @@ pub mod tooltip {
         tooltip: impl Into<Element<'a, Message>>,
         position: Position,
     ) -> Tooltip<'a, Message> {
-        let xxs = crate::theme::active().cosmic().space_xxs();
+        let xxs = crate::theme::spacing().space_xxs;
 
         Tooltip::new(content, tooltip, position)
             .class(crate::theme::Container::Tooltip)

--- a/src/widget/segmented_control.rs
+++ b/src/widget/segmented_control.rs
@@ -20,9 +20,8 @@ pub fn horizontal<SelectionMode: Default, Message>(
 where
     Model<SelectionMode>: Selectable,
 {
-    let theme = crate::theme::active();
-    let space_s = theme.cosmic().space_s();
-    let space_xxs = theme.cosmic().space_xxs();
+    let space_s = crate::theme::spacing().space_s;
+    let space_xxs = crate::theme::spacing().space_xxs;
 
     segmented_button::horizontal(model)
         .button_alignment(iced::Alignment::Center)
@@ -46,9 +45,8 @@ where
     Model<SelectionMode>: Selectable,
     SelectionMode: Default,
 {
-    let theme = crate::theme::active();
-    let space_s = theme.cosmic().space_s();
-    let space_xxs = theme.cosmic().space_xxs();
+    let space_s = crate::theme::spacing().space_s;
+    let space_xxs = crate::theme::spacing().space_xxs;
 
     segmented_button::vertical(model)
         .button_alignment(iced::Alignment::Center)

--- a/src/widget/settings/item.rs
+++ b/src/widget/settings/item.rs
@@ -38,7 +38,7 @@ pub fn item<'a, Message: 'static>(
 #[allow(clippy::module_name_repetitions)]
 pub fn item_row<Message>(children: Vec<Element<Message>>) -> Row<Message> {
     row::with_children(children)
-        .spacing(theme::active().cosmic().space_xs())
+        .spacing(theme::spacing().space_xs)
         .align_y(iced::Alignment::Center)
 }
 
@@ -69,7 +69,7 @@ pub fn flex_item<'a, Message: 'static>(
 #[allow(clippy::module_name_repetitions)]
 pub fn flex_item_row<Message>(children: Vec<Element<Message>>) -> FlexRow<Message> {
     flex_row(children)
-        .spacing(theme::active().cosmic().space_xs())
+        .spacing(theme::spacing().space_xs)
         .min_item_width(200.0)
         .justify_items(iced::Alignment::Center)
         .justify_content(AlignContent::SpaceBetween)

--- a/src/widget/settings/mod.rs
+++ b/src/widget/settings/mod.rs
@@ -13,5 +13,5 @@ use crate::{Element, theme};
 /// A column with a predefined style for creating a settings panel
 #[must_use]
 pub fn view_column<Message: 'static>(children: Vec<Element<Message>>) -> Column<Message> {
-    column::with_children(children).spacing(theme::active().cosmic().space_m())
+    column::with_children(children).spacing(theme::spacing().space_m)
 }

--- a/src/widget/tab_bar.rs
+++ b/src/widget/tab_bar.rs
@@ -20,9 +20,8 @@ pub fn horizontal<SelectionMode: Default, Message>(
 where
     Model<SelectionMode>: Selectable,
 {
-    let theme = crate::theme::active();
-    let space_s = theme.cosmic().space_s();
-    let space_xs = theme.cosmic().space_xs();
+    let space_s = crate::theme::spacing().space_s;
+    let space_xs = crate::theme::spacing().space_xs;
 
     segmented_button::horizontal(model)
         .minimum_button_width(76)
@@ -44,9 +43,8 @@ where
     Model<SelectionMode>: Selectable,
     SelectionMode: Default,
 {
-    let theme = crate::theme::active();
-    let space_s = theme.cosmic().space_s();
-    let space_xs = theme.cosmic().space_xs();
+    let space_s = crate::theme::spacing().space_s;
+    let space_xs = crate::theme::spacing().space_xs;
 
     SegmentedButton::new(model)
         .minimum_button_width(76)

--- a/src/widget/table/widget/compact.rs
+++ b/src/widget/table/widget/compact.rs
@@ -57,7 +57,7 @@ where
     Message: Clone + 'static,
 {
     fn from(val: CompactTableView<'a, SelectionMode, Item, Category, Message>) -> Self {
-        let cosmic_theme::Spacing { space_xxxs, .. } = theme::active().cosmic().spacing;
+        let cosmic_theme::Spacing { space_xxxs, .. } = theme::spacing();
         val.model
             .iter()
             .map(|entity| {
@@ -193,7 +193,7 @@ where
             space_xxxs,
             space_xxs,
             ..
-        } = theme::active().cosmic().spacing;
+        } = theme::spacing();
 
         Self {
             model,

--- a/src/widget/table/widget/standard.rs
+++ b/src/widget/table/widget/standard.rs
@@ -264,7 +264,7 @@ where
             space_xxxs,
             space_xxs,
             ..
-        } = theme::active().cosmic().spacing;
+        } = theme::spacing();
 
         Self {
             model,


### PR DESCRIPTION
Matches the spacing of About widget sections to the spacing of sections elsewhere, and makes the buttons use the `Button::Link` class, since the highlight can't look good until there's a widget (or an addition to e.g. list_column) that can have the buttons take the entire size of a row (so that the highlight covers the entire row).