### PR TITLE
fix(segmented_button): reset menu state when reopening context menu

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -1398,6 +1398,8 @@ where
                             state.context_cursor = cursor_position.position().unwrap_or_default();
 
                             state.menu_state.inner.with_data_mut(|data| {
+                                // Clear stale MenuBounds from any previous context menu before opening a new one.
+                                data.reset();
                                 data.open = true;
                                 data.view_cursor = cursor_position;
                             });


### PR DESCRIPTION
When a context menu is open and the user right-clicks a different item, the overlay's close handler resets the menu state but no longer captures the event (since e10459f). The right-click propagates to the widget, which reopens the menu with stale `MenuBounds` from the previous context menu. If the new menu has a different number of items, this causes an assertion failure in `MenuState::layout`.

Call `data.reset()` before setting `data.open = true` in the right-click handler to ensure stale `MenuBounds` are cleared before the next layout pass rebuilds them.

I hit this crash while developing my fix for https://github.com/pop-os/cosmic-files/pull/1777 . After confirming it was unrelated to that change, I gave the crash stack to AI to diagnose. it came back with this one-line fix. I also used it to find the regression commit. I did a lot of manual validation and reading of the code it referenced but, in the end, its concise fix is correct. I did clean up the comment though!

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

