### PR TITLE
fix: make menu bar background respect dynamic round settings

### DIFF
--- a/src/theme/style/menu_bar.rs
+++ b/src/theme/style/menu_bar.rs
@@ -71,7 +71,7 @@ impl StyleSheet for Theme {
                 background: component.base.into(),
                 border_width: 1.0,
                 bar_border_radius: cosmic.corner_radii.radius_xl,
-                menu_border_radius: cosmic.corner_radii.radius_s.map(|x| x + 2.0),
+                menu_border_radius: cosmic.corner_radii.radius_m,
                 border_color: component.divider.into(),
                 background_expand: [1; 4],
                 path: component.hover.into(),


### PR DESCRIPTION
Updated menu_border_radius in menu_bar.rs to use radius_m, matching standard dropdowns and correctly scaling with the dynamic Wayland popup border.

Fixes #1260 

