### PR TITLE
fix(header_bar): prevent double coloring

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -773,7 +773,6 @@ impl<App: Application> ApplicationExt for App {
                         .focused(focused)
                         .maximized(maximized)
                         .sharp_corners(sharp_corners)
-                        .transparent(content_container)
                         .title(&core.window.header_title)
                         .on_drag(crate::Action::Cosmic(Action::Drag))
                         .on_right_click(crate::Action::Cosmic(Action::ShowWindowMenu))

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -26,7 +26,6 @@ pub fn header_bar<'a, Message>() -> HeaderBar<'a, Message> {
         sharp_corners: false,
         is_ssd: false,
         on_double_click: None,
-        transparent: false,
     }
 }
 
@@ -88,9 +87,6 @@ pub struct HeaderBar<'a, Message> {
 
     /// HeaderBar used for server-side decorations
     is_ssd: bool,
-
-    /// Whether the headerbar should be transparent
-    transparent: bool,
 }
 
 impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
@@ -370,6 +366,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             space_xxs,
             ..
         } = theme::spacing();
+        let is_ssd = self.is_ssd;
 
         // Take ownership of the regions to be packed.
         let start = std::mem::take(&mut self.start);
@@ -379,7 +376,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
         // Also packs the window controls at the very end.
         end.push(self.window_controls(space_xxs));
 
-        let padding = if self.is_ssd {
+        let padding = if is_ssd {
             [2, 8, 2, 8]
         } else {
             match (
@@ -424,7 +421,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             .class(theme::Container::HeaderBar {
                 focused: self.focused,
                 sharp_corners: self.sharp_corners,
-                transparent: self.transparent,
+                transparent: if is_ssd { false } else { true },
             })
             .height(Length::Fixed(32.0 + padding[0] as f32 + padding[2] as f32))
             .padding(padding)


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

The non-content container header bar is already colored separately (to adapt to the wrapping container border), so the transparent field isn't needed.
Mentioned in #1196.