### PR TITLE
fix/cosmic-launcher #332: Terminal based programs Fail to run if using a different terminal emulator

### DIFF
--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -789,7 +789,7 @@ pub async fn spawn_desktop_exec<S, I, K, V>(
             })
             .unwrap_or_else(|| String::from("cosmic-term"));
 
-        term_exec = format!("{term} -- {}", exec.as_ref());
+        term_exec = format!("{term} -e {}", exec.as_ref());
         &term_exec
     } else {
         exec.as_ref()


### PR DESCRIPTION
Fixes [pop-os/cosmic-launcher#332](https://github.com/pop-os/cosmic-launcher/issues/332).

Tested with cosmic-term, ghostty, alacritty, kitty, xterm, konsole, foot, wezterm, and gnome-console. Should work with any terminal that supports the -e execute flag (most, if not all). 

No LLM or AI used for this contribution.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

