### PR TITLE
feat: list_column dnd support

### DIFF
--- a/src/widget/dnd_source.rs
+++ b/src/widget/dnd_source.rs
@@ -418,16 +418,3 @@ impl State {
         Self::default()
     }
 }
-
-/// A placeholder for situations that dnd is optional to fill generics.
-pub struct NoDrag;
-
-impl iced::clipboard::mime::AsMimeTypes for NoDrag {
-    fn available(&self) -> std::borrow::Cow<'static, [String]> {
-        std::borrow::Cow::Owned(vec![])
-    }
-
-    fn as_bytes(&self, _: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
-        None
-    }
-}

--- a/src/widget/dnd_source.rs
+++ b/src/widget/dnd_source.rs
@@ -418,3 +418,16 @@ impl State {
         Self::default()
     }
 }
+
+/// A placeholder for situations that dnd is optional to fill generics.
+pub struct NoDrag;
+
+impl iced::clipboard::mime::AsMimeTypes for NoDrag {
+    fn available(&self) -> std::borrow::Cow<'static, [String]> {
+        std::borrow::Cow::Owned(vec![])
+    }
+
+    fn as_bytes(&self, _: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+        None
+    }
+}

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -2,29 +2,27 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::widget::container::Catalog;
-use crate::widget::dnd_source::NoDrag;
 use crate::widget::space::vertical;
 use crate::widget::{DndDestination, DndSource, button, column, container, divider, row};
 use crate::{Apply, Element, theme};
-use iced::clipboard::mime::AsMimeTypes;
 use iced::{Length, Padding};
 
 /// A button list item for use in a [`ListColumn`].
-pub struct ListButton<'a, Message, D: iced::clipboard::mime::AsMimeTypes = NoDrag> {
+pub struct ListButton<'a, Message> {
     content: Element<'a, Message>,
     on_press: Option<Message>,
-    dnd_source_builder: Option<Box<DndSourceBuilder<'a, Message, D>>>,
+    dnd_source_builder: Option<Box<DndSourceBuilder<'a, Message>>>,
     dnd_destination_builder: Option<Box<DndDestinationBuilder<'a, Message>>>,
     selected: bool,
 }
 
 /// Builds a DndSource, wrapping an element
-pub type DndSourceBuilder<'a, Message, D> = dyn Fn(Element<'a, Message>) -> DndSource<'a, Message, D>;
+pub type DndSourceBuilder<'a, Message> = dyn FnOnce(Element<'a, Message>) -> DndSource<'a, Message, Box<dyn iced::clipboard::mime::AsMimeTypes + Send>>;
 /// Builds a DndDestination, wrapping an element
-pub type DndDestinationBuilder<'a, Message> = dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>;
+pub type DndDestinationBuilder<'a, Message> = dyn FnOnce(Element<'a, Message>) -> DndDestination<'a, Message>;
 
 /// Creates a [`ListButton`] with the given content.
-pub fn button<'a, Message, D: AsMimeTypes>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message, D> {
+pub fn button<'a, Message>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message> {
     ListButton {
         content: content.into(),
         on_press: None,
@@ -34,7 +32,7 @@ pub fn button<'a, Message, D: AsMimeTypes>(content: impl Into<Element<'a, Messag
     }
 }
 
-impl<'a, Message: 'static, D: iced::clipboard::mime::AsMimeTypes> ListButton<'a, Message, D> {
+impl<'a, Message: 'static> ListButton<'a, Message> {
     pub fn on_press(mut self, on_press: Message) -> Self {
         self.on_press = Some(on_press);
         self
@@ -50,7 +48,7 @@ impl<'a, Message: 'static, D: iced::clipboard::mime::AsMimeTypes> ListButton<'a,
         self
     }
 
-    pub fn with_dnd_source(mut self, builder: Box<DndSourceBuilder<'a, Message, D>>) -> Self {
+    pub fn with_dnd_source(mut self, builder: Box<DndSourceBuilder<'a, Message>>) -> Self {
         self.dnd_source_builder = Some(builder);
         self
     }

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -2,28 +2,36 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::widget::container::Catalog;
+use crate::widget::dnd_source::NoDrag;
 use crate::widget::space::vertical;
-use crate::widget::{button, column, container, divider, row};
+use crate::widget::{DndDestination, DndSource, button, column, container, divider, row};
 use crate::{Apply, Element, theme};
 use iced::{Length, Padding};
 
 /// A button list item for use in a [`ListColumn`].
-pub struct ListButton<'a, Message> {
+pub struct ListButton<'a, Message, D: iced::clipboard::mime::AsMimeTypes = NoDrag> {
     content: Element<'a, Message>,
     on_press: Option<Message>,
+    dnd_source_builder: Option<Box<DndSourceBuilder<'a, Message, D>>>,
+    dnd_destination_builder: Option<Box<DndDestinationBuilder<'a, Message>>>,
     selected: bool,
 }
+
+pub type DndSourceBuilder<'a, Message, D> = dyn Fn(Element<'a, Message>) -> DndSource<'a, Message, D>;
+pub type DndDestinationBuilder<'a, Message> = dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>;
 
 /// Creates a [`ListButton`] with the given content.
 pub fn button<'a, Message>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message> {
     ListButton {
         content: content.into(),
         on_press: None,
+        dnd_source_builder: None,
+        dnd_destination_builder: None,
         selected: false,
     }
 }
 
-impl<'a, Message: 'static> ListButton<'a, Message> {
+impl<'a, Message: 'static, D: iced::clipboard::mime::AsMimeTypes> ListButton<'a, Message, D> {
     pub fn on_press(mut self, on_press: Message) -> Self {
         self.on_press = Some(on_press);
         self
@@ -36,6 +44,16 @@ impl<'a, Message: 'static> ListButton<'a, Message> {
 
     pub fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
+        self
+    }
+
+    pub fn with_dnd_source(mut self, builder: Box<dyn Fn(Element<'a, Message>) -> DndSource<'a, Message, D>>) -> Self {
+        self.dnd_source_builder = Some(builder);
+        self
+    }
+
+    pub fn with_dnd_destination(mut self, builder: Box<dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>>) -> Self {
+        self.dnd_destination_builder = Some(builder);
         self
     }
 }
@@ -175,19 +193,32 @@ impl<'a, Message: Clone + 'static> ListColumn<'a, Message> {
                     content,
                     on_press,
                     selected,
-                }) => col.push(
-                    content_row(content)
-                        .apply(button::custom)
-                        .padding(item_padding)
-                        .width(Length::Fill)
-                        .on_press_maybe(on_press)
-                        .selected(selected)
-                        .class(theme::Button::ListItem(get_radius(
-                            radius_s,
-                            i == 0,
-                            i == last_index,
-                        ))),
-                ),
+                    dnd_source_builder,
+                    dnd_destination_builder,
+                }) => {
+                    let mut button: Element<'a, Message> =
+                        content_row(content)
+                            .apply(button::custom)
+                            .padding(item_padding)
+                            .width(Length::Fill)
+                            .on_press_maybe(on_press)
+                            .selected(selected)
+                            .class(theme::Button::ListItem(get_radius(
+                                radius_s,
+                                i == 0,
+                                i == last_index,
+                            )))
+                            .into();
+                    if let Some(builder) = dnd_source_builder {
+                        button = builder(button).into();
+                    }
+
+                    if let Some(builder) = dnd_destination_builder {
+                        button = builder(button).into();
+                    }
+
+                    col.push(button)
+                },
             };
         }
 

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -17,7 +17,9 @@ pub struct ListButton<'a, Message, D: iced::clipboard::mime::AsMimeTypes = NoDra
     selected: bool,
 }
 
+/// Builds a DndSource, wrapping an element
 pub type DndSourceBuilder<'a, Message, D> = dyn Fn(Element<'a, Message>) -> DndSource<'a, Message, D>;
+/// Builds a DndDestination, wrapping an element
 pub type DndDestinationBuilder<'a, Message> = dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>;
 
 /// Creates a [`ListButton`] with the given content.

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -6,6 +6,7 @@ use crate::widget::dnd_source::NoDrag;
 use crate::widget::space::vertical;
 use crate::widget::{DndDestination, DndSource, button, column, container, divider, row};
 use crate::{Apply, Element, theme};
+use iced::clipboard::mime::AsMimeTypes;
 use iced::{Length, Padding};
 
 /// A button list item for use in a [`ListColumn`].
@@ -23,7 +24,7 @@ pub type DndSourceBuilder<'a, Message, D> = dyn Fn(Element<'a, Message>) -> DndS
 pub type DndDestinationBuilder<'a, Message> = dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>;
 
 /// Creates a [`ListButton`] with the given content.
-pub fn button<'a, Message>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message> {
+pub fn button<'a, Message, D: AsMimeTypes>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message, D> {
     ListButton {
         content: content.into(),
         on_press: None,

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -47,12 +47,12 @@ impl<'a, Message: 'static, D: iced::clipboard::mime::AsMimeTypes> ListButton<'a,
         self
     }
 
-    pub fn with_dnd_source(mut self, builder: Box<dyn Fn(Element<'a, Message>) -> DndSource<'a, Message, D>>) -> Self {
+    pub fn with_dnd_source(mut self, builder: Box<DndSourceBuilder<'a, Message, D>>) -> Self {
         self.dnd_source_builder = Some(builder);
         self
     }
 
-    pub fn with_dnd_destination(mut self, builder: Box<dyn Fn(Element<'a, Message>) -> DndDestination<'a, Message>>) -> Self {
+    pub fn with_dnd_destination(mut self, builder: Box<DndDestinationBuilder<'a, Message>>) -> Self {
         self.dnd_destination_builder = Some(builder);
         self
     }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

It only allows user to wrap list column button with dnd source or destination, as they don't break styles.

This fixes #1305.