### PR TITLE
fix(table): Use on_item_mb_double for double-click handler instead of on_item_mb_left

### DIFF
--- a/src/widget/table/widget/compact.rs
+++ b/src/widget/table/widget/compact.rs
@@ -145,7 +145,7 @@ where
                             })
                             // Double click
                             .apply(|mouse_area| {
-                                if let Some(ref on_item_mb) = val.on_item_mb_left {
+                                if let Some(ref on_item_mb) = val.on_item_mb_double {
                                     mouse_area.on_double_click((on_item_mb)(entity))
                                 } else {
                                     mouse_area

--- a/src/widget/table/widget/standard.rs
+++ b/src/widget/table/widget/standard.rs
@@ -206,7 +206,7 @@ where
                             })
                             // Double click
                             .apply(|mouse_area| {
-                                if let Some(ref on_item_mb) = val.on_item_mb_left {
+                                if let Some(ref on_item_mb) = val.on_item_mb_double {
                                     mouse_area.on_double_click((on_item_mb)(entity))
                                 } else {
                                     mouse_area


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

The double-click handlers in both `standard.rs` and `compact.rs` table widgets were incorrectly using `on_item_mb_left` instead of `on_item_mb_double`. This caused double clicks to trigger the incorrect callback.