### PR TITLE
Fix shortcut matching for non-Latin keyboard layouts

### DIFF
--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -1,4 +1,4 @@
-use iced_core::keyboard::{Key, Modifiers};
+use iced_core::keyboard::{Key, Modifiers, key::Code, key::Physical};
 use std::fmt;
 
 /// Represents the modifier keys on a keyboard.
@@ -49,6 +49,18 @@ impl KeyBind {
             && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
             && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
     }
+
+    pub fn matches_physical(&self, modifiers: Modifiers, physical_key: Physical) -> bool {
+        let key_eq = match (&self.key, physical_key) {
+            (Key::Character(expected), Physical::Code(actual)) => physical_key_eq(expected, actual),
+            _ => false,
+        };
+        key_eq
+            && modifiers.logo() == self.modifiers.contains(&Modifier::Super)
+            && modifiers.control() == self.modifiers.contains(&Modifier::Ctrl)
+            && modifiers.alt() == self.modifiers.contains(&Modifier::Alt)
+            && modifiers.shift() == self.modifiers.contains(&Modifier::Shift)
+    }
 }
 
 impl fmt::Display for KeyBind {
@@ -61,5 +73,83 @@ impl fmt::Display for KeyBind {
             Key::Named(named) => write!(f, "{:?}", named),
             other => write!(f, "{:?}", other),
         }
+    }
+}
+
+fn physical_key_eq(expected: &str, code: Code) -> bool {
+    match code {
+        Code::KeyA => expected.eq_ignore_ascii_case("a"),
+        Code::KeyB => expected.eq_ignore_ascii_case("b"),
+        Code::KeyC => expected.eq_ignore_ascii_case("c"),
+        Code::KeyD => expected.eq_ignore_ascii_case("d"),
+        Code::KeyE => expected.eq_ignore_ascii_case("e"),
+        Code::KeyF => expected.eq_ignore_ascii_case("f"),
+        Code::KeyG => expected.eq_ignore_ascii_case("g"),
+        Code::KeyH => expected.eq_ignore_ascii_case("h"),
+        Code::KeyI => expected.eq_ignore_ascii_case("i"),
+        Code::KeyJ => expected.eq_ignore_ascii_case("j"),
+        Code::KeyK => expected.eq_ignore_ascii_case("k"),
+        Code::KeyL => expected.eq_ignore_ascii_case("l"),
+        Code::KeyM => expected.eq_ignore_ascii_case("m"),
+        Code::KeyN => expected.eq_ignore_ascii_case("n"),
+        Code::KeyO => expected.eq_ignore_ascii_case("o"),
+        Code::KeyP => expected.eq_ignore_ascii_case("p"),
+        Code::KeyQ => expected.eq_ignore_ascii_case("q"),
+        Code::KeyR => expected.eq_ignore_ascii_case("r"),
+        Code::KeyS => expected.eq_ignore_ascii_case("s"),
+        Code::KeyT => expected.eq_ignore_ascii_case("t"),
+        Code::KeyU => expected.eq_ignore_ascii_case("u"),
+        Code::KeyV => expected.eq_ignore_ascii_case("v"),
+        Code::KeyW => expected.eq_ignore_ascii_case("w"),
+        Code::KeyX => expected.eq_ignore_ascii_case("x"),
+        Code::KeyY => expected.eq_ignore_ascii_case("y"),
+        Code::KeyZ => expected.eq_ignore_ascii_case("z"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KeyBind, Modifier};
+    use iced_core::keyboard::{Key, Modifiers, key::Code, key::Physical};
+
+    #[test]
+    fn physical_shortcut_matches_layout_independent_key() {
+        let key_bind = KeyBind {
+            modifiers: vec![Modifier::Ctrl],
+            key: Key::Character("c".into()),
+        };
+
+        assert!(key_bind.matches_physical(Modifiers::CTRL, Physical::Code(Code::KeyC)));
+    }
+
+    #[test]
+    fn physical_shortcut_rejects_wrong_physical_key() {
+        let key_bind = KeyBind {
+            modifiers: vec![Modifier::Ctrl],
+            key: Key::Character("c".into()),
+        };
+
+        assert!(!key_bind.matches_physical(Modifiers::CTRL, Physical::Code(Code::KeyV)));
+    }
+
+    #[test]
+    fn physical_shortcut_rejects_wrong_modifiers() {
+        let key_bind = KeyBind {
+            modifiers: vec![Modifier::Ctrl],
+            key: Key::Character("c".into()),
+        };
+
+        assert!(!key_bind.matches_physical(Modifiers::SHIFT, Physical::Code(Code::KeyC)));
+    }
+
+    #[test]
+    fn logical_shortcut_still_matches_by_character() {
+        let key_bind = KeyBind {
+            modifiers: vec![Modifier::Ctrl],
+            key: Key::Character(",".into()),
+        };
+
+        assert!(key_bind.matches(Modifiers::CTRL, &Key::Character(",".into())));
     }
 }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages. - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR. - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

Adds layout-independent physical-key shortcut matching support to `KeyBind`.

This allows COSMIC applications to match standard editing shortcuts by physical
key position instead of only by the layout-dependent logical `Key::Character(...)`
value.

## Problem

Shortcut matching currently relies on logical key values such as
`Key::Character("c")` or `Key::Character("v")`.

Under non-Latin keyboard layouts, the same physical key can produce a different
logical character. For example, with a Ukrainian/Cyrillic layout, the physical
`C` key no longer produces the Latin `"С"` (They look similar, but the codes are different)character. As a result, applications
that define standard editing shortcuts with Latin letter keys may fail to match
those shortcuts when a non-Latin layout is active.

This affects common shortcuts such as:

- `Ctrl+C`
- `Ctrl+V`
- `Ctrl+X`
- `Ctrl+A`
- terminal-specific shortcuts such as `Ctrl+Shift+C` and `Ctrl+Shift+V`

## Fix

This change adds `KeyBind::matches_physical(...)`, which matches shortcuts by
layout-independent physical key position (`Physical::Code(Code::Key*)`) while
preserving the existing logical matcher.

The existing `KeyBind::matches(...)` behavior remains unchanged.

This lets applications opt into physical-key matching only where appropriate,
for example for standard editing shortcuts, while keeping logical matching for
layout-sensitive shortcuts such as punctuation.

## Why both logical and physical matching are needed

Desktop applications need both shortcut matching modes:

- logical matching for shortcuts that should follow the active keyboard layout;
- physical matching for standard editing shortcuts that should stay on the same
  physical keys across layouts.

This PR provides the missing shared primitive in `libcosmic` without changing
existing shortcut behavior for current consumers.

## Related issues

Addresses:

- pop-os/cosmic-epoch#3264

Related:

- pop-os/cosmic-epoch#3465 — duplicate of pop-os/cosmic-epoch#3264

## Follow-up

This change provides the shared `libcosmic` support needed to fix the issue in
COSMIC applications.

Follow-up changes are still needed in downstream applications such as
`cosmic-term` and `cosmic-edit` to opt into `matches_physical(...)` for their
standard editing shortcuts.