### PR TITLE
fix(cosmic_config): Make `get_local` return `key_path()` error

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -322,23 +322,22 @@ impl ConfigGet for Config {
     fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, Error> {
         match self.get_local(key) {
             Ok(value) => Ok(value),
-            Err(Error::NotFound) => self.get_system_default(key),
+            Err(Error::NoConfigDirectory | Error::NotFound) => self.get_system_default(key),
             Err(why) => Err(why),
         }
     }
 
     fn get_local<T: DeserializeOwned>(&self, key: &str) -> Result<T, Error> {
         // If key path exists
-        match self.key_path(key) {
-            Ok(key_path) if key_path.is_file() => {
-                // Load user override
-                let data = fs::read_to_string(key_path)
-                    .map_err(|err| Error::GetKey(key.to_string(), err))?;
+        let key_path = self.key_path(key)?;
+        if key_path.is_file() {
+            // Load user override
+            let data =
+                fs::read_to_string(key_path).map_err(|err| Error::GetKey(key.to_string(), err))?;
 
-                Ok(ron::from_str(&data)?)
-            }
-
-            _ => Err(Error::NotFound),
+            Ok(ron::from_str(&data)?)
+        } else {
+            Err(Error::NotFound)
         }
     }
 


### PR DESCRIPTION
It looks like this was changed to be like this in cd8f4ee85. But `key_path()` only seems to return `Error::NoConfigDirectory` or `Error::InvalidName`, so it seems reasonable to just update `get()` to also check for `NoConfigDirectory`. (`get_local()` doesn't seem to be used elsewhere, so I don't see nay issues this can cause.)

It's also a bit odd that `get_default()` doesn't map errors to `NotFound`. I guess `is_err()` should return `true` if the default config doesn't exist, since (at least for some settings) it's important to have default configurations present? But then `get_system_default()` could return `NoConfigDirectory` from the `.default_path()` call, which has the same issue...

Also, maybe using `is_file()`, then reading the file, is racy. Not that it should matter that much, but just checking for not found errors from the `read_to_string` call is probably sufficient.

Leaving as a draft while considering these other issues.