### PR TITLE
feat: add SSD support via config option

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -391,7 +391,7 @@ where
     pub fn style(&self, theme: &Theme) -> iced_runtime::Appearance {
         if let Some(style) = self.app.style() {
             style
-        } else if self.app.core().window.is_maximized {
+        } else if self.app.core().window.is_maximized || !self.app.core().window.client_decorations {
             let theme = THEME.lock().unwrap();
             crate::style::iced::application::appearance(theme.borrow())
         } else {

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -83,6 +83,9 @@ impl Default for Settings {
             #[cfg(feature = "wayland")]
             autosize: false,
             no_main_window: false,
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            client_decorations: false,
+            #[cfg(target_os = "linux")]
             client_decorations: true,
             debug: false,
             default_font: font::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,6 +46,11 @@ pub fn apply_theme_global() -> bool {
     COSMIC_TK.read().unwrap().apply_theme_global
 }
 
+/// Enable client-side decorations.
+pub fn client_decorations() -> bool {
+    COSMIC_TK.read().unwrap().client_decorations
+}
+
 /// Show minimize button in window header.
 #[allow(clippy::missing_panics_doc)]
 pub fn show_minimize() -> bool {
@@ -98,6 +103,9 @@ pub struct CosmicTk {
     /// Show maximize button in window header.
     pub show_maximize: bool,
 
+    /// Enables client-side decorations.
+    pub client_decorations: bool,
+
     /// Preferred icon theme.
     pub icon_theme: String,
 
@@ -120,6 +128,10 @@ impl Default for CosmicTk {
             apply_theme_global: false,
             show_minimize: true,
             show_maximize: true,
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            client_decorations: false,
+            #[cfg(target_os = "linux")]
+            client_decorations: true,
             icon_theme: String::from("Cosmic"),
             header_size: Density::Standard,
             interface_density: Density::Standard,

--- a/src/core.rs
+++ b/src/core.rs
@@ -39,6 +39,7 @@ pub struct Window {
     pub show_maximize: bool,
     pub show_minimize: bool,
     pub is_maximized: bool,
+    pub client_decorations: bool,
     height: f32,
     width: f32,
 }
@@ -143,6 +144,7 @@ impl Default for Core {
                 show_minimize: true,
                 show_window_menu: false,
                 is_maximized: false,
+                client_decorations: true,
                 height: 0.,
                 width: 0.,
             },


### PR DESCRIPTION
This PR adds support for SSD in libcosmic via a config option. 
CSD is default on Linux, but will be disabled if the option in the toolkit config file or in `app::settings::Settings` are true.
On MacOS and Windows, SSD is default: see the last comment on #523. It will be disabled if the option in the toolkit config file or in `app::settings::Settings` are false.
(I know it's not technically SSD on Mac and Windows but it functions mostly the same)

Fixes: 
- #913 
- #776 
- #437 and #487 (when SSD is enabled on a window manager which supports this) 
- #421 (when SSD is enabled on a window manager which supports this)
- #523 - partially.