### PR TITLE
Update syn to v2.

### DIFF
--- a/cosmic-config-derive/Cargo.toml
+++ b/cosmic-config-derive/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
+syn = "2.0"
 quote = "1.0"

--- a/cosmic-config-derive/src/lib.rs
+++ b/cosmic-config-derive/src/lib.rs
@@ -17,12 +17,16 @@ fn impl_cosmic_config_entry_macro(ast: &syn::DeriveInput) -> TokenStream {
     let version = attributes
         .iter()
         .find_map(|attr| {
-            if attr.path.is_ident("version") {
-                match attr.parse_meta() {
-                    Ok(syn::Meta::NameValue(syn::MetaNameValue {
-                        lit: syn::Lit::Int(lit_int),
+            if attr.path().is_ident("version") {
+                match attr.meta {
+                    syn::Meta::NameValue(syn::MetaNameValue {
+                        value:
+                            syn::Expr::Lit(syn::ExprLit {
+                                lit: syn::Lit::Int(ref lit_int),
+                                ..
+                            }),
                         ..
-                    })) => Some(lit_int.base10_parse::<u64>().unwrap()),
+                    }) => Some(lit_int.base10_parse::<u64>().unwrap()),
                     _ => None,
                 }
             } else {


### PR DESCRIPTION
This removes the last syn@1 dependency for at least cosmic-files and cosmic-comp.
Builds in the future will be faster by compiling less.