### PR TITLE
fix(windows): Mingw doesn't support trim

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -215,7 +215,7 @@ where
             crate::Action::DbusActivation(message) => self.app.dbus_activation(message),
         };
 
-        #[cfg(target_env = "gnu")]
+        #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
         crate::malloc::trim(0);
 
         message
@@ -397,7 +397,7 @@ where
             self.app.view().map(crate::Action::App)
         };
 
-        #[cfg(target_env = "gnu")]
+        #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
         crate::malloc::trim(0);
 
         view
@@ -407,7 +407,7 @@ where
     pub fn view(&self) -> Element<crate::Action<T::Message>> {
         let view = self.app.view_main();
 
-        #[cfg(target_env = "gnu")]
+        #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
         crate::malloc::trim(0);
 
         view

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -96,7 +96,7 @@ pub(crate) fn iced_settings<App: Application>(
 ///
 /// Returns error on application failure.
 pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Result {
-    #[cfg(target_env = "gnu")]
+    #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
     if let Some(threshold) = settings.default_mmap_threshold {
         crate::malloc::limit_mmap_threshold(threshold);
     }

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -460,7 +460,7 @@ pub fn run<App: Application>(flags: App::Flags) -> iced::Result {
     let mut settings = helper.window_settings();
     settings.resizable = None;
 
-    #[cfg(target_env = "gnu")]
+    #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
     if let Some(threshold) = settings.default_mmap_threshold {
         crate::malloc::limit_mmap_threshold(threshold);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub use iced_wgpu;
 pub mod icon_theme;
 pub mod keyboard_nav;
 
-#[cfg(target_env = "gnu")]
+#[cfg(all(target_env = "gnu", not(target_os = "windows")))]
 pub(crate) mod malloc;
 
 #[cfg(all(feature = "process", not(windows)))]


### PR DESCRIPTION
Closes: #872

Small fix. The intersection of GNU libc and Windows is mingw. Mingw doesn't [support `trim`](https://www.gnu.org/software/gnulib/manual/html_node/malloc_005ftrim.html).