### PR TITLE
Add `dbus_connection()` method to `app::Application` trait

### DIFF
--- a/src/app/action.rs
+++ b/src/app/action.rs
@@ -22,6 +22,8 @@ pub enum Action {
     Close,
     /// Closes or shows the context drawer.
     ContextDrawer(bool),
+    #[cfg(feature = "single-instance")]
+    DbusConnection(zbus::Connection),
     /// Requests to drag the window.
     Drag,
     /// Window focus changed

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -755,6 +755,11 @@ impl<T: Application> Cosmic<T> {
                 }
             }
 
+            #[cfg(feature = "single-instance")]
+            Action::DbusConnection(conn) => {
+                return self.app.dbus_connection(conn);
+            }
+
             #[cfg(feature = "xdg-portal")]
             Action::DesktopSettings(crate::theme::portal::Desktop::ColorScheme(s)) => {
                 use ashpd::desktop::settings::ColorScheme;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -437,6 +437,14 @@ where
     fn dbus_activation(&mut self, msg: crate::dbus_activation::Message) -> Task<Self::Message> {
         Task::none()
     }
+
+    /// Invoked on connect to dbus session socket used for dbus activation
+    ///
+    /// Can be used to expose custom interfaces on the same owned name.
+    #[cfg(feature = "single-instance")]
+    fn dbus_connection(&mut self, conn: zbus::Connection) -> Task<Self::Message> {
+        Task::none()
+    }
 }
 
 /// Methods automatically derived for all types implementing [`Application`].

--- a/src/dbus_activation.rs
+++ b/src/dbus_activation.rs
@@ -44,6 +44,12 @@ pub fn subscription<App: ApplicationExt>() -> Subscription<crate::Action<App::Me
                         std::process::exit(1);
                     }
 
+                    output
+                        .send(crate::Action::Cosmic(crate::app::Action::DbusConnection(
+                            conn.clone(),
+                        )))
+                        .await;
+
                     #[cfg(feature = "smol")]
                     let handle = {
                         std::thread::spawn(move || {


### PR DESCRIPTION
This allows an application that wants to expose a DBus protocol to use the same session DBus connection, and provide a protocol on the same owned bus name.

Without this, a Cosmic app using `single-instance` that wants to provide a DBus protocol must provide it on a bus name other than `APP_ID`.