### PR TITLE
fix(progress_bar): sync determinate animation clock on target change

### DIFF
--- a/src/widget/progress_bar/animation.rs
+++ b/src/widget/progress_bar/animation.rs
@@ -4,29 +4,38 @@ use std::time::Duration;
 
 const LAG: f32 = 0.1;
 
+#[derive(Default)]
 pub struct Progress {
     pub current: f32,
-    last: Instant,
-}
-
-impl Default for Progress {
-    fn default() -> Self {
-        Self {
-            current: 0.0,
-            last: Instant::now(),
-        }
-    }
+    target: Option<f32>,
+    last: Option<Instant>,
 }
 
 impl Progress {
     /// Smoothly chases `target` using exponential decay.
-    /// Returns `true` if still animating and a redraw should be requested.
+    /// Returns `true` if a redraw should be requested.
     pub fn update(&mut self, target: f32, now: Instant) -> bool {
-        let dt = (now - self.last).as_secs_f32();
-        self.last = now;
-        let next = self.current + (target - self.current) * (1.0 - (-dt / LAG).exp());
-        if (next - target).abs() > 0.001 {
-            self.current = next;
+        // Don't animate on start
+        let Some(last) = self.last else {
+            self.current = target;
+            self.target = Some(target);
+            self.last = Some(now);
+            return false;
+        };
+
+        // Sync animation clock when target changes
+        if self.target != Some(target) {
+            self.target = Some(target);
+            self.last = Some(now);
+            return true;
+        }
+
+        let dt = (now - last).as_secs_f32();
+        self.last = Some(now);
+        let diff = target - self.current;
+
+        if diff.abs() > 0.001 {
+            self.current += diff * (1.0 - (-dt / LAG).exp());
             true
         } else {
             self.current = target;


### PR DESCRIPTION
This prevents the time delta from becoming very large when the widget hasn't animated for a bit, leading to snapping instead of a smooth animation. Also prevents animating on widget creation, since it doesn't feel good in `cosmic-osd`.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.