### PR TITLE
fix(popover): set default new popover position to `Bottom`

### DIFF
--- a/src/widget/popover.rs
+++ b/src/widget/popover.rs
@@ -52,7 +52,7 @@ where
             content: content.into(),
             modal: false,
             popup: None,
-            position: Position::Center,
+            position: Position::Bottom,
             on_close: None,
         }
     }


### PR DESCRIPTION
I didn't see this part in my previous PR (sorry!).
Not too important, but would allow removing some lines of code in Settings.