### PR TITLE
improv(about): use `ListButton`

### DIFF
--- a/src/widget/about.rs
+++ b/src/widget/about.rs
@@ -1,8 +1,9 @@
 use crate::{
     Apply, Element, fl,
     iced::{Alignment, Length},
-    widget::{self, space},
+    widget::{self, list},
 };
+use std::rc::Rc;
 
 #[derive(Debug, Default, Clone, derive_setters::Setters)]
 #[setters(into, strip_option)]
@@ -104,19 +105,23 @@ pub fn about<'a, Message: Clone + 'static>(
         space_xxs, space_m, ..
     } = crate::theme::spacing();
 
-    let section_button = |name: &'a str, url: &'a str| -> Element<'a, Message> {
-        widget::row::with_capacity(3)
-            .push(widget::text(name))
-            .push(space::horizontal())
+    let svg_accent = Rc::new(|theme: &crate::Theme| widget::svg::Style {
+        color: Some(theme.cosmic().accent_text_color().into()),
+    });
+
+    let section_button = |name: &'a str, url: &'a str| -> list::ListButton<'a, Message> {
+        widget::row::with_capacity(2)
+            .push(widget::text::body(name).width(Length::Fill))
             .push_maybe(
-                (!url.is_empty()).then_some(crate::widget::icon::from_name("link-symbolic").icon()),
+                (!url.is_empty()).then_some(
+                    widget::icon::from_name("link-symbolic")
+                        .icon()
+                        .class(crate::theme::Svg::Custom(svg_accent.clone())),
+                ),
             )
             .align_y(Alignment::Center)
-            .apply(widget::button::custom)
-            .class(crate::theme::Button::Link)
+            .apply(list::button)
             .on_press(on_url_press(url))
-            .width(Length::Fill)
-            .into()
     };
 
     let section = |list: &'a Vec<(String, String)>, title: String| {

--- a/src/widget/settings/section.rs
+++ b/src/widget/settings/section.rs
@@ -3,12 +3,17 @@
 
 use crate::Element;
 use crate::widget::list_column::IntoListItem;
-use crate::widget::{ListColumn, column, text};
+use crate::widget::{ListColumn, column, list_column, text};
 use std::borrow::Cow;
 
 /// A section within a settings view column.
 pub fn section<'a, Message: Clone + 'static>() -> Section<'a, Message> {
     with_column(ListColumn::default())
+}
+
+/// A section with a pre-defined list column of a given capacity.
+pub fn with_capacity<'a, Message: Clone + 'static>(capacity: usize) -> Section<'a, Message> {
+    with_column(list_column::with_capacity(capacity))
 }
 
 /// A section with a pre-defined list column.
@@ -47,7 +52,7 @@ impl<'a, Message: Clone + 'static> Section<'a, Message> {
     }
 
     /// Add a child element to the section's list column, if `Some`.
-    pub fn add_maybe(self, item: Option<impl Into<Element<'a, Message>>>) -> Self {
+    pub fn add_maybe(self, item: Option<impl IntoListItem<'a, Message>>) -> Self {
         if let Some(item) = item {
             self.add(item)
         } else {
@@ -58,7 +63,7 @@ impl<'a, Message: Clone + 'static> Section<'a, Message> {
     /// Extends the [`Section`] with the given children.
     pub fn extend(
         self,
-        children: impl IntoIterator<Item = impl Into<Element<'a, Message>>>,
+        children: impl IntoIterator<Item = impl IntoListItem<'a, Message>>,
     ) -> Self {
         children.into_iter().fold(self, Self::add)
     }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

It seems I pushed this a minute after the previous PR was merged. 😅
This changes the about widget to use ListButton, and also updates the section methods that I forgot to use IntoListItem.
I also added `section::with_capacity()`. Not sure if it's worth the extra API complexity, since a section doesn't have a lot of items.

I've only colored the icon (rather than also the text), since I think it looks better this way:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/658031ce-5a69-44d8-895b-d3bf66395ba5" />