### PR TITLE
fix(process): safely exit forked child with _exit

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@
 use smol::io::AsyncReadExt;
 use std::io;
 use std::os::fd::OwnedFd;
-use std::process::{Command, Stdio, exit};
+use std::process::{Command, Stdio};
 #[cfg(feature = "tokio")]
 use tokio::io::AsyncReadExt;
 
@@ -56,24 +56,33 @@ pub async fn spawn(mut command: Command) -> Option<u32> {
 
     match unsafe { libc::fork() } {
         // Parent process
-        1.. => {
+        fork_pid @ 1..=i32::MAX => {
             // Drop copy of write end, then read PID from pipe
             drop(write);
             let pid = read_from_pipe(read).await;
-            // wait to prevent zombie
-            _ = rustix::process::wait(rustix::process::WaitOptions::empty());
+            _ = rustix::process::waitpid(
+                rustix::process::Pid::from_raw(fork_pid),
+                rustix::process::WaitOptions::empty(),
+            );
             pid
         }
 
         // Child process
         0 => {
             let _res = rustix::process::setsid();
-            if let Ok(child) = command.spawn() {
+            let exit_status = if let Ok(child) = command.spawn() {
                 // Write PID to pipe
                 let _ = rustix::io::write(write, &child.id().to_be_bytes());
-            }
+                0
+            } else {
+                1
+            };
 
-            exit(0)
+            // # Safety
+            // Required for child fork to exit without affecting the parent.
+            unsafe {
+                libc::_exit(exit_status);
+            }
         }
 
         ..=-1 => {

--- a/src/widget/menu/key_bind.rs
+++ b/src/widget/menu/key_bind.rs
@@ -44,7 +44,12 @@ impl KeyBind {
     /// # Returns
     ///
     /// * `bool` - `true` if the key and modifiers match the `KeyBind`, `false` otherwise.
-    pub fn matches(&self, modifiers: Modifiers, key: &Key, physical_key: Option<&Physical>) -> bool {
+    pub fn matches(
+        &self,
+        modifiers: Modifiers,
+        key: &Key,
+        physical_key: Option<&Physical>,
+    ) -> bool {
         let key_eq = self.key_eq(key)
             || physical_key
                 .and_then(physical_key_to_latin)


### PR DESCRIPTION
Replaces #1284

Though I cannot replicate it, this may fix some of the reports of the cosmic-app-library failing to open after spawning an application. And may fix the issue with NVIDIA GPUs having the validation error after spawning an application?

- Use `waitpid` to wait for the PID of the initial fork in the double fork to exit.
- Use `libc::_exit` in that initial fork after writing the PID of the double-forked child. This should ensure it exits without potentially affecting the state of the parent process.

After merging, this should be pulled in by cosmic-app-library, cosmic-files, and cosmic-launcher

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

