### PR TITLE
widget/icon: Bundle icons on macOS, not just Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,12 +170,12 @@ cosmic-config = { path = "cosmic-config", features = ["dbus"] }
 cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 zbus = { version = "5.14.0", default-features = false }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 freedesktop-icons = { package = "cosmic-freedesktop-icons", git = "https://github.com/pop-os/freedesktop-icons" }
 freedesktop-desktop-entry = { version = "0.8.1", optional = true }
 shlex = { version = "1.3.0", optional = true }
 
-[target.'cfg(not(unix))'.dependencies]
+[target.'cfg(any(not(unix), target_os = "macos"))'.dependencies]
 # Used to embed bundled icons for non-unix platforms.
 phf = { version = "0.13.1", features = ["macros"] }
 

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,9 @@ use std::env;
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
 
-    if env::var_os("CARGO_CFG_UNIX").is_none() {
+    if env::var_os("CARGO_CFG_UNIX").is_none()
+        || env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
+    {
         generate_bundled_icons();
     }
 }

--- a/src/widget/icon/bundle.rs
+++ b/src/widget/icon/bundle.rs
@@ -4,12 +4,12 @@
 //! Embedded icons for platforms which do not support icon themes yet.
 
 /// Icon bundling is not enabled on unix platforms.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub fn get(icon_name: &str) -> Option<super::Data> {
     None
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), target_os = "macos"))]
 /// Get a bundled icon on non-unix platforms.
 pub fn get(icon_name: &str) -> Option<super::Data> {
     ICONS
@@ -17,5 +17,5 @@ pub fn get(icon_name: &str) -> Option<super::Data> {
         .map(|bytes| super::Data::Svg(crate::iced::widget::svg::Handle::from_memory(*bytes)))
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), target_os = "macos"))]
 include!(concat!(env!("OUT_DIR"), "/bundled_icons.rs"));

--- a/src/widget/icon/named.rs
+++ b/src/widget/icon/named.rs
@@ -52,7 +52,7 @@ impl Named {
         }
     }
 
-    #[cfg(not(windows))]
+    #[cfg(all(unix, not(target_os = "macos")))]
     #[must_use]
     pub fn path(self) -> Option<PathBuf> {
         let name = &*self.name;
@@ -107,7 +107,7 @@ impl Named {
         result
     }
 
-    #[cfg(windows)]
+    #[cfg(any(not(unix), target_os = "macos"))]
     #[must_use]
     pub fn path(self) -> Option<PathBuf> {
         //TODO: implement icon lookup for Windows


### PR DESCRIPTION
Tested to be working as expected on macOS, Windows, and Linux. Icons in `cosmic-sync-gui` now appear as expected.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

