### PR TITLE
Update iced and fix crash by circular progressbar

### DIFF
--- a/src/theme/style/iced.rs
+++ b/src/theme/style/iced.rs
@@ -1341,9 +1341,16 @@ impl iced_widget::text::Catalog for Theme {
         match class {
             Text::Accent => iced_widget::text::Style {
                 color: Some(self.cosmic().accent_text_color().into()),
+                ..Default::default()
             },
-            Text::Default => iced_widget::text::Style { color: None },
-            Text::Color(c) => iced_widget::text::Style { color: Some(*c) },
+            Text::Default => iced_widget::text::Style {
+                color: None,
+                ..Default::default()
+            },
+            Text::Color(c) => iced_widget::text::Style {
+                color: Some(*c),
+                ..Default::default()
+            },
             Text::Custom(f) => f(self),
         }
     }

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -234,6 +234,7 @@ pub fn menu_items<
         color.alpha *= 0.75;
         TextStyle {
             color: Some(color.into()),
+            ..Default::default()
         }
     }
     let key_class = theme::Text::Custom(key_style);

--- a/src/widget/progress_bar/circular.rs
+++ b/src/widget/progress_bar/circular.rs
@@ -177,6 +177,9 @@ where
 
         let geometry = state.cache.draw(renderer, bounds.size(), |frame| {
             let track_radius = frame.width() / 2.0 - self.bar_height;
+            if track_radius <= 0.0 {
+                return;
+            }
             let track_path = canvas::Path::circle(frame.center(), track_radius);
 
             frame.stroke(


### PR DESCRIPTION
- adds the necessary changes for the selectable Text fill color
- fixes a crash when resizing circular progressbar
 
You can trigger the crash by running `RUST_BACKTRACE=1 cargo run -p application` and slowly changing the width of the window.

@wash2, not sure about "improv(wgpu): adapter selection" commit in Iced. I'm assuming it's fine to merge.  
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

