### PR TITLE
fix: nav item stays bold when context menu is closed

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -2073,7 +2073,7 @@ where
         _renderer: &Renderer,
         translation: Vector,
     ) -> Option<iced_core::overlay::Element<'b, Message, crate::Theme, Renderer>> {
-        let state = tree.state.downcast_ref::<LocalState>();
+        let state = tree.state.downcast_mut::<LocalState>();
         let menu_state = state.menu_state.clone();
 
         let entity = state.show_context?;
@@ -2089,6 +2089,12 @@ where
 
         if !menu_state.inner.with_data(|data| data.open) {
             // If the menu is not open, we don't need to show it.
+            // We also clear the context entity and update the text
+            // cache so that the item is not bold when the context menu is closed
+            state.show_context = None;
+            for key in self.model.order.iter().copied() {
+                self.update_entity_paragraph(state, key);
+            }
             return None;
         }
         bounds.x = state.context_cursor.x;


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This PR fixes: https://github.com/pop-os/cosmic-files/issues/1154, by removing the context entity and updating the text cache when the overlay is closed.
