### PR TITLE
fix: navbar fills the available height of the window

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -385,9 +385,8 @@ where
                 .on_context(|id| crate::Action::Cosmic(Action::NavBarContext(id)))
                 .context_menu(self.nav_context_menu(self.core().nav_bar_context()))
                 .into_container()
-                // XXX both must be shrink to avoid flex layout from ignoring it
                 .width(iced::Length::Shrink)
-                .height(iced::Length::Shrink);
+                .height(iced::Length::Fill);
 
         if !self.core().is_condensed() {
             nav = nav.max_width(280);


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

After the iced 0.14 rebase the default navbar no longer fills the height of the container. This applies the same fixes that have been applied individually to other apps (https://github.com/pop-os/cosmic-files/commit/3678a7fa0d91892e0cf55b746159d1c15cf5efd1), but for the default navbar.

Default navbar without fix:
<img width="1200" height="800" alt="nav_without_fix" src="https://github.com/user-attachments/assets/9e312f73-70b2-47ea-9499-d12b2feb3b3c" />


Default navbar after the fix:
<img width="1200" height="800" alt="nav_with_fix" src="https://github.com/user-attachments/assets/12813709-5081-4cf7-a4eb-a0ab5e57cf86" />
