### PR TITLE
chore: enable ico and xpm image support for desktop feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ desktop = [
     "process",
     "dep:cosmic-settings-config",
     "dep:freedesktop-desktop-entry",
+    "dep:image-extras",
     "dep:mime",
     "dep:shlex",
     "tokio?/io-util",
@@ -141,9 +142,14 @@ css-color = "0.2.8"
 derive_setters = "0.1.9"
 futures = "0.3"
 image = { version = "0.25.10", default-features = false, features = [
+    "ico",
     "jpeg",
     "png",
 ] }
+image-extras = { version = "0.1.0", default-features = false, features = [
+    "xpm",
+    "xbm",
+], optional = true }
 libc = { version = "0.2.183", optional = true }
 log = "0.4"
 mime = { version = "0.3.17", optional = true }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -128,6 +128,9 @@ impl<A: crate::app::Application> BootFn<cosmic::Cosmic<A>, crate::Action<A::Mess
 ///
 /// Returns error on application failure.
 pub fn run<App: Application>(settings: Settings, flags: App::Flags) -> iced::Result {
+    #[cfg(feature = "desktop")]
+    image_extras::register();
+
     #[cfg(all(target_env = "gnu", not(target_os = "windows")))]
     if let Some(threshold) = settings.default_mmap_threshold {
         crate::malloc::limit_mmap_threshold(threshold);


### PR DESCRIPTION
Adds ico and xpm image support. Some older apps (Like Tizen studio) are missing icon in cosmic-app-library.

before:
<img width="1870" height="1088" alt="image" src="https://github.com/user-attachments/assets/f51fd051-9105-4bc7-82eb-9bc7f6d409b5" />

after:
<img width="1831" height="1055" alt="image" src="https://github.com/user-attachments/assets/d1ef0ea2-ab9b-46f4-bf56-635cc12b6496" />



___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

