### PR TITLE
Remove context drawer padding without content container

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -610,7 +610,7 @@ impl<App: Application> ApplicationExt for App {
                                 ))
                             })
                             .apply(container)
-                            .padding([0, border_padding, 0, 0])
+                            .padding([0, if content_container { border_padding } else { 0 }, 0, 0])
                             .apply(Element::from)
                             .map(crate::Action::App),
                         );


### PR DESCRIPTION
Follow up to #840, this removes the padding of the overlay context drawer when content_container is false, to prevent visual issues in cosmic-term.
I removed that section of code, and later returned it, forgetting about the content container (sorry!).