### PR TITLE
Menu item width

### DIFF
--- a/examples/application/src/main.rs
+++ b/examples/application/src/main.rs
@@ -236,26 +236,26 @@ impl cosmic::Application for App {
                 (
                     "hi 1".into(),
                     vec![
-                        menu::Item::Button("hi 12", None, Action::Hi),
-                        menu::Item::Button("hi 13", None, Action::Hi2),
+                        menu::Item::button("hi 12", None, Action::Hi),
+                        menu::Item::button("hi 13", None, Action::Hi2),
                     ],
                 ),
                 (
                     "hi 2".into(),
                     vec![
-                        menu::Item::Button("hi 21", None, Action::Hi),
-                        menu::Item::Button("hi 22", None, Action::Hi2),
-                        menu::Item::Folder(
+                        menu::Item::button("hi 21", None, Action::Hi),
+                        menu::Item::button("hi 22", None, Action::Hi2),
+                        menu::Item::folder(
                             "nest 3 2 >".into(),
                             vec![
-                                menu::Item::Button("21", None, Action::Hi),
-                                menu::Item::Button("242", None, Action::Hi2),
-                                menu::Item::Button("2443", None, Action::Hi3),
-                                menu::Item::Folder(
+                                menu::Item::button("21", None, Action::Hi),
+                                menu::Item::button("242", None, Action::Hi2),
+                                menu::Item::button("2443", None, Action::Hi3),
+                                menu::Item::folder(
                                     "nest 4 2 >".into(),
                                     vec![
-                                        menu::Item::Button("243", None, Action::Hi2),
-                                        menu::Item::Button("2444", None, Action::Hi),
+                                        menu::Item::button("243", None, Action::Hi2),
+                                        menu::Item::button("2444", None, Action::Hi),
                                     ],
                                 ),
                             ],
@@ -265,34 +265,34 @@ impl cosmic::Application for App {
                 (
                     "hi 3".into(),
                     vec![
-                        menu::Item::Button("hi 31", None, Action::Hi),
-                        menu::Item::Button("hi 332", None, Action::Hi2),
-                        menu::Item::Button("hi 3333", None, Action::Hi3),
-                        menu::Item::Button("hi 33334", None, Action::Hi3),
-                        menu::Item::Button("hi 333335", None, Action::Hi3),
-                        menu::Item::Button("hi 3333336", None, Action::Hi3),
+                        menu::Item::button("hi 31", None, Action::Hi),
+                        menu::Item::button("hi 332", None, Action::Hi2),
+                        menu::Item::button("hi 3333", None, Action::Hi3),
+                        menu::Item::button("hi 33334", None, Action::Hi3),
+                        menu::Item::button("hi 333335", None, Action::Hi3),
+                        menu::Item::button("hi 3333336", None, Action::Hi3),
                     ],
                 ),
                 (
                     "hiiiiiiiiiiiiiiiiiii 4".into(),
                     vec![
-                        menu::Item::Button("hi 4", None, Action::Hi),
-                        menu::Item::Button("hi 44", None, Action::Hi2),
-                        menu::Item::Button("hi 444", None, Action::Hi3),
-                        menu::Item::Folder(
+                        menu::Item::button("hi 4", None, Action::Hi),
+                        menu::Item::button("hi 44", None, Action::Hi2),
+                        menu::Item::button("hi 444", None, Action::Hi3),
+                        menu::Item::folder(
                             "nest 4 >".into(),
                             vec![
-                                menu::Item::Button("hi 41", None, Action::Hi),
-                                menu::Item::Button("hi 442", None, Action::Hi2),
-                                menu::Item::Folder(
+                                menu::Item::button("hi 41", None, Action::Hi),
+                                menu::Item::button("hi 442", None, Action::Hi2),
+                                menu::Item::folder(
                                     "nest 3 4 >".into(),
                                     vec![
-                                        menu::Item::Button("hi 443", None, Action::Hi2),
-                                        menu::Item::Button("hi 4444", None, Action::Hi),
-                                        menu::Item::Button("hi 44444", None, Action::Hi3),
-                                        menu::Item::Button("hi 444445", None, Action::Hi3),
-                                        menu::Item::Button("hi 4444446", None, Action::Hi3),
-                                        menu::Item::Button("hi 44444447", None, Action::Hi3),
+                                        menu::Item::button("hi 443", None, Action::Hi2),
+                                        menu::Item::button("hi 4444", None, Action::Hi),
+                                        menu::Item::button("hi 44444", None, Action::Hi3),
+                                        menu::Item::button("hi 444445", None, Action::Hi3),
+                                        menu::Item::button("hi 4444446", None, Action::Hi3),
+                                        menu::Item::button("hi 44444447", None, Action::Hi3),
                                     ],
                                 ),
                             ],

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -122,19 +122,21 @@ impl App {
         Some(menu::items(
             &HashMap::new(),
             vec![
-                menu::Item::Button("New window", None, ContextMenuAction::WindowNew),
-                menu::Item::Divider,
-                menu::Item::Folder(
+                menu::Item::button("New window", None, ContextMenuAction::WindowNew),
+                menu::Item::divider(),
+                menu::Item::folder(
                     "View",
-                    vec![menu::Item::CheckBox(
+                    vec![menu::Item::checkbox(
                         "Hide content",
                         None,
                         self.hide_content,
                         ContextMenuAction::ToggleHideContent,
                     )],
-                ),
-                menu::Item::Divider,
-                menu::Item::Button("Quit", None, ContextMenuAction::WindowClose),
+                )
+                .width(200)
+                .min_width(180),
+                menu::Item::divider(),
+                menu::Item::button("Quit", None, ContextMenuAction::WindowClose),
             ],
         ))
     }

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -160,23 +160,26 @@ pub fn menu_bar<'a>(config: &Config, key_binds: &HashMap<KeyBind, Action>) -> El
         menu::items(
             key_binds,
             vec![
-                menu::Item::Button(
+                menu::Item::button(
                     "New window",
                     Some(cosmic::widget::icon::from_name("screenshot-window-symbolic").into()),
                     Action::WindowNew,
                 ),
-                menu::Item::Divider,
-                menu::Item::Folder(
+                menu::Item::divider(),
+                menu::Item::folder(
                     "View",
-                    vec![menu::Item::CheckBox(
+                    vec![menu::Item::checkbox(
                         "Hide content",
                         Some(cosmic::widget::icon::from_name("view-conceal-symbolic").into()),
                         config.hide_content,
                         Action::ToggleHideContent,
                     )],
-                ),
-                menu::Item::Divider,
-                menu::Item::Button(
+                )
+                .width(280)
+                .min_width(200)
+                .max_width(300),
+                menu::Item::divider(),
+                menu::Item::button(
                     "Quit",
                     Some(cosmic::widget::icon::from_name("window-close-symbolic").into()),
                     Action::WindowClose,

--- a/examples/nav-context/src/main.rs
+++ b/examples/nav-context/src/main.rs
@@ -135,9 +135,9 @@ impl cosmic::Application for App {
         Some(menu::items(
             &HashMap::new(),
             vec![
-                menu::Item::Button("Move Up", None, NavMenuAction::MoveUp(id)),
-                menu::Item::Button("Move Down", None, NavMenuAction::MoveDown(id)),
-                menu::Item::Button("Delete", None, NavMenuAction::Delete(id)),
+                menu::Item::button("Move Up", None, NavMenuAction::MoveUp(id)),
+                menu::Item::button("Move Down", None, NavMenuAction::MoveDown(id)),
+                menu::Item::button("Delete", None, NavMenuAction::Delete(id)),
             ],
         ))
     }

--- a/examples/table-view/src/main.rs
+++ b/examples/table-view/src/main.rs
@@ -212,7 +212,7 @@ impl cosmic::Application for App {
                     .item_context(move |item| {
                         Some(widget::menu::items(
                             &HashMap::new(),
-                            vec![widget::menu::Item::Button(
+                            vec![widget::menu::Item::button(
                                 format!("Action on {}", item.name.to_string()),
                                 None,
                                 Action::None,
@@ -227,7 +227,7 @@ impl cosmic::Application for App {
                     .item_context(|item| {
                         Some(widget::menu::items(
                             &HashMap::new(),
-                            vec![widget::menu::Item::Button(
+                            vec![widget::menu::Item::button(
                                 format!("Action on {}", item.name),
                                 None,
                                 Action::None,
@@ -238,12 +238,12 @@ impl cosmic::Application for App {
                         Some(widget::menu::items(
                             &HashMap::new(),
                             vec![
-                                widget::menu::Item::Button(
+                                widget::menu::Item::button(
                                     format!("Action on {} category", category.to_string()),
                                     None,
                                     Action::None,
                                 ),
-                                widget::menu::Item::Button(
+                                widget::menu::Item::button(
                                     format!("Other action on {} category", category.to_string()),
                                     None,
                                     Action::None,

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -69,7 +69,8 @@ pub use menu_bar::{MenuBar, menu_bar as bar};
 mod menu_inner;
 mod menu_tree;
 pub use menu_tree::{
-    MenuItem as Item, MenuTree as Tree, menu_button, menu_items as items, menu_root as root,
+    MenuItem as Item, MenuItemKind as ItemKind, MenuTree as Tree, menu_button, menu_items as items,
+    menu_root as root,
 };
 
 pub use crate::style::menu_bar::{Appearance, StyleSheet};

--- a/src/widget/menu/menu_inner.rs
+++ b/src/widget/menu/menu_inner.rs
@@ -1647,7 +1647,12 @@ fn get_children_layout<Message>(
 ) -> (Size, Vec<f32>, Vec<Size>) {
     let width = match item_width {
         ItemWidth::Uniform(u) => f32::from(u),
-        ItemWidth::Static(s) => f32::from(menu_tree.width.unwrap_or(s)),
+        ItemWidth::Static(s) => {
+            let base = f32::from(menu_tree.width.unwrap_or(s));
+            let min = menu_tree.min_width.map(f32::from).unwrap_or(0.0);
+            let max = menu_tree.max_width.map(f32::from).unwrap_or(f32::MAX);
+            base.clamp(min, max)
+        }
     };
 
     let child_sizes: Vec<Size> = match item_height {

--- a/src/widget/responsive_menu_bar.rs
+++ b/src/widget/responsive_menu_bar.rs
@@ -132,7 +132,7 @@ impl ResponsiveMenuBar {
                             key_binds,
                             trees
                                 .into_iter()
-                                .map(|mt| menu::Item::Folder(mt.0, mt.1))
+                                .map(|mt| menu::Item::folder(mt.0, mt.1))
                                 .collect(),
                         )
                         .into_iter()


### PR DESCRIPTION
## Summary

Refactors `MenuItem` from an enum to a struct wrapper, adding a `.width()` builder method that can be applied to any menu item type. This lets applications control submenu widths without hardcoding values into libcosmic forks/patches.

## Problem

Currently, there's no way to set a custom width on menu items. This causes issues when menu content (like file paths) is longer than the default width, resulting is bad looking UI.

**Before**:
<img width="1276" height="770" alt="before_cosmic-edit_menu_ui" src="https://github.com/user-attachments/assets/12311cec-5c6f-419f-8de6-1bae76331a40" />

**After**:
<img width="1273" height="580" alt="after_cosmic-viewer_ui" src="https://github.com/user-attachments/assets/c4e761b5-e4cc-491e-aeca-cd85dbb6f263" />

## Changes

- Renamed `MenuItem` enum to `MenuItemKind`
- Created new `MenuItem` struct wrapping `MenuItemKind` with optional `width` field
- Added `.width(u16)` builder method
- Added convenience constructors: `button()`, `button_disabled()`, `checkbox()`, `folder()`, and `divider()`
- Updated `menu_items()` to apply width to all item types.
- Updated `responsive_menu_bar.rs` to use new API

## Usage

```rust
// Old API
menu::Item::Folder(fl!("recent-folders"), items)

// New API
menu::Item::folder(fl!("recent-folders"), items).width(300)
```

## Migration

Existing code using enum variants (Item::Button(...), Item::Folder(...), etc.) should switch to the method constructors (Item::button(...), Item::folder(...), etc.). The From<MenuItemKind> impl provides backwards compatibility for code that builds MenuItemKind directly.

