### PR TITLE
feat(applets): add destroy tooltip popup action

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -230,6 +230,17 @@ where
                 iced_winit::commands::popup::destroy_popup(id)
             }
             #[cfg(all(feature = "wayland", target_os = "linux"))]
+            crate::surface::Action::DestroyTooltipPopup => {
+                #[cfg(feature = "applet")]
+                {
+                    iced_winit::commands::popup::destroy_popup(*crate::applet::TOOLTIP_WINDOW_ID)
+                }
+                #[cfg(not(feature = "applet"))]
+                {
+                    Task::none()
+                }
+            }
+            #[cfg(all(feature = "wayland", target_os = "linux"))]
             crate::surface::Action::DestroySubsurface(id) => {
                 iced_winit::commands::subsurface::destroy_subsurface(id)
             }

--- a/src/applet/mod.rs
+++ b/src/applet/mod.rs
@@ -42,7 +42,7 @@ static AUTOSIZE_ID: LazyLock<iced::id::Id> =
 static AUTOSIZE_MAIN_ID: LazyLock<iced::id::Id> =
     LazyLock::new(|| iced::id::Id::new("cosmic-applet-autosize-main"));
 static TOOLTIP_ID: LazyLock<crate::widget::Id> = LazyLock::new(|| iced::id::Id::new("subsurface"));
-static TOOLTIP_WINDOW_ID: LazyLock<window::Id> = LazyLock::new(window::Id::unique);
+pub(crate) static TOOLTIP_WINDOW_ID: LazyLock<window::Id> = LazyLock::new(window::Id::unique);
 
 #[derive(Debug, Clone)]
 pub struct Context {

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -36,6 +36,8 @@ pub enum Action {
     ),
     /// Destroy a subsurface with a view function
     DestroyPopup(iced::window::Id),
+    /// Destroys the global tooltip popup subsurface
+    DestroyTooltipPopup,
 
     /// Create a window with a view function accepting the App as a parameter
     AppWindow(
@@ -85,6 +87,7 @@ impl std::fmt::Debug for Action {
             }
             Self::Popup(arg0, arg1) => f.debug_tuple("Popup").field(arg0).field(arg1).finish(),
             Self::DestroyPopup(arg0) => f.debug_tuple("DestroyPopup").field(arg0).finish(),
+            Self::DestroyTooltipPopup => f.debug_tuple("DestroyTooltipPopup").finish(),
             Self::ResponsiveMenuBar {
                 menu_bar,
                 limits,


### PR DESCRIPTION
## Problem  
When an applet is minimized, its tooltip remains visible after activating the minimized button. 
After the applet button is clicked it gets removed and it is no longer capable of detecting mouse movements.

## Solution  
After the applet button is removed destroy the tooltip popup. 

At the moment the cosmic-applet-minimize cannot access the WindowId of the popup.
Therefor this PR exposes a Surface Action to destroy the tooltip popup on Window TOOLTIP_WINDOW_ID.
An alternative can be to expose `TOOLTIP_WINDOW_ID` directly instead of adding a new Surface action. Will change if wanted.

Related to pop-os/cosmic-panel#458
Needed for pop-os/cosmic-applets#1324

## Checks

- [x] I have disclosed use of any AI generated code in my commit messages. 
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

