### PR TITLE
Bug Fix: Update Windows escape character

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,9 @@ fn generate_bundled_icons() {
         )
         .into_iter()
         .fold(String::new(), |mut output, (name, path)| {
+            // This changes the escape character to the one used by Windows.
+            #[cfg(windows)]
+            let path = path.replace("\\", "/");
             output.push_str(&format!("    \"{name}\" => include_bytes!(\"{path}\"),\n"));
             output
         });


### PR DESCRIPTION
This single line change to the build.rs file just changes the escape character from the *nix standard `\` to the Windows standard `/`. This is in relation to issue #1071. 