### PR TITLE
Don't error when default config for toolkit settings is not present

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -369,6 +369,12 @@ where
                         .into_iter()
                         .filter(cosmic_config::Error::is_err)
                     {
+                        if let cosmic_config::Error::GetKey(_, err) = &why {
+                            if err.kind() == std::io::ErrorKind::NotFound {
+                                // No system default config installed; don't error
+                                continue;
+                            }
+                        }
                         tracing::error!(?why, "cosmic toolkit config update error");
                     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,12 @@ pub static COSMIC_TK: LazyLock<RwLock<CosmicTk>> = LazyLock::new(|| {
             .map(|c| {
                 CosmicTk::get_entry(&c).unwrap_or_else(|(errors, mode)| {
                     for why in errors.into_iter().filter(cosmic_config::Error::is_err) {
+                        if let cosmic_config::Error::GetKey(_, err) = &why {
+                            if err.kind() == std::io::ErrorKind::NotFound {
+                                // No system default config installed; don't error
+                                continue;
+                            }
+                        }
                         tracing::error!(?why, "CosmicTk config entry error");
                     }
                     mode


### PR DESCRIPTION
Like https://github.com/pop-os/cosmic-settings-daemon/pull/100. We don't appear to install default configs for these settings anywhere? And we may not want libcosmic to inherently depend on globally installed config files.

So just avoid printing errors in that case.

We may want to consider what errors `ConfigGet` returns (https://github.com/pop-os/libcosmic/pull/948) but this should do for now.

This should help with a big part of the log spam libcosmic is currently producing.