### PR TITLE
Fixing build-time error on Non-Linux targets

### DIFF
--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -441,15 +441,12 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                     .map(|m: Message| icon!("window-minimize-symbolic", 16, m)),
             )
             .push_maybe(self.on_maximize.take().map(|m| {
-                icon!(
-                    if self.maximized {
-                        "window-restore-symbolic"
-                    } else {
-                        "window-maximize-symbolic"
-                    },
-                    16,
-                    m
-                )
+                if self.maximized {
+                    icon!("window-restore-symbolic", 16, m)
+                }
+                else {
+                    icon!("window-maximize-symbolic", 16, m)
+                }
             }))
             .push_maybe(
                 self.on_close


### PR DESCRIPTION
fixed error on non-linux targets due to use of a non-literal expression getting passed to the concat!()-macro