### PR TITLE
[Header Bar] Reduce chance of end elements being pushed out

### DIFF
--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -15,14 +15,14 @@ pub fn calendar<M>(
     on_select: impl Fn(NaiveDate) -> M + 'static,
     on_prev: impl Fn() -> M + 'static,
     on_next: impl Fn() -> M + 'static,
-    first_day_of_week: Weekday
+    first_day_of_week: Weekday,
 ) -> Calendar<M> {
     Calendar {
         model,
         on_select: Box::new(on_select),
         on_prev: Box::new(on_prev),
         on_next: Box::new(on_next),
-        first_day_of_week
+        first_day_of_week,
     }
 }
 
@@ -107,7 +107,7 @@ pub struct Calendar<'a, M> {
     on_select: Box<dyn Fn(NaiveDate) -> M>,
     on_prev: Box<dyn Fn() -> M>,
     on_next: Box<dyn Fn() -> M>,
-    first_day_of_week: Weekday
+    first_day_of_week: Weekday,
 }
 
 impl<'a, Message> From<Calendar<'a, Message>> for crate::Element<'a, Message>

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -24,6 +24,7 @@ pub fn header_bar<'a, Message>() -> HeaderBar<'a, Message> {
         density: None,
         focused: false,
         maximized: false,
+        is_ssd: false,
         on_double_click: None,
     }
 }
@@ -80,6 +81,9 @@ pub struct HeaderBar<'a, Message> {
 
     /// Maximized state of the window
     maximized: bool,
+
+    /// HeaderBar used for server-side decorations
+    is_ssd: bool,
 }
 
 impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
@@ -363,7 +367,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             )
             .align_y(iced::Alignment::Center)
             .height(Length::Fixed(32.0 + padding[0] as f32 + padding[2] as f32))
-            .padding(padding)
+            .padding(if self.is_ssd { [0, 8, 0, 8] } else { padding })
             .spacing(8)
             .apply(widget::container)
             .class(crate::theme::Container::HeaderBar {

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -326,7 +326,6 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
         let portion = ((start.len().max(end.len()) as f32 / center.len().max(1) as f32).round()
             as u16)
             .max(1);
-        let center_empty = center.is_empty() && self.title.is_empty();
         // Creates the headerbar widget.
         let mut widget = widget::row::with_capacity(3)
             // If elements exist in the start region, append them here.
@@ -340,17 +339,19 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             )
             // If elements exist in the center region, use them here.
             // This will otherwise use the title as a widget if a title was defined.
-            .push(if !center.is_empty() {
-                widget::row::with_children(center)
-                    .spacing(space_xxxs)
-                    .align_y(iced::Alignment::Center)
-                    .apply(widget::container)
-                    .center_x(Length::Fill)
-                    .into()
-            } else if self.title.is_empty() {
-                widget::horizontal_space().into()
+            .push_maybe(if !center.is_empty() {
+                Some(
+                    widget::row::with_children(center)
+                        .spacing(space_xxxs)
+                        .align_y(iced::Alignment::Center)
+                        .apply(widget::container)
+                        .center_x(Length::Fill)
+                        .into(),
+                )
+            } else if !self.title.is_empty() {
+                Some(self.title_widget())
             } else {
-                self.title_widget()
+                None
             })
             .push(
                 widget::row::with_children(end)
@@ -358,11 +359,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
                     .align_y(iced::Alignment::Center)
                     .apply(widget::container)
                     .align_x(iced::Alignment::End)
-                    .width(if center_empty {
-                        Length::Fill
-                    } else {
-                        Length::FillPortion(portion)
-                    }),
+                    .width(Length::FillPortion(portion)),
             )
             .align_y(iced::Alignment::Center)
             .height(Length::Fixed(32.0 + padding[0] as f32 + padding[2] as f32))

--- a/src/widget/spin_button.rs
+++ b/src/widget/spin_button.rs
@@ -153,13 +153,14 @@ macro_rules! make_button {
     ($spin_button:expr, $icon:expr, $operation:expr) => {{
         #[cfg(target_os = "linux")]
         let button = icon::from_name($icon);
-        
+
         #[cfg(not(target_os = "linux"))]
-        let button = icon::from_svg_bytes(
-            include_bytes!(concat!["../../res/icons/", $icon ,".svg"])
-        ).symbolic(true);
-        
-        button.apply(button::icon)
+        let button =
+            icon::from_svg_bytes(include_bytes!(concat!["../../res/icons/", $icon, ".svg"]))
+                .symbolic(true);
+
+        button
+            .apply(button::icon)
             .on_press(($spin_button.on_press)($operation(
                 $spin_button.value,
                 $spin_button.step,

--- a/src/widget/warning.rs
+++ b/src/widget/warning.rs
@@ -40,13 +40,12 @@ impl<'a, Message: 'static + Clone> Warning<'a, Message> {
             .on_press_maybe(self.on_close);
 
         #[cfg(not(target_os = "linux"))]
-        let close_button = icon::from_svg_bytes(
-            include_bytes!("../../res/icons/window-close-symbolic.svg")
-        )
-            .symbolic(true)
-            .apply(widget::button::icon)
-            .icon_size(16)
-            .on_press_maybe(self.on_close);
+        let close_button =
+            icon::from_svg_bytes(include_bytes!("../../res/icons/window-close-symbolic.svg"))
+                .symbolic(true)
+                .apply(widget::button::icon)
+                .icon_size(16)
+                .on_press_maybe(self.on_close);
 
         widget::row::with_capacity(2)
             .push(label)


### PR DESCRIPTION
This mostly addresses #852, but end elements can still get pushed out at narrow widths if the center is populated (or the center is empty but there are a lot of them or some of them take a lot of space).

A proper fix would likely need some upstream improvements to the row widget to prevent children from going out of bounds (if they haven't already been made), or some kind of custom widget that would handle things as it should (so that #854 could also be fixed).

Edit: Also adds an `is_ssd` field to the bar, for different handling of SSDs.