### PR TITLE
Improve table sort

### DIFF
--- a/src/widget/table/model/mod.rs
+++ b/src/widget/table/model/mod.rs
@@ -349,14 +349,14 @@ where
     pub fn sort(&mut self, category: Category, ascending: bool) {
         match self.sort {
             Some((cat, asc)) if cat == category && asc == ascending => return,
-            Some((cat, asc)) if cat == category => self.order.make_contiguous().reverse(),
+            Some((cat, _)) if cat == category => self.order.make_contiguous().reverse(),
             _ => {
-                let items = &self.items;
                 self.order.make_contiguous().sort_by(|entity_a, entity_b| {
-                    let cmp = items
+                    let cmp = self
+                        .items
                         .get(*entity_a)
                         .unwrap()
-                        .compare(items.get(*entity_b).unwrap(), category);
+                        .compare(self.items.get(*entity_b).unwrap(), category);
                     if ascending { cmp } else { cmp.reverse() }
                 });
             }

--- a/src/widget/table/model/mod.rs
+++ b/src/widget/table/model/mod.rs
@@ -347,19 +347,20 @@ where
 
     /// Sorts items in the model, this should be called before it is drawn after all items have been added for the view
     pub fn sort(&mut self, category: Category, ascending: bool) {
-        self.sort = Some((category, ascending));
-        let mut order: Vec<Entity> = self.order.iter().cloned().collect();
-        order.sort_by(|entity_a, entity_b| {
-            if ascending {
-                self.item(*entity_a)
-                    .unwrap()
-                    .compare(self.item(*entity_b).unwrap(), category)
-            } else {
-                self.item(*entity_b)
-                    .unwrap()
-                    .compare(self.item(*entity_a).unwrap(), category)
+        match self.sort {
+            Some((cat, asc)) if cat == category && asc == ascending => return,
+            Some((cat, asc)) if cat == category => self.order.make_contiguous().reverse(),
+            _ => {
+                let items = &self.items;
+                self.order.make_contiguous().sort_by(|entity_a, entity_b| {
+                    let cmp = items
+                        .get(*entity_a)
+                        .unwrap()
+                        .compare(items.get(*entity_b).unwrap(), category);
+                    if ascending { cmp } else { cmp.reverse() }
+                });
             }
-        });
-        self.order = order.into();
+        }
+        self.sort = Some((category, ascending));
     }
 }


### PR DESCRIPTION
While quickly reading at table widget, I figured the sort function was suboptimal.

This PR should speed it up.

- If the sort is already done, noop
- If the sort is on the same category but with a different direction, just reverse the order
  - **I believe this is something that happens a lot**
- If not, use `make_contiguous` to avoid reallocating new entities