### PR TITLE
Add `list_button` component

### DIFF
--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -75,6 +75,8 @@ pub struct Theme {
     pub icon_button: Component,
     /// link button element colors
     pub link_button: Component,
+    /// list button element colors
+    pub list_button: Component,
     /// text button element colors
     pub text_button: Component,
     /// button component styling
@@ -1285,6 +1287,15 @@ impl ThemeBuilder {
                 component.on_disabled = over(component.on.with_alpha(0.5), component.base);
                 component
             },
+            list_button: Component::component(
+                Srgba::new(0.0, 0.0, 0.0, 0.0),
+                accent,
+                on_bg_component,
+                Srgba::new(0.0, 0.0, 0.0, 0.0),
+                button_pressed_overlay,
+                is_high_contrast,
+                control_steps_array[8],
+            ),
             success: Component::colored_component(
                 success,
                 control_steps_array[0],

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -150,7 +150,7 @@ pub fn appearance(
         }
         Button::ListItem(radii) => {
             corner_radii = radii;
-            let (background, text, icon) = color(&cosmic.background.component);
+            let (background, text, icon) = color(&cosmic.list_button);
 
             if selected {
                 appearance.background =
@@ -197,7 +197,7 @@ impl Catalog for crate::Theme {
             return active(focused, self);
         }
 
-        let mut s = appearance(self, focused, selected, false, style, move |component| {
+        appearance(self, focused, selected, false, style, move |component| {
             let text_color = if matches!(
                 style,
                 Button::Icon | Button::IconVertical | Button::HeaderBar
@@ -209,15 +209,7 @@ impl Catalog for crate::Theme {
             };
 
             (component.base.into(), text_color, text_color)
-        });
-
-        if let Button::ListItem(_) = style {
-            if !selected {
-                s.background = None;
-            }
-        }
-
-        s
+        })
     }
 
     fn disabled(&self, style: &Self::Class) -> Style {
@@ -245,7 +237,7 @@ impl Catalog for crate::Theme {
             return hovered(focused, self);
         }
 
-        let mut s = appearance(
+        appearance(
             self,
             focused || matches!(style, Button::Image),
             selected,
@@ -264,15 +256,7 @@ impl Catalog for crate::Theme {
 
                 (component.hover.into(), text_color, text_color)
             },
-        );
-
-        if let Button::ListItem(_) = style {
-            if !selected {
-                s.background = None;
-            }
-        }
-
-        s
+        )
     }
 
     fn pressed(&self, focused: bool, selected: bool, style: &Self::Class) -> Style {


### PR DESCRIPTION
This adds a new `list_button` field to theme, which makes ListItem buttons stay transparent when pressed. It's essentially a mix of `text_button` and `background.component`, without hover highlights (as per designs).

I noticed that applet menu buttons are transparent (while trying to use something similar as a ListColumn for them, with buttons having rounded corners), so I checked the differences and found out about this part of the code, which also allows simplifying stuff. :)

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

