### PR TITLE
feat(text_input): Implement minimal IME support for COSMIC specific text widgets

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -26,7 +26,7 @@ use iced_core::input_method::{self, InputMethod, Preedit};
 use iced_core::mouse::{self, click};
 use iced_core::overlay::Group;
 use iced_core::renderer::{self, Renderer as CoreRenderer};
-use iced_core::text::{self, Paragraph, Renderer, Text};
+use iced_core::text::{self, Affinity, Paragraph, Renderer, Text};
 use iced_core::time::{Duration, Instant};
 use iced_core::touch;
 use iced_core::widget::Id;
@@ -2347,8 +2347,14 @@ fn input_method<'b>(
         cursor::State::Index(position) => position,
         cursor::State::Selection { start, end } => start.min(end),
     };
-    let (cursor, offset) =
-        measure_cursor_and_scroll_offset(state.value.raw(), text_bounds, cursor_index);
+    let (cursor, offset) = measure_cursor_and_scroll_offset(
+        state.value.raw(),
+        text_bounds,
+        cursor_index,
+        value,
+        state.cursor.affinity(),
+        state.scroll_offset,
+    );
     InputMethod::Enabled {
         cursor: Rectangle::new(
             Point::new(text_bounds.x + cursor - offset, text_bounds.y),


### PR DESCRIPTION
Closes https://github.com/pop-os/libcosmic/issues/578

The input method support in iced 14.0 requires custom text widgets to implement some logic to support input method input. This PR includes this for following COSMIC specific text widgets:
- COSMIC common `text_input`
- (and its search field state)

This PR
- Adds `InputMethod` event handling which
  - Opt-in the input method feature of the toolkit when the widget has the keyboard focus.
  - Inserts the committed text into the widget by reusing the clipboard pasting logic (you would like to refactor this).
- Specifies the IME's candidates window position from the text cursor position.
- Passes through the composing text (a.k.a. preedit) to the toolkit to display them in the redrawing path.

This PR depends on my pop-os/iced fork to work well with the current fcitx5 version. Please see the PR I opened:
- https://github.com/pop-os/iced/pull/291
- https://github.com/pop-os/iced/pull/292
- following one can be fixed later separately
  - https://github.com/pop-os/iced/pull/297

FYI, my old PR of backporting the IME feature may be a good reference to add IME support for an existing custom text widget. See `text_input.rs`:
- https://github.com/pop-os/iced/pull/255/changes#diff-0ae22896bd5e1f12bdc062ebe7916a6a0b5d4046614f28b3243a801b384c7894

---

demonstration with cosmic-file

https://github.com/user-attachments/assets/d68916a0-df74-4300-8b30-e919c569219d

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.