### PR TITLE
improv(widget): take `FnOnce` in segbutton builder

### DIFF
--- a/src/widget/segmented_button/model/builder.rs
+++ b/src/widget/segmented_button/model/builder.rs
@@ -25,7 +25,7 @@ where
     #[must_use]
     pub fn insert(
         mut self,
-        builder: impl Fn(BuilderEntity<SelectionMode>) -> BuilderEntity<SelectionMode>,
+        builder: impl FnOnce(BuilderEntity<SelectionMode>) -> BuilderEntity<SelectionMode>,
     ) -> Self {
         let id = self.0.insert().id();
         builder(BuilderEntity { model: self, id }).model


### PR DESCRIPTION
The `builder` function only needs to be run once, so the `Fn` bound is a little restrictive.

Since all `Fn`s also implement `FnOnce` this is not a breaking change.