### PR TITLE
fix: right-clicking any sidebar item makes all sidebar items bold

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -246,7 +246,7 @@ where
         if let Some(text) = self.model.text.get(key) {
             let font = if self.button_is_focused(state, key) {
                 self.font_active
-            } else if state.show_context.is_some() || self.button_is_hovered(state, key) {
+            } else if state.show_context == Some(key) || self.button_is_hovered(state, key) {
                 self.font_hovered
             } else if self.model.is_active(key) {
                 self.font_active


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Hi, recently I implemented a context menu in the navabar inside my app and I stumbled upon a bug that made all items bold when opening the context menu (in the navbar), I found the issue has already been reported in: https://github.com/pop-os/cosmic-files/issues/1154. This commit fixes the issue with I believe no side effects.

When a context menu is open, state.show_context.is_some() is true for every button, not just the one that was right clicked. So every button gets assigned font_hovered (which is semibold), making them all appear bold.
I've fixed it by checking whether the context menu belongs to this specific button, not just whether any context menu is open at all. 