### PR TITLE
Fix IME double commit on GNOME Wayland desktop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ desktop-systemd-scope = ["desktop", "dep:zbus"]
 # Enables keycode serialization
 serde-keycode = ["iced_core/serde"]
 # Prevents multiple separate process instances.
-single-instance = ["zbus/blocking-api", "ron"]
+single-instance = ["iced_winit/single-instance", "zbus/blocking-api", "ron"]
 # smol async runtime
 smol = ["dep:smol", "iced/smol", "zbus?/async-io", "rfd?/async-std"]
 tokio = [


### PR DESCRIPTION
Fixes https://github.com/pop-os/libcosmic/issues/1251.

Depends on following iced change:
- https://github.com/pop-os/iced/pull/329

and iced update:
- https://github.com/pop-os/libcosmic/pull/1256

---

Before fix:

https://github.com/user-attachments/assets/0dae6d12-eb5b-487b-b528-fbe3b6d79809

After fix:

https://github.com/user-attachments/assets/ce99d5af-415a-4810-9c54-8508e8979656

- It sends winit's Ime::Commit event twice on only GNOME Wayland as far as I tested
  - One from winit wayland backend
  - One from my SctkWindow impl forwarding from wayland protocol to the iced toolkit in:
    - https://github.com/pop-os/iced/pull/292
- Though I am not sure this is the best way to enable/disable the latter mechanism, it works well if we limit the latter mechanism only when `single-instance` feature enabled.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
