### PR TITLE
chore(circular): simplify code

### DIFF
--- a/src/widget/progress_bar/circular.rs
+++ b/src/widget/progress_bar/circular.rs
@@ -9,7 +9,8 @@ use iced::{Element, Event, Length, Radians, Rectangle, Renderer, Size, Vector, m
 use std::f32::consts::PI;
 use std::time::Duration;
 
-const MIN_ANGLE: Radians = Radians(PI / 8.0);
+const MIN_GAP_ANGLE: Radians = Radians(PI / 4.0);
+const MAX_WRAP: f32 = 1.0 - MIN_GAP_ANGLE.0 / (2.0 * PI);
 
 #[must_use]
 pub struct Circular<Theme>
@@ -75,12 +76,6 @@ where
     pub fn progress(mut self, progress: f32) -> Self {
         self.progress = Some(progress.clamp(0.0, 1.0));
         self
-    }
-
-    fn min_wrap(&self, track_radius: f32) -> (f32, f32) {
-        let cap_angle = self.bar_height / track_radius;
-        let gap = MIN_ANGLE.0.max(cap_angle);
-        ((gap - cap_angle) / (2.0 * PI), 1.0 - gap / PI)
     }
 }
 
@@ -148,11 +143,12 @@ where
                     shell.request_redraw();
                 }
             } else {
-                let (_, wrap) = self.min_wrap(self.size / 2.0 - self.bar_height);
-                state.animation =
-                    state
-                        .animation
-                        .timed_transition(self.cycle_duration, self.period, wrap, *now);
+                state.animation = state.animation.timed_transition(
+                    self.cycle_duration,
+                    self.period,
+                    MAX_WRAP,
+                    *now,
+                );
                 state.cache.clear();
                 shell.request_redraw();
             }
@@ -191,25 +187,6 @@ where
 
             // Converts a track fraction to an angle in radians, with 0 being top of circle
             let to_angle = |t: f32| t * 2.0 * PI - PI / 2.0;
-
-            let draw_cap = |frame: &mut canvas::Frame, t: f32, flip: bool| {
-                let angle = to_angle(t);
-                let center = frame.center() + Vector::new(angle.cos(), angle.sin()) * track_radius;
-                let (start_angle, end_angle) = if flip {
-                    (angle - PI, angle)
-                } else {
-                    (angle, angle + PI)
-                };
-                let mut builder = canvas::path::Builder::new();
-                builder.arc(canvas::path::Arc {
-                    center,
-                    radius: self.bar_height / 2.0,
-                    start_angle: Radians(start_angle),
-                    end_angle: Radians(end_angle),
-                });
-                frame.fill(&builder.build(), custom_style.bar_color);
-            };
-
             let draw_bar = |frame: &mut canvas::Frame, start: f32, end: f32| {
                 let mut builder = canvas::path::Builder::new();
                 builder.arc(canvas::path::Arc {
@@ -222,10 +199,9 @@ where
                     &builder.build(),
                     canvas::Stroke::default()
                         .with_color(custom_style.bar_color)
-                        .with_width(self.bar_height),
+                        .with_width(self.bar_height)
+                        .with_line_cap(canvas::LineCap::Round),
                 );
-                draw_cap(frame, end, false);
-                draw_cap(frame, start, true);
             };
 
             if self.progress.is_some() {
@@ -243,10 +219,11 @@ where
                 }
                 draw_bar(frame, 0.0, state.progress.current);
             } else {
-                let (min, wrap) = self.min_wrap(track_radius);
-                let (start, end) = state
-                    .animation
-                    .bar_positions(self.cycle_duration, min, wrap);
+                // f32::EPSILON prevents flicker when wrap angle is 0.0
+                let (start, end) =
+                    state
+                        .animation
+                        .bar_positions(self.cycle_duration, f32::EPSILON, MAX_WRAP);
                 draw_bar(frame, start, end);
             }
         });

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -259,7 +259,7 @@ where
 
                 // draw bar segment
                 if current_p > seg_lo {
-                    let fill = ((current_p - seg_lo) / (seg_hi - seg_lo)).clamp(0.0, 1.0);
+                    let fill = ((current_p - seg_lo) / (seg_hi - seg_lo)).min(1.0);
                     draw_quad(
                         x_start,
                         x_width * fill,


### PR DESCRIPTION
Uses `with_line_cap(canvas::LineCap::Round)` for drawing caps directly, instead of attaching semi-circles to the ends manually. This also fixes the small wedge-shaped gap between the caps and the bar.

There's also a very minor change in Linear, because clamping isn't needed when the value is always positive.

[Screencast_20260529_140817.webm](https://github.com/user-attachments/assets/80f4f8ca-d7f2-44c1-af0f-0b090053db45)


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

