### PR TITLE
fix: restore width and height fill for app content

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -742,6 +742,8 @@ impl<App: Application> ApplicationExt for App {
             }));
         let content: Element<_> = if content_container {
             content_col
+                .width(iced::Length::Fill)
+                .height(iced::Length::Fill)
                 .apply(|w| id_container(w, iced_core::id::Id::new("COSMIC_content_container")))
                 .into()
         } else {


### PR DESCRIPTION
Looks like these were removed in https://github.com/pop-os/libcosmic/pull/1175. Not sure why.
Maybe @git-f0x can chime in.

But without these the content container shrinks when the navbar closes:

https://github.com/user-attachments/assets/c1fb7f1c-6147-44e3-84f5-fe06f7fcd68f


____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

