### PR TITLE
fix: compile errors on windows

### DIFF
--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -117,19 +117,6 @@ where
     Message: Clone + 'static,
 {
     fn from(this: Calendar<'a, Message>) -> Self {
-        macro_rules! icon {
-            ($name:expr, $on_press:expr) => {{
-                #[cfg(target_os = "linux")]
-                let icon = { icon::from_name($name).apply(button::icon) };
-                #[cfg(not(target_os = "linux"))]
-                let icon = {
-                    icon::from_svg_bytes(include_bytes!(concat!("../../res/icons/", $name, ".svg")))
-                        .symbolic(true)
-                        .apply(button::icon)
-                };
-                icon.padding([0, 12]).on_press($on_press)
-            }};
-        }
         macro_rules! translate_month {
             ($month:expr, $year:expr) => {{
                 match $month {
@@ -170,8 +157,18 @@ where
         .size(18);
 
         let month_controls = row::with_capacity(2)
-            .push(icon!("go-previous-symbolic", (this.on_prev)()))
-            .push(icon!("go-next-symbolic", (this.on_next)()));
+            .push(
+                icon::from_name("go-previous-symbolic")
+                    .apply(button::icon)
+                    .padding([0, 12])
+                    .on_press((this.on_prev)()),
+            )
+            .push(
+                icon::from_name("go-next-symbolic")
+                    .apply(button::icon)
+                    .padding([0, 12])
+                    .on_press((this.on_next)()),
+            );
 
         // Calender
         let mut calendar_grid: Grid<'_, Message> =

--- a/src/widget/icon/bundle.rs
+++ b/src/widget/icon/bundle.rs
@@ -4,6 +4,7 @@
 //! Embedded icons for platforms which do not support icon themes yet.
 
 /// Icon bundling is not enabled on unix platforms.
+#[cfg(unix)]
 pub fn get(icon_name: &str) -> Option<super::Data> {
     None
 }


### PR DESCRIPTION
calendar.rs had some left over icon! macro_rules macros referencing now deleted files.

bundle::get was defined twice on non-unix platforms.

A known remaining issue is that projects using libcosmic need to have cosmic-icons in their project root, since the crabtime macro uses crabtime::WORKSPACE_PATH rather than the path to wherever cargo puts libcosmic's git submodule.

See: 639326fcc31a95a0c7a9a5bb56f1ed4d53530f26