### PR TITLE
feat(text_input): add select_range method and Task function

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -1125,6 +1125,14 @@ pub fn select_all<Message: 'static>(id: Id) -> Task<Message> {
     task::effect(Action::widget(operation::text_input::select_all(id)))
 }
 
+/// Produces a [`Task`] that selects a range of the content of the [`TextInput`] with the given
+/// [`Id`].
+pub fn select_range<Message: 'static>(id: Id, start: usize, end: usize) -> Task<Message> {
+    task::effect(Action::widget(operation::text_input::select_range(
+        id, start, end,
+    )))
+}
+
 /// Computes the layout of a [`TextInput`].
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::too_many_arguments)]
@@ -2782,6 +2790,12 @@ impl State {
         self.cursor.select_range(0, usize::MAX);
     }
 
+    /// Selects a range of the content of the [`TextInput`].
+    #[inline]
+    pub fn select_range(&mut self, start: usize, end: usize) {
+        self.cursor.select_range(start, end);
+    }
+
     pub(super) fn setting_selection(&mut self, value: &Value, bounds: Rectangle<f32>, target: f32) {
         let position = if target > 0.0 {
             find_cursor_position(bounds, value, self, target)
@@ -2842,8 +2856,9 @@ impl operation::TextInput for State {
         todo!()
     }
 
+    #[inline]
     fn select_range(&mut self, start: usize, end: usize) {
-        todo!()
+        Self::select_range(self, start, end);
     }
 }
 


### PR DESCRIPTION
Adds a public select_range(start, end) method to text_input::State and a corresponding Task function, following the same pattern as select_all.

Depends on: Dellareti/iced#1 (adds select_range to the iced TextInput operation trait)

Note: The iced submodule reference will need to be updated once the iced PR is merged.

Related: pop-os/cosmic-files#181


- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

