### PR TITLE
feat: `none` task utils

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -31,3 +31,7 @@ pub fn stream<X: Into<Y> + 'static, Y: 'static>(
 ) -> iced::Task<Y> {
     iced::Task::stream(stream.map(Into::into))
 }
+
+pub fn none<Y: 'static>() -> iced::Task<Y> {
+    iced::Task::none()
+}


### PR DESCRIPTION
`Task::none` is a popular variant so I think it's sensible to add it here for ease of access.