### PR TITLE
fix(cosmic-config): Avoid dual notifications in transaction commits

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -1,7 +1,7 @@
 //! Integrations for cosmic-config — the cosmic configuration system.
 
 use notify::{
-    event::{EventKind, ModifyKind},
+    event::{EventKind, ModifyKind, RenameMode},
     RecommendedWatcher, Watcher,
 };
 use serde::{de::DeserializeOwned, Serialize};
@@ -261,7 +261,9 @@ impl Config {
                 match event_res {
                     Ok(event) => {
                         match &event.kind {
-                            EventKind::Access(_) | EventKind::Modify(ModifyKind::Metadata(_)) => {
+                            EventKind::Access(_)
+                            | EventKind::Modify(ModifyKind::Metadata(_))
+                            | EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
                                 // Data not mutated
                                 return;
                             }


### PR DESCRIPTION
When a transaction gets committed, the files gets written to a file in the `.atomicwrite[0-9a-Z]` folder and then gets moved to their final location. The watcher will emit two events:

- Modify(Name(To))
- Modify(Name(Both)

The last one will include both the source and the destination and is essentially a duplicate of the first event. By discarding this event, behavior seems to be the same, and all consumers of those events get only notified once instead of twice when a configuration changes.


This should avoid unnecessary computation when theme configuration changes and improve perceived performances.

Here's an example of a log where the same event is dispatched twice:

```
Key valid for dispatch: "is_dark": Event { kind: Modify(Name(To)), paths: ["/home/broken/.config/cosmic/com.system76.CosmicTheme.Mode/v1/is_dark"], attr:tracker: Some(32990), attr:flag: None, attr:info: None, attr:source: None }
Key valid for dispatch: "is_dark": Event { kind: Modify(Name(Both)), paths: ["/home/broken/.config/cosmic/com.system76.CosmicTheme.Mode/v1/.atomicwriteu1hIqv/tmpfile.tmp", "/home/broken/.config/cosmic/com.system76.CosmicTheme.Mode/v1/is_dark"], attr:tracker: Some(32990), attr:flag: None, attr:info: None, attr:source: None }
```