### PR TITLE
fix(single-instance): unminimize main window on dbus activate

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -1025,15 +1025,28 @@ impl<T: Application> Cosmic<T> {
                 }
                 return Task::batch(cmds);
             }
-            Action::Activate(_token) =>
-            {
-                #[cfg(feature = "wayland")]
+            Action::Activate(_token) => {
                 if let Some(id) = self.app.core().main_window_id() {
-                    return iced_winit::platform_specific::commands::activation::activate(
-                        id,
-                        #[allow(clippy::used_underscore_binding)]
-                        _token,
-                    );
+                    // Unminimize window before requesting to activate it.
+                    let mut task = iced_runtime::window::minimize(id, false);
+
+                    #[cfg(feature = "wayland")]
+                    {
+                        task = task.chain(
+                            iced_winit::platform_specific::commands::activation::activate(
+                                id,
+                                #[allow(clippy::used_underscore_binding)]
+                                _token,
+                            ),
+                        )
+                    }
+
+                    #[cfg(not(feature = "wayland"))]
+                    {
+                        task = task.chain(iced_runtime::window::gain_focus(id));
+                    }
+
+                    return task;
                 }
             }
 


### PR DESCRIPTION
Needed by https://github.com/pop-os/cosmic-settings/issues/1298.

This won't focus the window, but it will unminimize it before requesting activation from the compositor.