### PR TITLE
fix: dialog overflow

### DIFF
--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -93,7 +93,9 @@ impl<'a, Message: Clone + 'static> From<Dialog<'a, Message>> for Element<'a, Mes
                 content_col = content_col
                     .push(widget::vertical_space().height(Length::Fixed(space_xxs.into())));
             }
-            content_col = content_col.push(widget::text::body(body));
+            content_col = content_col.push(
+                widget::container(widget::scrollable(widget::text::body(body))).max_height(300.),
+            );
             should_space = true;
         }
         for control in dialog.controls {


### PR DESCRIPTION
This pull request wraps overflowing text in a `scrollable` widget for the `body` method in the `Dialog` widget.