### PR TITLE
feat(keybind): add layout-aware matching for non-Latin keyboard layouts

### DIFF
--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -1,3 +1,4 @@
+use iced_core::keyboard::key::{Code, Physical};
 use iced_core::keyboard::{Key, Modifiers};
 use std::fmt;
 
@@ -37,6 +38,7 @@ impl KeyBind {
     /// # Returns
     ///
     /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
+    #[deprecated(note = "Use `matches_layout_aware` instead for correct non-Latin keyboard layout support")]
     pub fn matches(&self, modifiers: Modifiers, key: &Key) -> bool {
         let key_eq = match (key, &self.key) {
             // CapsLock and Shift change the case of Key::Character, so we compare these in a case insensitive way
@@ -49,6 +51,94 @@ impl KeyBind {
             && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
             && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
     }
+
+    /// Checks if the given key and modifiers match the `KeyBind`, with a
+    /// fallback to the physical key position for non-Latin keyboard layouts.
+    ///
+    /// This is the recommended replacement for [`Self::matches`], which does not
+    /// handle non-Latin layouts correctly.
+    ///
+    /// # Arguments
+    ///
+    /// * `modifiers` - A `Modifiers` instance representing the current active modifiers.
+    /// * `key` - A reference to the `Key` that is being checked.
+    /// * `physical_key` - An optional reference to the physical key position,
+    ///   used as a fallback when the logical `key` does not match (e.g. on
+    ///   Cyrillic or other non-Latin layouts). Can be `None` for keys where
+    ///   the physical position is not relevant (e.g. `Key::Named`).
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
+    #[allow(deprecated)]
+    pub fn matches_layout_aware(
+        &self,
+        modifiers: Modifiers,
+        key: &Key,
+        physical_key: Option<&Physical>,
+    ) -> bool {
+        self.matches(modifiers, key)
+            || physical_key
+                .and_then(physical_key_to_latin)
+                .map(|latin| self.matches(modifiers, &latin))
+                .unwrap_or(false)
+    }
+}
+
+/// Converts a physical key code to the corresponding US-layout Latin `Key`.
+///
+/// This mapping is intentionally limited to keys that may produce different
+/// characters on non-Latin keyboard layouts (letters and punctuation). Keys
+/// like digits are not included because they remain the same across layouts.
+///
+/// Only used as a fallback when the primary key comparison in
+/// [`KeyBind::matches`] does not match.
+fn physical_key_to_latin(physical_key: &Physical) -> Option<Key> {
+    let code = match physical_key {
+        Physical::Code(code) => code,
+        Physical::Unidentified(_) => return None,
+    };
+    let ch = match code {
+        Code::KeyA => "a",
+        Code::KeyB => "b",
+        Code::KeyC => "c",
+        Code::KeyD => "d",
+        Code::KeyE => "e",
+        Code::KeyF => "f",
+        Code::KeyG => "g",
+        Code::KeyH => "h",
+        Code::KeyI => "i",
+        Code::KeyJ => "j",
+        Code::KeyK => "k",
+        Code::KeyL => "l",
+        Code::KeyM => "m",
+        Code::KeyN => "n",
+        Code::KeyO => "o",
+        Code::KeyP => "p",
+        Code::KeyQ => "q",
+        Code::KeyR => "r",
+        Code::KeyS => "s",
+        Code::KeyT => "t",
+        Code::KeyU => "u",
+        Code::KeyV => "v",
+        Code::KeyW => "w",
+        Code::KeyX => "x",
+        Code::KeyY => "y",
+        Code::KeyZ => "z",
+        Code::Minus => "-",
+        Code::Equal => "=",
+        Code::BracketLeft => "[",
+        Code::BracketRight => "]",
+        Code::Backslash => "\\",
+        Code::Semicolon => ";",
+        Code::Quote => "'",
+        Code::Backquote => "`",
+        Code::Comma => ",",
+        Code::Period => ".",
+        Code::Slash => "/",
+        _ => return None,
+    };
+    Some(Key::Character(ch.into()))
 }
 
 impl fmt::Display for KeyBind {

--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -28,35 +28,9 @@ pub struct KeyBind {
 }
 
 impl KeyBind {
-    /// Checks if the given key and modifiers match the `KeyBind`.
-    ///
-    /// # Arguments
-    ///
-    /// * `modifiers` - A `Modifiers` instance representing the current active modifiers.
-    /// * `key` - A reference to the `Key` that is being checked.
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
-    #[deprecated(note = "Use `matches_layout_aware` instead for correct non-Latin keyboard layout support")]
-    pub fn matches(&self, modifiers: Modifiers, key: &Key) -> bool {
-        let key_eq = match (key, &self.key) {
-            // CapsLock and Shift change the case of Key::Character, so we compare these in a case insensitive way
-            (Key::Character(a), Key::Character(b)) => a.eq_ignore_ascii_case(b),
-            (a, b) => a.eq(b),
-        };
-        key_eq
-            && modifiers.logo() == self.modifiers.contains(&Modifier::Super)
-            && modifiers.control() == self.modifiers.contains(&Modifier::Ctrl)
-            && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
-            && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
-    }
-
-    /// Checks if the given key and modifiers match the `KeyBind`, with a
-    /// fallback to the physical key position for non-Latin keyboard layouts.
-    ///
-    /// This is the recommended replacement for [`Self::matches`], which does not
-    /// handle non-Latin layouts correctly.
+    /// Checks if the given key and modifiers match the `KeyBind`, with an
+    /// optional fallback to the physical key position for non-Latin keyboard
+    /// layouts.
     ///
     /// # Arguments
     ///
@@ -70,18 +44,24 @@ impl KeyBind {
     /// # Returns
     ///
     /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
-    #[allow(deprecated)]
-    pub fn matches_layout_aware(
-        &self,
-        modifiers: Modifiers,
-        key: &Key,
-        physical_key: Option<&Physical>,
-    ) -> bool {
-        self.matches(modifiers, key)
+    pub fn matches(&self, modifiers: Modifiers, key: &Key, physical_key: Option<&Physical>) -> bool {
+        let key_eq = self.key_eq(key)
             || physical_key
                 .and_then(physical_key_to_latin)
-                .map(|latin| self.matches(modifiers, &latin))
-                .unwrap_or(false)
+                .is_some_and(|latin| self.key_eq(&latin));
+        key_eq
+            && modifiers.logo() == self.modifiers.contains(&Modifier::Super)
+            && modifiers.control() == self.modifiers.contains(&Modifier::Ctrl)
+            && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
+            && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
+    }
+
+    fn key_eq(&self, key: &Key) -> bool {
+        match (key, &self.key) {
+            // CapsLock and Shift change the case of Key::Character, so we compare these in a case insensitive way
+            (Key::Character(a), Key::Character(b)) => a.eq_ignore_ascii_case(b),
+            (a, b) => a.eq(b),
+        }
     }
 }
 


### PR DESCRIPTION
So, the description of this feature is better to start with by referencing the fix for keyboard layout-independent shortcuts in the cosmic-comp: https://github.com/pop-os/cosmic-comp/pull/2067.

**Brief fix/feature overview:**
Keyboard shortcuts defined as Latin characters (e.g., Ctrl+Shift+C, Ctrl+Shift+V) don't work when a non-Latin keyboard layout (Cyrillic, Arabic, etc.) is active. It happens because `KeyBind::matches` compares the logical `Key`, which contains the localized character (e.g., "м" instead of "v" on Cyrillic layout).

The PR adds `KeyBind::matches_layout_aware` which accepts an optional physical_key parameter and uses it as a fallback: if the logical key doesn't match, the physical key position is mapped to its US-layout Latin equivalent and compared against it.

**Investigation**
There are plenty of options that were considered, and honestly, it was a deep-deep rabbit hole to figure out what is happening and what solution we can provide for a better experience with less invasion.

So, the root cause is in how events flow through the whole stack:
- `sctk` receives a raw keycode from the compositor and creates a [KeyEvent](https://github.com/Smithay/client-toolkit/blob/master/src/seat/keyboard/mod.rs#L269) with `Keysym` (which is already a localized character, for "м" it returns `Keysym::Cyrllic_Em`), yet it still contains raw_code (KEY_V, which is great for us)!
- `iced` keyboard handler receives `KeyEvent` from `sctk` and [passes it further](https://github.com/pop-os/iced/blob/master/winit/src/platform_specific/wayland/handlers/seat/keyboard.rs#L176)
- `sctk_event.rs` [converts it to the iced keyboard-event](https://github.com/pop-os/iced/blob/master/winit/src/platform_specific/wayland/sctk_event.rs#L609) and introduces `physical_key` based on `raw_code`: `PhysicalKey::Code(KeyCode::KeyV)`!
- a-a-a-nd libcosmic-based application subscribes to events like that:
```rs
event::listen_with(|event, _status, _window_id| match event {
      // physical_key almost always is just dropped
      Event::Keyboard(KeyEvent::KeyPressed { key, modifiers, .. }) => { 
         if some_keybind.matches(modifiers, &key) {
            // fails to capture with non-Latin layouts
         }
      }
      // ...
  })
```

**Possible solutions**
- In cosmic-comp, we managed to use xkb state to get latin keysym, but `sctk` doesn't expose xkb state
- We can try to introduce owned `xkb` state in the iced, but why?
- We can introduce `latin_keysym` for each keyboard event in `sctk`, but again, why?

**Not very elegant, but a reasonable solution**
Use the existing `physical_key` from iced's `KeyPressed` event to build a US-layout Latin fallback directly in `KeyBind::matches_layout_aware`.
- Match logical `Key`
- If didn't match - Convert `physical_key` to Latin Key
- Match Latin `Key`

So a failed example will become successful with minor changes in the code:
```rs
event::listen_with(|event, _status, _window_id| match event {
      // now we use physical_key
      Event::Keyboard(KeyEvent::KeyPressed { key, modifiers, physical_key .. }) => { 
         if some_keybind.matches_layout_aware(modifiers, &key, &phycial_key) {
            // 🥳 captured!
         }
      }
      // ...
  })
```

**UPD:** Per review feedback, removed `matches_layout_aware` and `#[deprecated]`. Instead, I've updated `matches` directly with an additional `physical_key` parameter.

Updated usage example:
```rs
// - `some_keybind` is Ctrl+V
// - User pressed Ctrl+м
if some_keybind.matches(modifiers, &key, Some(&physical_key)) {
  // 🥳 captured!
}
```

**Some additional notes:**
- The best option, in my opinion, is to change the base of the `KeyBind` to `physical_key` only instead of `key`, but it's about redesign and introducing a parallel API. Which is quite too much for the first PR.
- I've added `#[deprecated]` to the existing matches method, and made `physical_key` optional in the layout-aware method - it feels natural to use the single replacement method for both cases for Named and Character `Key`s.
- `physical_key_to_latin` is intentionally put here, since we are not trying to cover all keys, but only those that alternate depending on the layout.

Agreements:
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

