### PR TITLE
Fix : using gradient to render progrees bar to prevent overflow.

### DIFF
--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -201,25 +201,24 @@ where
 
         let mut draw_quad =
             |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
-                let background = if progress_width == 0.0 {
-                    iced::Background::Color(custom_style.track_color)
-                } else if (segment_width - progress_width).abs() < f32::EPSILON {
-                    iced::Background::Color(custom_style.bar_color)
-                } else {
-                    let mid_point = progress_width / segment_width;
-                    iced::Background::Gradient(iced::Gradient::Linear(
-                        iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
-                            ColorStop {
-                                color: custom_style.bar_color,
-                                offset: mid_point,
-                            },
-                            ColorStop {
-                                color: custom_style.track_color,
-                                offset: mid_point.next_up(),
-                            },
-                        ]),
-                    ))
-                };
+
+                let mut mid_point = progress_width / segment_width;
+                if mid_point >= 1.0_f32 {
+                    mid_point = 1.0_f32.next_down().next_down();
+                }
+                let background = iced::Background::Gradient(iced::Gradient::Linear(
+                    iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
+                        ColorStop {
+                            color: custom_style.bar_color,
+                            offset: mid_point,
+                        },
+                        ColorStop {
+                            color: custom_style.track_color,
+                            offset: mid_point.next_up(),
+                        },
+                    ]),
+                ));
+
 
                 renderer.fill_quad(
                     renderer::Quad {

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -199,7 +199,7 @@ where
         let border_color = custom_style.border_color.unwrap_or(custom_style.bar_color);
         let radius = custom_style.border_radius;
 
-        let mut draw_quad_n =
+        let mut draw_quad =
             |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
                 let mut mid_point = progress_width / segment_width;
                 if mid_point >= 1.0 {
@@ -272,7 +272,7 @@ where
 
                 if current_p > seg_lo {
                     let fill = ((current_p - seg_lo) / (seg_hi - seg_lo)).min(1.0);
-                    draw_quad_n(
+                    draw_quad(
                         x_start * bounds.width,
                         x_width * bounds.width,
                         x_width * fill * bounds.width,
@@ -283,7 +283,7 @@ where
                         },
                     );
                 } else {
-                    draw_quad_n(
+                    draw_quad(
                         x_start * bounds.width,
                         x_width * bounds.width,
                         0.0,
@@ -301,29 +301,29 @@ where
                     .animation
                     .bar_positions(self.cycle_duration, MIN_LENGTH, WRAP_LENGTH);
             let length = bar_end - bar_start;
-            let mut start = bar_start % 1.0;
-            let right_width = (1.0 - start).min(length);
-            let mut left_offset = length - right_width;
+            let mut right_start_offset = bar_start % 1.0;
+            let right_width = (1.0 - right_start_offset).min(length);
+            let mut left_width_offset = length - right_width;
             let border = iced::Border {
                 radius: radius.into(),
                 ..iced::Border::default()
             };
-            if left_offset >= 1.0 {
-                left_offset = 1.0;
+            if left_width_offset >= 1.0 {
+                left_width_offset = 1.0;
                 for _ in 0..6 {
-                    left_offset = left_offset.next_down();
+                    left_width_offset = left_width_offset.next_down();
                 }
             }
-            if start >= 1.0 {
-                start = 1.0;
+            if right_start_offset >= 1.0 {
+                right_start_offset = 1.0;
                 for _ in 0..4 {
-                    start = start.next_down();
+                    right_start_offset = right_start_offset.next_down();
                 }
             }
 
-            let mut right_offset = start + right_width;
-            if right_offset >= 1.0 {
-                right_offset = 1.0_f32.next_down().next_down();
+            let mut right_width_offset = right_start_offset + right_width;
+            if right_width_offset >= 1.0 {
+                right_width_offset = 1.0_f32.next_down().next_down();
             }
 
             let background = iced::Background::Gradient(iced::Gradient::Linear(
@@ -334,27 +334,27 @@ where
                     },
                     ColorStop {
                         color: custom_style.bar_color,
-                        offset: left_offset,
+                        offset: left_width_offset,
                     },
                     ColorStop {
                         color: custom_style.track_color,
-                        offset: left_offset.next_up(),
+                        offset: left_width_offset.next_up(),
                     },
                     ColorStop {
                         color: custom_style.track_color,
-                        offset: start,
+                        offset: right_start_offset,
                     },
                     ColorStop {
                         color: custom_style.bar_color,
-                        offset: start.next_up(),
+                        offset: right_start_offset.next_up(),
                     },
                     ColorStop {
                         color: custom_style.bar_color,
-                        offset: right_offset,
+                        offset: right_width_offset,
                     },
                     ColorStop {
                         color: custom_style.track_color,
-                        offset: right_offset.next_up(),
+                        offset: right_width_offset.next_up(),
                     },
                     ColorStop {
                         color: custom_style.track_color,

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -299,10 +299,7 @@ where
             let mut right_start_offset = bar_start % 1.0;
             let right_width = (1.0 - right_start_offset).min(length);
             let mut left_width_offset = length - right_width;
-            let border = iced::Border {
-                radius: radius.into(),
-                ..iced::Border::default()
-            };
+
             if left_width_offset >= 1.0 {
                 left_width_offset = 1.0_f32.next_down().next_down();
             }
@@ -360,7 +357,11 @@ where
                         width: bounds.width,
                         height: bounds.height,
                     },
-                    border,
+                    border: iced::Border {
+                        width: border_width,
+                        color: border_color,
+                        radius: radius.into(),
+                    },
                     snap: true,
                     ..renderer::Quad::default()
                 },

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -1,6 +1,7 @@
 //! Show a linear progress indicator.
 use super::animation::{Animation, Progress};
 use super::style::StyleSheet;
+use iced::gradient::ColorStop;
 use iced::advanced::widget::tree::{self, Tree};
 use iced::advanced::{self, Clipboard, Layout, Shell, Widget, layout, renderer};
 use iced::{Element, Event, Length, Pixels, Rectangle, Size, mouse, window};
@@ -175,6 +176,7 @@ where
         }
     }
 
+        #[allow(clippy::too_many_lines)]
     fn draw(
         &self,
         tree: &Tree,
@@ -197,66 +199,54 @@ where
         let border_color = custom_style.border_color.unwrap_or(custom_style.bar_color);
         let radius = custom_style.border_radius;
 
-        let mut draw_quad = |x: f32,
-                             width: f32,
-                             color: iced::Color,
-                             mut border: iced::Border,
-                             is_track: bool,
-                             total_progress_width: f32| {
-            let mut height = bounds.height;
-            if !is_track {
-                // For progress that is at the end of completion
-                if total_progress_width > bounds.width - radius {
-                    let border_radius =
-                        radius.min(bounds.height / 2.0) - (bounds.width - total_progress_width);
-                    border.radius.top_right = border_radius;
-                    border.radius.bottom_right = border_radius;
-                } else {
-                    border.radius.top_right = 0.0;
-                    border.radius.bottom_right = 0.0;
+        let mut draw_quad_n =
+            |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
+                let mut mid_point = progress_width / segment_width;
+                if mid_point >= 1.0 {
+                    mid_point = 1.0_f32.next_down().next_down();
                 }
 
-                // For indeterminate mode or when progress has just started
-                if x < radius.min(bounds.height / 2.0) {
-                    let border_radius = radius.min(bounds.height / 2.0) - x;
-                    border.radius.top_left = border_radius;
-                    border.radius.bottom_left = border_radius;
+                let background = iced::Background::Gradient(iced::Gradient::Linear(
+                    iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
+                        ColorStop {
+                            color: custom_style.bar_color,
+                            offset: 0.0,
+                        },
+                        ColorStop {
+                            color: custom_style.bar_color,
+                            offset: mid_point,
+                        },
+                        ColorStop {
+                            color: custom_style.track_color,
+                            offset: mid_point.next_up(),
+                        },
+                        ColorStop {
+                            color: custom_style.track_color,
+                            offset: 1.0,
+                        },
+                    ]),
+                ));
 
-                    if total_progress_width < radius.min(bounds.height / 2.0) {
-                        height = bounds.height - 2.0 * radius.min(bounds.height / 2.0)
-                            + total_progress_width * 2.0;
-                    }
-                } else {
-                    border.radius.top_left = 0.0;
-                    border.radius.bottom_left = 0.0;
-                }
-
-                if x > bounds.width - radius.min(bounds.height / 2.0) {
-                    height = bounds.height - 2.0 * radius.min(bounds.height / 2.0) + width * 2.0;
-                }
-            }
-
-            renderer.fill_quad(
-                renderer::Quad {
-                    bounds: Rectangle {
-                        x: bounds.x + x,
-                        y: bounds.y + (bounds.height - height) / 2.0,
-                        width,
-                        height,
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds: Rectangle {
+                            x: bounds.x + start,
+                            y: bounds.y,
+                            width: segment_width,
+                            height: bounds.height,
+                        },
+                        border,
+                        snap: true,
+                        ..renderer::Quad::default()
                     },
-                    border,
-                    snap: true,
-                    ..renderer::Quad::default()
-                },
-                color,
-            );
-        };
+                    background,
+                );
+            };
 
         if self.progress.is_some() {
             let current_p = state.progress.current;
             let len = self.markers.len();
             let spacing = self.segment_spacing;
-            let radius_inner = radius.min(spacing);
 
             let gap = if len != 0 {
                 spacing / bounds.width
@@ -265,107 +255,127 @@ where
             };
             let drawable = 1.0 - gap * len as f32;
 
-            let mut absolute_width = 0.0;
             for i in 0..=len {
                 let (seg_lo, r_left) = if i == 0 {
                     (0.0, radius)
                 } else {
-                    (self.markers[i - 1], radius_inner)
+                    (self.markers[i - 1], 0.0)
                 };
                 let (seg_hi, r_right) = if i == len {
                     (1.0, radius)
                 } else {
-                    (self.markers[i], radius_inner)
+                    (self.markers[i], 0.0)
                 };
                 let x_start = seg_lo * drawable + i as f32 * gap;
                 let x_width = (seg_hi - seg_lo) * drawable;
+                let segment_radius = [r_left, r_right, r_right, r_left].into();
 
-                let mut segment_radius = if i == 0 && len == 0 {
-                    [r_left, r_right, r_right, r_left].into()
-                } else if i == 0 {
-                    [r_left, 0.0, 0.0, r_left].into()
-                } else if i == len {
-                    [0.0, r_right, r_right, 0.0].into()
-                } else {
-                    [0.0, 0.0, 0.0, 0.0].into()
-                };
-
-                // draw track segment
-                draw_quad(
-                    x_start * bounds.width,
-                    x_width * bounds.width,
-                    custom_style.track_color,
-                    iced::Border {
-                        width: border_width,
-                        color: border_color,
-                        radius: segment_radius,
-                    },
-                    true,
-                    bounds.width,
-                );
-
-                // draw bar segment
                 if current_p > seg_lo {
                     let fill = ((current_p - seg_lo) / (seg_hi - seg_lo)).min(1.0);
-                    absolute_width += x_width * fill + if i == 0 { 0.0 } else { gap };
-                    segment_radius = [r_left, r_right, r_right, r_left].into();
-                    draw_quad(
+                    draw_quad_n(
                         x_start * bounds.width,
+                        x_width * bounds.width,
                         x_width * fill * bounds.width,
-                        custom_style.bar_color,
                         iced::Border {
+                            width: border_width,
+                            color: border_color,
                             radius: segment_radius,
-                            ..iced::Border::default()
                         },
-                        false,
-                        absolute_width * bounds.width,
+                    );
+                } else {
+                    draw_quad_n(
+                        x_start * bounds.width,
+                        x_width * bounds.width,
+                        0.0,
+                        iced::Border {
+                            width: border_width,
+                            color: border_color,
+                            radius: segment_radius,
+                        },
                     );
                 }
             }
         } else {
-            // draw track
-            draw_quad(
-                0.0,
-                bounds.width,
-                custom_style.track_color,
-                iced::Border {
-                    width: border_width,
-                    color: border_color,
-                    radius: radius.into(),
-                },
-                true,
-                bounds.width,
-            );
-
-            // draw bar
             let (bar_start, bar_end) =
                 state
                     .animation
                     .bar_positions(self.cycle_duration, MIN_LENGTH, WRAP_LENGTH);
             let length = bar_end - bar_start;
-            let start = bar_start % 1.0;
+            let mut start = bar_start % 1.0;
             let right_width = (1.0 - start).min(length);
-            let left_width = length - right_width;
+            let mut left_offset = length - right_width;
             let border = iced::Border {
                 radius: radius.into(),
                 ..iced::Border::default()
             };
+            if left_offset >= 1.0 {
+                left_offset = 1.0;
+                for _ in 0..6 {
+                    left_offset = left_offset.next_down();
+                }
+            }
+            if start >= 1.0 {
+                start = 1.0;
+                for _ in 0..4 {
+                    start = start.next_down();
+                }
+            }
 
-            draw_quad(
-                start * bounds.width,
-                right_width * bounds.width,
-                custom_style.bar_color,
-                border,
-                false,
-                (right_width + start) * bounds.width,
-            );
-            draw_quad(
-                0.0,
-                left_width * bounds.width,
-                custom_style.bar_color,
-                border,
-                false,
-                left_width * bounds.width,
+            let mut right_offset = start + right_width;
+            if right_offset >= 1.0 {
+                right_offset = 1.0_f32.next_down().next_down();
+            }
+
+            let background = iced::Background::Gradient(iced::Gradient::Linear(
+                iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
+                    ColorStop {
+                        color: custom_style.bar_color,
+                        offset: 0.0,
+                    },
+                    ColorStop {
+                        color: custom_style.bar_color,
+                        offset: left_offset,
+                    },
+                    ColorStop {
+                        color: custom_style.track_color,
+                        offset: left_offset.next_up(),
+                    },
+                    ColorStop {
+                        color: custom_style.track_color,
+                        offset: start,
+                    },
+                    ColorStop {
+                        color: custom_style.bar_color,
+                        offset: start.next_up(),
+                    },
+                    ColorStop {
+                        color: custom_style.bar_color,
+                        offset: right_offset,
+                    },
+                    ColorStop {
+                        color: custom_style.track_color,
+                        offset: right_offset.next_up(),
+                    },
+                    ColorStop {
+                        color: custom_style.track_color,
+                        offset: 1.0,
+                    },
+                ]),
+            ));
+
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds: Rectangle {
+                        x: bounds.x,
+                        y: bounds.y,
+                        width: bounds.width,
+                        height: bounds.height,
+                    },
+                    border,
+                    snap: true,
+                    ..renderer::Quad::default()
+                },
+                background,
             );
         }
     }

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -201,31 +201,25 @@ where
 
         let mut draw_quad =
             |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
-                let mut mid_point = progress_width / segment_width;
-                if mid_point >= 1.0 {
-                    mid_point = 1.0_f32.next_down().next_down();
-                }
-
-                let background = iced::Background::Gradient(iced::Gradient::Linear(
-                    iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
-                        ColorStop {
-                            color: custom_style.bar_color,
-                            offset: 0.0,
-                        },
-                        ColorStop {
-                            color: custom_style.bar_color,
-                            offset: mid_point,
-                        },
-                        ColorStop {
-                            color: custom_style.track_color,
-                            offset: mid_point.next_up(),
-                        },
-                        ColorStop {
-                            color: custom_style.track_color,
-                            offset: 1.0,
-                        },
-                    ]),
-                ));
+                let background = if progress_width == 0.0 {
+                    iced::Background::Color(custom_style.track_color)
+                } else if (segment_width - progress_width).abs() < f32::EPSILON {
+                    iced::Background::Color(custom_style.bar_color)
+                } else {
+                    let mid_point = progress_width / segment_width;
+                    iced::Background::Gradient(iced::Gradient::Linear(
+                        iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
+                            ColorStop {
+                                color: custom_style.bar_color,
+                                offset: mid_point,
+                            },
+                            ColorStop {
+                                color: custom_style.track_color,
+                                offset: mid_point.next_up(),
+                            },
+                        ]),
+                    ))
+                };
 
                 renderer.fill_quad(
                     renderer::Quad {
@@ -247,6 +241,7 @@ where
             let current_p = state.progress.current;
             let len = self.markers.len();
             let spacing = self.segment_spacing;
+            let radius_inner = radius.min(spacing);
 
             let gap = if len != 0 {
                 spacing / bounds.width
@@ -259,12 +254,12 @@ where
                 let (seg_lo, r_left) = if i == 0 {
                     (0.0, radius)
                 } else {
-                    (self.markers[i - 1], 0.0)
+                    (self.markers[i - 1], radius_inner)
                 };
                 let (seg_hi, r_right) = if i == len {
                     (1.0, radius)
                 } else {
-                    (self.markers[i], 0.0)
+                    (self.markers[i], radius_inner)
                 };
                 let x_start = seg_lo * drawable + i as f32 * gap;
                 let x_width = (seg_hi - seg_lo) * drawable;
@@ -309,16 +304,10 @@ where
                 ..iced::Border::default()
             };
             if left_width_offset >= 1.0 {
-                left_width_offset = 1.0;
-                for _ in 0..6 {
-                    left_width_offset = left_width_offset.next_down();
-                }
+                left_width_offset = 1.0_f32.next_down().next_down();
             }
             if right_start_offset >= 1.0 {
-                right_start_offset = 1.0;
-                for _ in 0..4 {
-                    right_start_offset = right_start_offset.next_down();
-                }
+                right_start_offset = 1.0_f32.next_down().next_down();
             }
 
             let mut right_width_offset = right_start_offset + right_width;
@@ -328,10 +317,6 @@ where
 
             let background = iced::Background::Gradient(iced::Gradient::Linear(
                 iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
-                    ColorStop {
-                        color: custom_style.bar_color,
-                        offset: 0.0,
-                    },
                     ColorStop {
                         color: custom_style.bar_color,
                         offset: left_width_offset,
@@ -355,10 +340,6 @@ where
                     ColorStop {
                         color: custom_style.track_color,
                         offset: right_width_offset.next_up(),
-                    },
-                    ColorStop {
-                        color: custom_style.track_color,
-                        offset: 1.0,
                     },
                 ]),
             ));

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -1,10 +1,10 @@
 //! Show a linear progress indicator.
 use super::animation::{Animation, Progress};
 use super::style::StyleSheet;
-use iced::gradient::ColorStop;
 use iced::advanced::widget::tree::{self, Tree};
 use iced::advanced::{self, Clipboard, Layout, Shell, Widget, layout, renderer};
 use iced::{Element, Event, Length, Pixels, Rectangle, Size, mouse, window};
+use iced_core::gradient::ColorStop;
 
 use std::time::Duration;
 
@@ -176,7 +176,7 @@ where
         }
     }
 
-        #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     fn draw(
         &self,
         tree: &Tree,

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -201,30 +201,33 @@ where
 
         let mut draw_quad =
             |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
-                let mut mid_point = progress_width / segment_width;
-                if mid_point >= 1.0_f32 {
-                    mid_point = 1.0_f32.next_down().next_down();
-                }
-                let background = iced::Background::Gradient(iced::Gradient::Linear(
-                    iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
-                        ColorStop {
-                            color: custom_style.bar_color,
-                            offset: mid_point,
-                        },
-                        ColorStop {
-                            color: custom_style.track_color,
-                            offset: mid_point.next_up(),
-                        },
-                    ]),
-                ));
+                let background = if progress_width == 0.0 {
+                    iced::Background::Color(custom_style.track_color)
+                } else if (segment_width - progress_width).abs() < f32::EPSILON {
+                    iced::Background::Color(custom_style.bar_color)
+                } else {
+                    let mid_point = progress_width / segment_width;
+                    iced::Background::Gradient(iced::Gradient::Linear(
+                        iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
+                            ColorStop {
+                                color: custom_style.bar_color,
+                                offset: mid_point,
+                            },
+                            ColorStop {
+                                color: custom_style.track_color,
+                                offset: mid_point.next_up(),
+                            },
+                        ]),
+                    ))
+                };
 
                 renderer.fill_quad(
                     renderer::Quad {
                         bounds: Rectangle {
                             x: bounds.x + start,
-                            y: bounds.y,
+                            y: bounds.y.floor(),
                             width: segment_width,
-                            height: bounds.height,
+                            height: bounds.height.floor(),
                         },
                         border,
                         snap: true,
@@ -316,6 +319,10 @@ where
                 iced_core::gradient::Linear::new(90.0_f32.to_radians()).add_stops([
                     ColorStop {
                         color: custom_style.bar_color,
+                        offset: 0.0,
+                    },
+                    ColorStop {
+                        color: custom_style.bar_color,
                         offset: left_width_offset,
                     },
                     ColorStop {
@@ -337,6 +344,10 @@ where
                     ColorStop {
                         color: custom_style.track_color,
                         offset: right_width_offset.next_up(),
+                    },
+                    ColorStop {
+                        color: custom_style.track_color,
+                        offset: 1.0,
                     },
                 ]),
             ));

--- a/src/widget/progress_bar/linear.rs
+++ b/src/widget/progress_bar/linear.rs
@@ -201,7 +201,6 @@ where
 
         let mut draw_quad =
             |start: f32, segment_width: f32, progress_width: f32, border: iced::Border| {
-
                 let mut mid_point = progress_width / segment_width;
                 if mid_point >= 1.0_f32 {
                     mid_point = 1.0_f32.next_down().next_down();
@@ -218,7 +217,6 @@ where
                         },
                     ]),
                 ));
-
 
                 renderer.fill_quad(
                     renderer::Quad {


### PR DESCRIPTION
Fixed progress bar overflow.
Now even for low progress phase the active progress bar does not go outside of that track.
Are there any changes needed?

https://github.com/user-attachments/assets/602721ac-45ee-40ab-a71a-e48be41a0d70

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

