### PR TITLE
fix(item builder): remove unnecessary lifetime bound for radio

### DIFF
--- a/src/widget/settings/item.rs
+++ b/src/widget/settings/item.rs
@@ -208,8 +208,8 @@ impl<'a, Message: Clone + 'static> Item<'a, Message> {
 
     pub fn radio<V, F>(self, value: V, selected: Option<V>, f: F) -> list::ListButton<'a, Message>
     where
-        V: Eq + Copy + 'static,
-        F: Fn(V) -> Message + 'static,
+        V: Eq + Copy,
+        F: Fn(V) -> Message,
     {
         let on_press = f(value);
         list::button(


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

CC @mmstick

Just removes the unneeded `'static` lifetime bounds for the radio builder, which caused lifetime nightmares in one spot in Settings. 🫠