### PR TITLE
refactor(segmented button): only clear tab drag after source event ca…

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -1121,7 +1121,6 @@ where
                             shell.publish(msg);
                         }
                         state.drop_hint = None;
-                        state.dragging_tab = None;
 
                         self.emit_drop_hint(shell, state.drop_hint);
                         if let Some(event) = pending_reorder {
@@ -1136,7 +1135,6 @@ where
                             "data received without entity id={my_id:?}"
                         );
                         state.drop_hint = None;
-                        state.dragging_tab = None;
 
                         self.emit_drop_hint(shell, state.drop_hint);
                         if let Some(event) = pending_reorder {


### PR DESCRIPTION
…ncel or finish.

Should improve the behavior so that drags are preserved as long as the button is held as mentioned in https://github.com/pop-os/cosmic-files/pull/1535