### PR TITLE
improv(cosmic-config): Remove unneeded trait bounds for subscriptions

### DIFF
--- a/cosmic-config/src/subscription.rs
+++ b/cosmic-config/src/subscription.rs
@@ -18,7 +18,7 @@ pub enum ConfigUpdate<T> {
 
 #[cold]
 pub fn config_subscription<
-    I: 'static + Copy + Send + Sync + Hash,
+    I: 'static + Hash,
     T: 'static + Send + Sync + PartialEq + Clone + CosmicConfigEntry,
 >(
     id: I,
@@ -30,7 +30,7 @@ pub fn config_subscription<
 
 #[cold]
 pub fn config_state_subscription<
-    I: 'static + Copy + Send + Sync + Hash,
+    I: 'static + Hash,
     T: 'static + Send + Sync + PartialEq + Clone + CosmicConfigEntry,
 >(
     id: I,


### PR DESCRIPTION
It looks like these functions where previously implemented in a different way that required these traits, but now it uses `Subscription::run_with_id`, the `id` only needs to be `Hash + 'static`.