### PR TITLE
fix: cross compiling for windows from linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,13 @@
+use std::env;
+
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
 
-    #[cfg(not(unix))]
-    generate_bundled_icons();
+    if env::var_os("CARGO_CFG_UNIX").is_none() {
+        generate_bundled_icons();
+    }
 }
 
-#[cfg(not(unix))]
 fn generate_bundled_icons() {
     println!("cargo::rerun-if-changed=cosmic-icons");
 


### PR DESCRIPTION
#[cfg(not(unix))] applies to the host machine (since that's where the build script is running) rather than the compilation target. Instead, environment variables are available to provide the information relevant to the build target at the build script's runtime.

See #1060