### PR TITLE
fix(theme mode subscription): avoid checking the keys because this in…

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -602,9 +602,6 @@ impl<T: Application> Cosmic<T> {
                 };
             }
             Action::SystemThemeModeChange(keys, mode) => {
-                if !keys.contains(&"is_dark") {
-                    return iced::Task::none();
-                }
                 if match THEME.lock().unwrap().theme_type {
                     ThemeType::System {
                         theme: _,


### PR DESCRIPTION
…terferes with the first value from the subscription

the check should be redundant, because we also later check whether the value has changed or not anyway

fixes https://github.com/pop-os/cosmic-panel/issues/364