### PR TITLE
Feat(cosmic-config): '::new_data'

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -54,6 +54,22 @@ fn get_state_dir() -> Option<PathBuf> {
     dirs::state_dir()
 }
 
+/// Get the data directory, with Flatpak sandbox support.
+fn get_data_dir() -> Option<PathBuf> {
+    // Check if we're running in Flatpak
+    if env::var_os("FLATPAK_ID").is_some() {
+        // Try HOST_XDG_DATA_HOME first
+        if let Some(host_data) = env::var_os("HOST_XDG_DATA_HOME") {
+            return Some(PathBuf::from(host_data));
+        }
+        // Fallback: try to construct from HOME
+        if let Some(home) = env::var_os("HOME") {
+            return Some(PathBuf::from(home).join(".local").join("share"));
+        }
+    }
+    dirs::data_dir()
+}
+
 #[cfg(feature = "subscription")]
 mod subscription;
 #[cfg(feature = "subscription")]
@@ -258,6 +274,24 @@ impl Config {
         user_path.push("cosmic");
         user_path.push(path);
         // Create new state directory if not found.
+        fs::create_dir_all(&user_path)?;
+
+        Ok(Self {
+            system_path: None,
+            user_path: Some(user_path),
+        })
+    }
+
+    /// Get data for the given application name and config version.
+    pub fn new_data(name: &str, version: u64) -> Result<Self, Error> {
+        // Look for [name]/v[version]
+        let path = sanitize_name(name)?.join(format!("v{}", version));
+
+        // Get libcosmic user data directory
+        let mut user_path = get_data_dir().ok_or(Error::NoConfigDirectory)?;
+        user_path.push("cosmic");
+        user_path.push(path);
+        // Create new data directory if not found.
         fs::create_dir_all(&user_path)?;
 
         Ok(Self {

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -88,4 +88,7 @@ pub fn main() {
 
     println!("Testing state");
     test_config(Config::new_state("com.system76.Example", 1).unwrap());
+
+    println!("Testing data");
+    test_config(Config::new_data("com.system76.Example", 1).unwrap());
 }


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

It works like `::new_state`, but stores files in `~/.local/share/cosmic/com.system76.Example/` instead of `~/.local/state/cosmic/com.system76.Example/` (on Linux, idk about `dirs` crate in other system)
