### PR TITLE
fix: register image_extras in run_single_instance too

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -197,6 +197,9 @@ where
     App::Flags: CosmicFlags,
     App::Message: Clone + std::fmt::Debug + Send + 'static,
 {
+    #[cfg(feature = "desktop")]
+    image_extras::register();
+
     use std::collections::HashMap;
 
     let activation_token = std::env::var("XDG_ACTIVATION_TOKEN").ok();


### PR DESCRIPTION
I missed this in https://github.com/pop-os/libcosmic/pull/1245.
Should fix https://github.com/pop-os/cosmic-app-library/pull/361#pullrequestreview-4116239875.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

