### PR TITLE
fix(cosmic-theme): copy for backup, not rename

### DIFF
--- a/cosmic-theme/src/output/qt_output.rs
+++ b/cosmic-theme/src/output/qt_output.rs
@@ -338,7 +338,7 @@ widgetStyle=qt6ct-style
     fn backup_non_cosmic_kdeglobals(ini: &Ini, path: &Path) -> io::Result<()> {
         if !Self::is_cosmic_kdeglobals(&ini)?.unwrap_or(true) {
             let backup_path = path.with_extension("bak");
-            fs::rename(path, &backup_path)?;
+            fs::copy(path, &backup_path)?;
         }
         Ok(())
     }


### PR DESCRIPTION
We're now merging the colors with kdeglobals, not replacing it with a symlink. So renaming the file gives us a missing file Io error:
`[2026-02-18T20:03:08Z ERROR cosmic_settings_daemon::theme] Failed to apply COSMIC theme exports. Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })`

Can confirm this fixes this bug:
1. Open COSMIC Settings > Desktop > Appearance
2. Enable "Apply current theme to GNOME apps"
3. Try switching between light and dark modes.
4. Qt apps like Ark do not respond to theme changes.

Also I checked to made sure that a non-existent kdeglobals file isn't an issue (i.e. for first boot into COSMIC).

***
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

