### PR TITLE
fix(process): safely exit forked child after spawning command

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@
 use smol::io::AsyncReadExt;
 use std::io;
 use std::os::fd::OwnedFd;
-use std::process::{Command, Stdio, exit};
+use std::process::{Command, Stdio};
 #[cfg(feature = "tokio")]
 use tokio::io::AsyncReadExt;
 
@@ -56,12 +56,18 @@ pub async fn spawn(mut command: Command) -> Option<u32> {
 
     match unsafe { libc::fork() } {
         // Parent process
-        1.. => {
+        fork_pid @ 1..=i32::MAX => {
             // Drop copy of write end, then read PID from pipe
             drop(write);
             let pid = read_from_pipe(read).await;
             // wait to prevent zombie
-            _ = rustix::process::wait(rustix::process::WaitOptions::empty());
+            let _ = tokio::task::spawn_blocking(move || {
+                let mut status = 0;
+                unsafe {
+                    libc::waitpid(fork_pid, &mut status, 0);
+                }
+            }).await;
+
             pid
         }
 
@@ -71,9 +77,14 @@ pub async fn spawn(mut command: Command) -> Option<u32> {
             if let Ok(child) = command.spawn() {
                 // Write PID to pipe
                 let _ = rustix::io::write(write, &child.id().to_be_bytes());
+                unsafe {
+                    libc::_exit(0);
+                }
             }
 
-            exit(0)
+            unsafe {
+                libc::_exit(1);
+            }
         }
 
         ..=-1 => {


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---

## Summary

Fixed process handling in `spawn()` to prevent `cosmic-app-library` from becoming a zombie process after launching applications.

## Before

When launching any application through `cosmic-app-library`, the `cosmic-app-library` process could become a zombie process.

The parent process was waiting using `rustix::process::wait(...)`, while the forked child process was exiting via `std::process::exit(0)`. This could affect the parent process state and leave the launcher in a broken state.

## How to reproduce

1. Open `cosmic-app-library`.
2. Launch any application from it.
3. Open `cosmic-app-library`.

Expected behavior:
`cosmic-app-library` responsive after spawning applications;

Current behavior:
`cosmic-app-library` became zombie process and doesn't response until restart;

## After

The parent process now waits for the forked child using `libc::waitpid(...)` inside `tokio::task::spawn_blocking(...)`, avoiding blocking the async runtime.

The forked child now exits using `libc::_exit(...)` after spawning the target command and writing the child PID to the pipe.

As a result, the child process terminates correctly and `cosmic-app-library` continues working normally after launching applications.

## Impact

- Prevents zombie processes after launching applications from `cosmic-app-library`
- Keeps `cosmic-app-library` responsive after spawning applications
- Avoids blocking the async runtime while waiting for the forked process
- Improves process cleanup and launcher stability

---

## Note

I marked several issues as possibly related to this fix because the problem stopped reproducing on my local setup after applying the change.

I have been testing the current version locally for the last 3 days, and the issue has not reproduced so far.

I do not have solid proof that these issues are definitely fixed by this change, but I can no longer reproduce them locally.