### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ image = { version = "0.25.8", default-features = false, features = [
     "jpeg",
     "png",
 ] }
-lazy_static = "1.5.0"
 libc = { version = "0.2.175", optional = true }
 license = { version = "3.7.0", optional = true }
 mime = { version = "0.3.17", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,50 +99,50 @@ async-std = [
 
 [dependencies]
 apply = "0.3.0"
-ashpd = { version = "0.11.0", default-features = false, optional = true }
+ashpd = { version = "0.12.0", default-features = false, optional = true }
 async-fs = { version = "2.1", optional = true }
 async-std = { version = "1.13", optional = true }
 auto_enums = "0.8.7"
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "6254f50", optional = true }
-chrono = "0.4.40"
+chrono = "0.4.41"
 cosmic-config = { path = "cosmic-config" }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", optional = true }
 css-color = "0.2.8"
-derive_setters = "0.1.6"
+derive_setters = "0.1.8"
 futures = "0.3"
-image = { version = "0.25.5", default-features = false, features = [
+image = { version = "0.25.8", default-features = false, features = [
     "jpeg",
     "png",
 ] }
 lazy_static = "1.5.0"
-libc = { version = "0.2.171", optional = true }
-license = { version = "3.6.0", optional = true }
+libc = { version = "0.2.175", optional = true }
+license = { version = "3.7.0", optional = true }
 mime = { version = "0.3.17", optional = true }
 palette = "0.7.6"
 raw-window-handle = "0.6"
-rfd = { version = "0.15.3", default-features = false, features = [
+rfd = { version = "0.15.4", default-features = false, features = [
     "xdg-portal",
 ], optional = true }
 rustix = { version = "1.0", features = ["pipe", "process"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 slotmap = "1.0.7"
 smol = { version = "2.0.2", optional = true }
-thiserror = "2.0.12"
-tokio = { version = "1.44.1", optional = true }
+thiserror = "2.0.16"
+tokio = { version = "1.47.1", optional = true }
 tracing = "0.1.41"
 unicode-segmentation = "1.12"
-url = "2.5.4"
-zbus = { version = "5.7.1", default-features = false, optional = true }
+url = "2.5.7"
+zbus = { version = "5.10.0", default-features = false, optional = true }
 
 # Enable DBus feature on Linux targets
 [target.'cfg(target_os = "linux")'.dependencies]
 cosmic-config = { path = "cosmic-config", features = ["dbus"] }
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings" }
-zbus = { version = "5.7.1", default-features = false }
+zbus = { version = "5.10.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 freedesktop-icons = { package = "cosmic-freedesktop-icons", git = "https://github.com/pop-os/freedesktop-icons" }
-freedesktop-desktop-entry = { version = "0.7.11", optional = true }
+freedesktop-desktop-entry = { version = "0.7.14", optional = true }
 shlex = { version = "1.3.0", optional = true }
 
 [dependencies.cosmic-theme]
@@ -197,7 +197,7 @@ git = "https://github.com/pop-os/cosmic-panel"
 optional = true
 
 [dependencies.ron]
-version = "0.9"
+version = "0.11"
 optional = true
 
 [dependencies.taffy]

--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -11,24 +11,24 @@ subscription = ["iced_futures"]
 
 [dependencies]
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
-zbus = { version = "5.7.1", default-features = false, optional = true }
+zbus = { version = "5.10.0", default-features = false, optional = true }
 atomicwrites = { git = "https://github.com/jackpot51/rust-atomicwrites" }
-calloop = { version = "0.14.2", optional = true }
-notify = "8.0.0"
-ron = "0.9.0"
+calloop = { version = "0.14.3", optional = true }
+notify = "8.2.0"
+ron = "0.11.0"
 serde = "1.0.219"
 cosmic-config-derive = { path = "../cosmic-config-derive/", optional = true }
 iced = { path = "../iced/", default-features = false, optional = true }
 iced_futures = { path = "../iced/futures/", default-features = false, optional = true }
-once_cell = "1.21.1"
+once_cell = "1.21.3"
 futures-util = { version = "0.3", optional = true }
 dirs.workspace = true
-tokio = { version = "1.44", optional = true, features = ["time"] }
+tokio = { version = "1.47", optional = true, features = ["time"] }
 async-std = { version = "1.13", optional = true }
 tracing = "0.1"
 
 [target.'cfg(unix)'.dependencies]
-xdg = "2.5"
+xdg = "3.0"
 
 [target.'cfg(windows)'.dependencies]
-known-folders = "1.2.0"
+known-folders = "1.3.1"

--- a/cosmic-config/Cargo.toml
+++ b/cosmic-config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-config"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = ["macro", "subscription"]
@@ -20,7 +20,6 @@ serde = "1.0.219"
 cosmic-config-derive = { path = "../cosmic-config-derive/", optional = true }
 iced = { path = "../iced/", default-features = false, optional = true }
 iced_futures = { path = "../iced/futures/", default-features = false, optional = true }
-once_cell = "1.21.3"
 futures-util = { version = "0.3", optional = true }
 dirs.workspace = true
 tokio = { version = "1.47", optional = true, features = ["time"] }

--- a/cosmic-config/src/dbus.rs
+++ b/cosmic-config/src/dbus.rs
@@ -4,8 +4,9 @@ use crate::{CosmicConfigEntry, Update};
 use cosmic_settings_daemon::{Changed, ConfigProxy, CosmicSettingsDaemonProxy};
 use futures_util::SinkExt;
 use iced_futures::{
-    futures::{self, future::pending, Stream, StreamExt},
-    stream, Subscription,
+    Subscription,
+    futures::{self, Stream, StreamExt, future::pending},
+    stream,
 };
 
 pub async fn settings_daemon_proxy() -> zbus::Result<CosmicSettingsDaemonProxy<'static>> {

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -140,9 +140,7 @@ impl Config {
     pub fn system(name: &str, version: u64) -> Result<Self, Error> {
         let path = sanitize_name(name)?.join(format!("v{version}"));
         #[cfg(unix)]
-        let system_path = xdg::BaseDirectories::with_prefix("cosmic")
-            .map_err(std::io::Error::from)?
-            .find_data_file(path);
+        let system_path = xdg::BaseDirectories::with_prefix("cosmic").find_data_file(path);
 
         #[cfg(windows)]
         let system_path =
@@ -164,9 +162,7 @@ impl Config {
 
         // Search data file, which provides default (e.g. /usr/share)
         #[cfg(unix)]
-        let system_path = xdg::BaseDirectories::with_prefix("cosmic")
-            .map_err(std::io::Error::from)?
-            .find_data_file(&path);
+        let system_path = xdg::BaseDirectories::with_prefix("cosmic").find_data_file(&path);
 
         #[cfg(windows)]
         let system_path =

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -1,10 +1,10 @@
 //! Integrations for cosmic-config — the cosmic configuration system.
 
 use notify::{
-    event::{EventKind, ModifyKind, RenameMode},
     RecommendedWatcher, Watcher,
+    event::{EventKind, ModifyKind, RenameMode},
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::{
     fmt, fs,
     io::Write,

--- a/cosmic-config/src/subscription.rs
+++ b/cosmic-config/src/subscription.rs
@@ -62,7 +62,7 @@ async fn start_listening<T: 'static + Send + Sync + PartialEq + Clone + CosmicCo
     state: ConfigState<T>,
     output: &mut mpsc::Sender<crate::Update<T>>,
 ) -> ConfigState<T> {
-    use iced_futures::futures::{future::pending, StreamExt};
+    use iced_futures::futures::{StreamExt, future::pending};
 
     match state {
         ConfigState::Init(config_id, version, is_state) => {

--- a/cosmic-theme/Cargo.toml
+++ b/cosmic-theme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-theme"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,7 +22,6 @@ serde_json = { version = "1.0.143", optional = true, features = [
     "preserve_order",
 ] }
 ron = "0.11.0"
-lazy_static = "1.5.0"
 csscolorparser = { version = "0.7.2", features = ["serde"] }
 cosmic-config = { path = "../cosmic-config/", default-features = false, features = [
     "subscription",

--- a/cosmic-theme/Cargo.toml
+++ b/cosmic-theme/Cargo.toml
@@ -18,15 +18,15 @@ no-default = []
 palette = { version = "0.7.6", features = ["serializing"] }
 almost = "0.2"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = { version = "1.0.140", optional = true, features = [
+serde_json = { version = "1.0.143", optional = true, features = [
     "preserve_order",
 ] }
-ron = "0.9.0"
+ron = "0.11.0"
 lazy_static = "1.5.0"
-csscolorparser = { version = "0.7.0", features = ["serde"] }
+csscolorparser = { version = "0.7.2", features = ["serde"] }
 cosmic-config = { path = "../cosmic-config/", default-features = false, features = [
     "subscription",
     "macro",
 ] }
 dirs.workspace = true
-thiserror = "2.0.12"
+thiserror = "2.0.16"

--- a/cosmic-theme/src/model/cosmic_palette.rs
+++ b/cosmic-theme/src/model/cosmic_palette.rs
@@ -1,15 +1,14 @@
-use lazy_static::lazy_static;
 use palette::Srgba;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
-lazy_static! {
-    /// built in light palette
-    pub static ref LIGHT_PALETTE: CosmicPalette =
-        ron::from_str(include_str!("light.ron")).unwrap();
-    /// built in dark palette
-    pub static ref DARK_PALETTE: CosmicPalette =
-        ron::from_str(include_str!("dark.ron")).unwrap();
-}
+/// built-in light palette
+pub static LIGHT_PALETTE: LazyLock<CosmicPalette> =
+    LazyLock::new(|| ron::from_str(include_str!("light.ron")).unwrap());
+
+/// built-in dark palette
+pub static DARK_PALETTE: LazyLock<CosmicPalette> =
+    LazyLock::new(|| ron::from_str(include_str!("dark.ron")).unwrap());
 
 /// Palette type
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -1,12 +1,12 @@
 use crate::{
+    Component, Container, CornerRadii, CosmicPalette, CosmicPaletteInner, DARK_PALETTE,
+    LIGHT_PALETTE, NAME, Spacing, ThemeMode,
     composite::over,
     steps::{color_index, get_small_widget_color, get_surface_color, get_text, steps},
-    Component, Container, CornerRadii, CosmicPalette, CosmicPaletteInner, Spacing, ThemeMode,
-    DARK_PALETTE, LIGHT_PALETTE, NAME,
 };
 use cosmic_config::{Config, CosmicConfigEntry};
 use palette::{
-    color_difference::Wcag21RelativeContrast, rgb::Rgb, IntoColor, Oklcha, Srgb, Srgba, WithAlpha,
+    IntoColor, Oklcha, Srgb, Srgba, WithAlpha, color_difference::Wcag21RelativeContrast, rgb::Rgb,
 };
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;

--- a/cosmic-theme/src/output/gtk4_output.rs
+++ b/cosmic-theme/src/output/gtk4_output.rs
@@ -1,5 +1,5 @@
-use crate::{composite::over, steps::steps, Component, Theme};
-use palette::{rgb::Rgba, Darken, IntoColor, Lighten, Srgba, WithAlpha};
+use crate::{Component, Theme, composite::over, steps::steps};
+use palette::{Darken, IntoColor, Lighten, Srgba, WithAlpha, rgb::Rgba};
 use std::{
     fs::{self, File},
     io::{self, Write},
@@ -7,7 +7,7 @@ use std::{
     path::Path,
 };
 
-use super::{to_rgba, OutputError};
+use super::{OutputError, to_rgba};
 
 impl Theme {
     #[must_use]

--- a/cosmic-theme/src/output/mod.rs
+++ b/cosmic-theme/src/output/mod.rs
@@ -1,4 +1,4 @@
-use palette::{rgb::Rgba, Srgba};
+use palette::{Srgba, rgb::Rgba};
 use thiserror::Error;
 
 use crate::Theme;

--- a/cosmic-theme/src/output/vs_code.rs
+++ b/cosmic-theme/src/output/vs_code.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Theme;
 
-use super::{to_hex, OutputError};
+use super::{OutputError, to_hex};
 
 /// Represents the workbench.colorCustomizations section of a VS Code settings.json file
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cosmic-theme/src/steps.rs
+++ b/cosmic-theme/src/steps.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 
 use almost::equal;
-use palette::{convert::FromColorUnclamped, ClampAssign, FromColor, Lch, Oklcha, Srgb, Srgba};
+use palette::{ClampAssign, FromColor, Lch, Oklcha, Srgb, Srgba, convert::FromColorUnclamped};
 
 /// Get an array of 100 colors with a specific hue and chroma
 /// over the full range of lightness.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -15,33 +15,37 @@ use cosmic_theme::Spacing;
 use cosmic_theme::ThemeMode;
 use iced_futures::Subscription;
 use iced_runtime::{Appearance, DefaultStyle};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 pub use style::*;
 
 pub type CosmicColor = ::palette::rgb::Srgba;
 pub type CosmicComponent = cosmic_theme::Component;
 pub type CosmicTheme = cosmic_theme::Theme;
 
-lazy_static::lazy_static! {
-    pub static ref COSMIC_DARK: CosmicTheme = CosmicTheme::dark_default();
-    pub static ref COSMIC_HC_DARK: CosmicTheme = CosmicTheme::high_contrast_dark_default();
-    pub static ref COSMIC_LIGHT: CosmicTheme = CosmicTheme::light_default();
-    pub static ref COSMIC_HC_LIGHT: CosmicTheme = CosmicTheme::high_contrast_light_default();
-    pub static ref TRANSPARENT_COMPONENT: Component = Component {
-        base: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        hover: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        pressed: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        selected: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        selected_text: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        focus: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        disabled: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        on: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        on_disabled: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        divider: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        border: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-        disabled_border: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
-    };
-}
+pub static COSMIC_DARK: LazyLock<CosmicTheme> = LazyLock::new(|| CosmicTheme::dark_default());
+
+pub static COSMIC_HC_DARK: LazyLock<CosmicTheme> =
+    LazyLock::new(|| CosmicTheme::high_contrast_dark_default());
+
+pub static COSMIC_LIGHT: LazyLock<CosmicTheme> = LazyLock::new(|| CosmicTheme::light_default());
+
+pub static COSMIC_HC_LIGHT: LazyLock<CosmicTheme> =
+    LazyLock::new(|| CosmicTheme::high_contrast_light_default());
+
+pub static TRANSPARENT_COMPONENT: LazyLock<Component> = LazyLock::new(|| Component {
+    base: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    hover: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    pressed: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    selected: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    selected_text: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    focus: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    disabled: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    on: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    on_disabled: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    divider: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    border: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+    disabled_border: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
+});
 
 pub(crate) static THEME: Mutex<Theme> = Mutex::new(Theme {
     theme_type: ThemeType::Dark,

--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -119,22 +119,14 @@ where
         macro_rules! icon {
             ($name:expr, $on_press:expr) => {{
                 #[cfg(target_os = "linux")]
-                let icon = {
-                    icon::from_name($name)
-                        .apply(button::icon)
-                };
+                let icon = { icon::from_name($name).apply(button::icon) };
                 #[cfg(not(target_os = "linux"))]
                 let icon = {
-                    icon::from_svg_bytes(include_bytes!(concat!(
-                        "../../res/icons/",
-                        $name,
-                        ".svg"
-                    )))
-                    .symbolic(true)
-                    .apply(button::icon)
+                    icon::from_svg_bytes(include_bytes!(concat!("../../res/icons/", $name, ".svg")))
+                        .symbolic(true)
+                        .apply(button::icon)
                 };
-                icon.padding([0, 12])
-                    .on_press($on_press)
+                icon.padding([0, 12]).on_press($on_press)
             }};
         }
         let date = text(this.model.visible.format("%B %Y").to_string()).size(18);

--- a/src/widget/color_picker/mod.rs
+++ b/src/widget/color_picker/mod.rs
@@ -6,6 +6,7 @@
 use std::borrow::Cow;
 use std::iter;
 use std::rc::Rc;
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -26,7 +27,6 @@ use iced_core::{
 
 use iced_widget::slider::HandleShape;
 use iced_widget::{Row, canvas, column, horizontal_space, row, scrollable, vertical_space};
-use lazy_static::lazy_static;
 use palette::{FromColor, RgbHue};
 
 use super::divider::horizontal;
@@ -38,17 +38,17 @@ use super::{Icon, button, segmented_control, text, text_input, tooltip};
 pub use ColorPickerModel as Model;
 
 // TODO is this going to look correct enough?
-lazy_static! {
-    pub static ref HSV_RAINBOW: Vec<iced::Color> = (0u16..8)
-        .map(
-            |h| iced::Color::from(palette::Srgba::from_color(palette::Hsv::new_srgb_const(
+pub static HSV_RAINBOW: LazyLock<Vec<Color>> = LazyLock::new(|| {
+    (0u16..8)
+        .map(|h| {
+            Color::from(palette::Srgba::from_color(palette::Hsv::new_srgb_const(
                 RgbHue::new(f32::from(h) * 360.0 / 7.0),
                 1.0,
-                1.0
+                1.0,
             )))
-        )
-        .collect();
-}
+        })
+        .collect()
+});
 
 const MAX_RECENT: usize = 20;
 


### PR DESCRIPTION
Updates dependencies and migrates workspace members to Rust 2024. Also replaces uses of `lazy_static` with `std::sync::LazyLock`.