### PR TITLE
tweak(cosmic-theme): pretty write ini

### DIFF
--- a/cosmic-theme/src/output/mod.rs
+++ b/cosmic-theme/src/output/mod.rs
@@ -1,3 +1,4 @@
+use configparser::ini::WriteOptions;
 use palette::{Srgba, rgb::Rgba};
 use thiserror::Error;
 
@@ -77,4 +78,10 @@ pub fn to_rgba(c: Srgba) -> String {
         "rgba({}, {}, {}, {:1.2})",
         c_u8.red, c_u8.green, c_u8.blue, c.alpha
     )
+}
+
+pub fn qt_settings_ini_style() -> WriteOptions {
+    let mut write_options = WriteOptions::default();
+    write_options.blank_lines_between_sections = 1;
+    write_options
 }

--- a/cosmic-theme/src/output/qt56ct_output.rs
+++ b/cosmic-theme/src/output/qt56ct_output.rs
@@ -5,7 +5,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::OutputError;
+use super::{OutputError, qt_settings_ini_style};
 
 impl Theme {
     /// The "version" of this theme.
@@ -86,7 +86,8 @@ impl Theme {
             }
         }
 
-        ini.write(path).map_err(OutputError::Io)?;
+        ini.pretty_write(path, &qt_settings_ini_style())
+            .map_err(OutputError::Io)?;
         Ok(())
     }
 

--- a/cosmic-theme/src/output/qt_output.rs
+++ b/cosmic-theme/src/output/qt_output.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::OutputError;
+use super::{OutputError, qt_settings_ini_style};
 
 impl Theme {
     /// Produces a color scheme ini file for Qt.
@@ -258,7 +258,7 @@ widgetStyle=qt6ct-style
         }
 
         kdeglobals_ini
-            .write(kdeglobals_file)
+            .pretty_write(kdeglobals_file, &qt_settings_ini_style())
             .map_err(OutputError::Io)?;
         Ok(())
     }


### PR DESCRIPTION
Adds newlines in between ini sections.
Makes the files easier to read and it's how QtSettings formats it.

<img width="391" height="700" src="https://github.com/user-attachments/assets/fc437182-ef8d-4389-8bbf-85c225d45bcf" />


- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

