### PR TITLE
Fix: Gradient shifting of color picker's hue slider.

### DIFF
--- a/src/widget/color_picker/mod.rs
+++ b/src/widget/color_picker/mod.rs
@@ -5,13 +5,11 @@
 
 use std::borrow::Cow;
 use std::rc::Rc;
-use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::Element;
-use crate::theme::iced::Slider;
-use crate::theme::{Button, THEME};
+use crate::theme::{Button, THEME, Theme, iced::Slider};
 use crate::widget::button::Catalog;
 use crate::widget::segmented_button::Entity;
 use crate::widget::{container, slider};
@@ -38,37 +36,6 @@ use super::{Icon, button, segmented_control, text, text_input, tooltip};
 
 #[doc(inline)]
 pub use ColorPickerModel as Model;
-
-// TODO is this going to look correct enough?
-pub static HSV_RAINBOW: LazyLock<Vec<Color>> = LazyLock::new(|| {
-    (0u16..8)
-        .map(|h| {
-            Color::from(palette::Srgba::from_color(palette::Hsv::new_srgb_const(
-                RgbHue::new(f32::from(h) * 360.0 / 7.0),
-                1.0,
-                1.0,
-            )))
-        })
-        .collect()
-});
-
-fn hsv_rainbow(low_hue: f32, high_hue: f32) -> Vec<ColorStop> {
-    let mut colors = Vec::new();
-    let steps: u8 = 7;
-    let step_size = (high_hue - low_hue) / f32::from(steps);
-    for i in 0..=steps {
-        let hue = low_hue + step_size * f32::from(i);
-        colors.push(ColorStop {
-            color: Color::from(palette::Srgba::from_color(palette::Hsv::new_srgb_const(
-                RgbHue::new(hue),
-                1.0,
-                1.0,
-            ))),
-            offset: f32::from(i) / f32::from(steps),
-        });
-    }
-    colors
-}
 
 const MAX_RECENT: usize = 20;
 
@@ -301,22 +268,66 @@ where
         copy_to_clipboard_label: T,
         copied_to_clipboard_label: T,
     ) -> ColorPicker<'a, Message> {
-        fn rail_backgrounds(hue: f32) -> (Background, Background) {
-            let low_range = hsv_rainbow(0., hue);
-            let high_range = hsv_rainbow(hue, 360.);
-
-            (
-                Background::Gradient(iced::Gradient::Linear(
-                    Linear::new(Radians(90.0)).add_stops(low_range),
-                )),
-                Background::Gradient(iced::Gradient::Linear(
-                    Linear::new(Radians(90.0)).add_stops(high_range),
-                )),
-            )
-        }
-
         let on_update = self.on_update;
         let spacing = THEME.lock().unwrap().cosmic().spacing;
+
+        let color_slider_style = Rc::new(move |t: &Theme| {
+            let cosmic = t.cosmic();
+            let mut a = slider::Catalog::style(t, &Slider::default(), slider::Status::Active);
+            a.rail.backgrounds = (
+                // active track
+                Background::Gradient(iced::Gradient::Linear(
+                    Linear::new(Radians(90.0)).add_stops((0..8_u8).map(|index| {
+                        let offset;
+                        let hue = self.active_color.hue.into_positive_degrees();
+                        let new_hue: f32;
+                        if hue <= f32::from(index) * 360.0 / 7.0 {
+                            offset = 1.0;
+                            new_hue = hue;
+                        } else {
+                            offset = (f32::from(index) / 7.0) * (360.0 / hue);
+                            new_hue = f32::from(index) * 360.0 / 7.0;
+                        }
+                        ColorStop {
+                            color: Color::from(palette::Srgba::from_color(
+                                palette::Hsv::new_srgb_const(RgbHue::new(new_hue), 1.0, 1.0),
+                            )),
+                            offset,
+                        }
+                    })),
+                )),
+                // inactive track
+                Background::Gradient(iced::Gradient::Linear(
+                    Linear::new(Radians(90.0)).add_stops((0..8_u8).map(|index| {
+                        let offset;
+                        let hue = self.active_color.hue.into_positive_degrees();
+                        let new_hue: f32;
+                        if hue >= f32::from(index) * 360.0 / 7.0 {
+                            offset = 0.0;
+                            new_hue = hue;
+                        } else {
+                            offset =
+                                ((f32::from(index) / 7.0) - (hue / 360.0)) / (1.0 - (hue / 360.0));
+                            new_hue = f32::from(index) * 360.0 / 7.0;
+                        }
+                        ColorStop {
+                            color: Color::from(palette::Srgba::from_color(
+                                palette::Hsv::new_srgb_const(RgbHue::new(new_hue), 1.0, 1.0),
+                            )),
+                            offset,
+                        }
+                    })),
+                )),
+            );
+            a.rail.width = 8.0;
+            a.handle.background = Background::Color(Color::from(palette::Srgba::from_color(
+                palette::Hsv::new_srgb_const(self.active_color.hue, 1.0, 1.0),
+            )));
+            a.handle.shape = HandleShape::Circle { radius: 8.0 };
+            a.handle.border_color = cosmic.palette.neutral_10.into();
+            a.handle.border_width = 4.0;
+            a
+        });
 
         let mut inner = column![
             // segmented buttons
@@ -332,56 +343,22 @@ where
                 .width(self.width)
                 .height(self.height),
             slider(
-                0.001..=359.99,
+                0.0..=359.99,
                 self.active_color.hue.into_positive_degrees(),
                 move |v| {
                     let mut new = self.active_color;
                     new.hue = v.into();
                     on_update(ColorPickerUpdate::ActiveColor(new))
-                }
+                },
             )
             .on_release(on_update(ColorPickerUpdate::ActionFinished))
             .class(Slider::Custom {
-                active: Rc::new(move |t| {
-                    let cosmic = t.cosmic();
-                    let mut a =
-                        slider::Catalog::style(t, &Slider::default(), slider::Status::Active);
-                    let hue = self.active_color.hue.into_positive_degrees();
-                    a.rail.backgrounds = rail_backgrounds(hue);
-                    a.rail.width = 8.0;
-                    a.handle.background = Color::TRANSPARENT.into();
-                    a.handle.shape = HandleShape::Circle { radius: 8.0 };
-                    a.handle.border_color = cosmic.palette.neutral_10.into();
-                    a.handle.border_width = 4.0;
-                    a
-                }),
-                hovered: Rc::new(move |t| {
-                    let cosmic = t.cosmic();
-                    let mut a =
-                        slider::Catalog::style(t, &Slider::default(), slider::Status::Active);
-                    let hue = self.active_color.hue.into_positive_degrees();
-                    a.rail.backgrounds = rail_backgrounds(hue);
-                    a.rail.width = 8.0;
-                    a.handle.background = Color::TRANSPARENT.into();
-                    a.handle.shape = HandleShape::Circle { radius: 8.0 };
-                    a.handle.border_color = cosmic.palette.neutral_10.into();
-                    a.handle.border_width = 4.0;
-                    a
-                }),
-                dragging: Rc::new(move |t| {
-                    let cosmic = t.cosmic();
-                    let mut a =
-                        slider::Catalog::style(t, &Slider::default(), slider::Status::Active);
-                    let hue = self.active_color.hue.into_positive_degrees();
-                    a.rail.backgrounds = rail_backgrounds(hue);
-                    a.rail.width = 8.0;
-                    a.handle.background = Color::TRANSPARENT.into();
-                    a.handle.shape = HandleShape::Circle { radius: 8.0 };
-                    a.handle.border_color = cosmic.palette.neutral_10.into();
-                    a.handle.border_width = 4.0;
-                    a
-                }),
+                active: color_slider_style.clone(),
+                hovered: color_slider_style.clone(),
+                dragging: color_slider_style,
             })
+            .step(4.0 / 17.0)
+            .shift_step(64.0 / 17.0)
             .width(self.width),
             text_input("", self.input_color)
                 .on_input(move |s| on_update(ColorPickerUpdate::Input(s)))

--- a/src/widget/list/list_column.rs
+++ b/src/widget/list/list_column.rs
@@ -17,9 +17,13 @@ pub struct ListButton<'a, Message> {
 }
 
 /// Builds a DndSource, wrapping an element
-pub type DndSourceBuilder<'a, Message> = dyn FnOnce(Element<'a, Message>) -> DndSource<'a, Message, Box<dyn iced::clipboard::mime::AsMimeTypes + Send>>;
+pub type DndSourceBuilder<'a, Message> =
+    dyn FnOnce(
+        Element<'a, Message>,
+    ) -> DndSource<'a, Message, Box<dyn iced::clipboard::mime::AsMimeTypes + Send>>;
 /// Builds a DndDestination, wrapping an element
-pub type DndDestinationBuilder<'a, Message> = dyn FnOnce(Element<'a, Message>) -> DndDestination<'a, Message>;
+pub type DndDestinationBuilder<'a, Message> =
+    dyn FnOnce(Element<'a, Message>) -> DndDestination<'a, Message>;
 
 /// Creates a [`ListButton`] with the given content.
 pub fn button<'a, Message>(content: impl Into<Element<'a, Message>>) -> ListButton<'a, Message> {
@@ -53,7 +57,10 @@ impl<'a, Message: 'static> ListButton<'a, Message> {
         self
     }
 
-    pub fn with_dnd_destination(mut self, builder: Box<DndDestinationBuilder<'a, Message>>) -> Self {
+    pub fn with_dnd_destination(
+        mut self,
+        builder: Box<DndDestinationBuilder<'a, Message>>,
+    ) -> Self {
         self.dnd_destination_builder = Some(builder);
         self
     }
@@ -197,19 +204,18 @@ impl<'a, Message: Clone + 'static> ListColumn<'a, Message> {
                     dnd_source_builder,
                     dnd_destination_builder,
                 }) => {
-                    let mut button: Element<'a, Message> =
-                        content_row(content)
-                            .apply(button::custom)
-                            .padding(item_padding)
-                            .width(Length::Fill)
-                            .on_press_maybe(on_press)
-                            .selected(selected)
-                            .class(theme::Button::ListItem(get_radius(
-                                radius_s,
-                                i == 0,
-                                i == last_index,
-                            )))
-                            .into();
+                    let mut button: Element<'a, Message> = content_row(content)
+                        .apply(button::custom)
+                        .padding(item_padding)
+                        .width(Length::Fill)
+                        .on_press_maybe(on_press)
+                        .selected(selected)
+                        .class(theme::Button::ListItem(get_radius(
+                            radius_s,
+                            i == 0,
+                            i == last_index,
+                        )))
+                        .into();
                     if let Some(builder) = dnd_source_builder {
                         button = builder(button).into();
                     }
@@ -219,7 +225,7 @@ impl<'a, Message: Clone + 'static> ListColumn<'a, Message> {
                     }
 
                     col.push(button)
-                },
+                }
             };
         }
 


### PR DESCRIPTION



https://github.com/user-attachments/assets/64a3a307-18e6-414e-bdcd-4e08dc9705a6



This also removes vertical line gap in the center of slider handle by adding current hue color to handle.
<hr>

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.