### PR TITLE
Make ashpd optional for async-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ markdown = ["iced/markdown"]
 highlighter = ["iced/highlighter"]
 async-std = [
     "dep:async-std",
-    "ashpd/async-std",
+    "ashpd?/async-std",
     "rfd?/async-std",
     "zbus?/async-io",
     "iced/async-std",


### PR DESCRIPTION
This makes it possible to build libcosmic with the async-std feature for windows.