### PR TITLE
wayland_handler: break on dispatch error instead of panicking

### DIFF
--- a/src/applet/token/wayland_handler.rs
+++ b/src/applet/token/wayland_handler.rs
@@ -171,7 +171,11 @@ pub(crate) fn wayland_handler(
         if app_data.exit {
             break;
         }
-        event_loop.dispatch(None, &mut app_data).unwrap();
+        if event_loop.dispatch(None, &mut app_data).is_err() {
+            // Compositor disconnected (e.g. broken pipe). Exit the
+            // dispatch loop instead of panicking the applet (#1243).
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1243. Compositor disconnect (broken pipe under heavy load) panicked all applets simultaneously; break out of the dispatch loop instead.