### PR TITLE
Use size thresholds for panel sizing in libcosmic

### DIFF
--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -426,23 +426,24 @@ impl Context {
     pub fn text<'a>(&self, msg: impl Into<Cow<'a, str>>) -> crate::widget::Text<'a, crate::Theme> {
         let msg = msg.into();
         let t = match self.size {
-            Size::PanelSize(PanelSize::XL) => crate::widget::text::title2,
-            Size::PanelSize(PanelSize::L) => crate::widget::text::title3,
-            Size::PanelSize(PanelSize::M) => crate::widget::text::title4,
-            Size::PanelSize(PanelSize::S) => crate::widget::text::body,
-            Size::PanelSize(PanelSize::XS) => crate::widget::text::body,
-            Size::PanelSize(PanelSize::Custom(s)) => {
-                if s >= 80 {
-                    crate::widget::text::title2
-                } else if s >= 64 {
-                    crate::widget::text::title3
-                } else if s >= 48 {
-                    crate::widget::text::title4
-                } else {
+            Size::Hardcoded(_) => crate::widget::text,
+            Size::PanelSize(ref s) => {
+                let size = s.get_applet_icon_size_with_padding(false);
+
+                let size_threshold_small = PanelSize::S.get_applet_icon_size_with_padding(false);
+                let size_threshold_medium = PanelSize::M.get_applet_icon_size_with_padding(false);
+                let size_threshold_large = PanelSize::L.get_applet_icon_size_with_padding(false);
+
+                if size <= size_threshold_small {
                     crate::widget::text::body
+                } else if size <= size_threshold_medium {
+                    crate::widget::text::title4
+                } else if size <= size_threshold_large {
+                    crate::widget::text::title3
+                } else {
+                    crate::widget::text::title2
                 }
             }
-            Size::Hardcoded(_) => crate::widget::text,
         };
         t(msg).font(crate::font::default())
     }


### PR DESCRIPTION
After working on https://github.com/pop-os/cosmic-applets/pull/957, I realized that a more future-proof way of handling the variable sizing for panels is to have size thresholds instead of hardcoding the current panel size values for `PanelSize::S` and `PanelSize::M`, etc.

The alternative would be to come up with some sort of math that scales these sizes up depending on panel size, but this is the next best thing.

Doesn't introduce any sizing changes, just changes how the sizing is calculated, so that if we change the equivalent sizes of the small, medium, large panels, we will have these change for free.