### PR TITLE
fix(popover): forward in-flight pointer events to modal popups so a selection drag started inside still receives its release

### DIFF
--- a/src/widget/popover.rs
+++ b/src/widget/popover.rs
@@ -402,6 +402,26 @@ where
             && matches!(event, Event::Mouse(_) | Event::Touch(_))
             && !cursor_position.is_over(layout.bounds())
         {
+            // Swallow new presses outside the popup, but still forward other
+            // events so an interaction started inside it (such as a selection
+            // drag) receives its release once the cursor leaves the bounds.
+            let is_press = matches!(
+                event,
+                Event::Mouse(mouse::Event::ButtonPressed(_))
+                    | Event::Touch(touch::Event::FingerPressed { .. })
+            );
+            if !is_press {
+                self.content.as_widget_mut().update(
+                    self.tree,
+                    event,
+                    layout,
+                    cursor_position,
+                    renderer,
+                    clipboard,
+                    shell,
+                    &layout.bounds(),
+                );
+            }
             shell.capture_event();
             return;
         }


### PR DESCRIPTION
resolves the issue descriped in here https://github.com/pop-os/cosmic-files/issues/1352#issuecomment-4805710336 from https://github.com/pop-os/cosmic-files/issues/1352

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

