### PR TITLE
fix(flex_row): calculate height based on nodes

### DIFF
--- a/src/widget/flex_row/layout.rs
+++ b/src/widget/flex_row/layout.rs
@@ -162,9 +162,14 @@ pub fn resolve<Message>(
             });
         });
 
+    let actual_height = nodes
+        .iter()
+        .map(|node| node.bounds().y + node.bounds().height)
+        .fold(0.0f32, f32::max);
+
     let size = Size {
         width: flex_layout.content_size.width,
-        height: flex_layout.content_size.height,
+        height: actual_height.max(flex_layout.content_size.height),
     };
 
     Node::with_children(size, nodes)


### PR DESCRIPTION
`flex_row` was not resizing on word wrap:
 
<img width="747" height="230" alt="image" src="https://github.com/user-attachments/assets/454b2b4e-9476-404f-ac57-6a14777e66b3" />

after:
<img width="740" height="252" alt="image" src="https://github.com/user-attachments/assets/fc963b4d-250d-47d0-aa86-f9bf2bbd6a8d" />

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

