### PR TITLE
fix(progress_bar): prevent large animation time delta

### DIFF
--- a/src/widget/progress_bar/animation.rs
+++ b/src/widget/progress_bar/animation.rs
@@ -2,44 +2,36 @@ use crate::anim::smootherstep;
 use iced::time::Instant;
 use std::time::Duration;
 
-/// Angular frequency of the critically damped spring (snappiness)
-const OMEGA: f32 = 15.0;
+const LAG: f32 = 0.1;
 
 #[derive(Default)]
 pub struct Progress {
     pub current: f32,
-    velocity: f32,
     last: Option<Instant>,
 }
 
 impl Progress {
-    /// Chases `target` using a critically damped spring.
+    /// Chases `target` using exponential decay.
     /// Returns `true` if a redraw should be requested.
     pub fn update(&mut self, target: f32, now: Instant) -> bool {
         // Don't animate on start
         let Some(last) = self.last else {
             self.current = target;
-            self.velocity = 0.0;
             self.last = Some(now);
             return false;
         };
 
-        let dt = (now - last).as_secs_f32();
+        let dt = (now - last).as_secs_f32().min(1.0 / 60.0);
         self.last = Some(now);
-        let displacement = self.current - target;
+        let diff = target - self.current;
 
-        if displacement.abs() < 0.001 && self.velocity.abs() < 0.001 {
+        if diff.abs() > 0.001 {
+            self.current += diff * (1.0 - (-dt / LAG).exp());
+            true
+        } else {
             self.current = target;
-            self.velocity = 0.0;
-            return false;
+            false
         }
-
-        let exp = (-OMEGA * dt).exp();
-        let coeff = self.velocity + OMEGA * displacement;
-        self.current = target + (displacement + coeff * dt) * exp;
-        self.velocity = (self.velocity - OMEGA * coeff * dt) * exp;
-
-        true
     }
 }
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Effectively just reverts 76bc13ff40eec798a0937d87fce20b699688c69a and makes some changes to the original exponential decay code.

I noticed that CPU load bars in the updated cosmic-monitor don't feel as smooth as before with the new code (with 1.2.0), and I also checked with patched cosmic-osd, and the animations snap if there weren't updates for a longer amount of time.
In the original animation, I fixed that by resetting the timer on every target change, but that caused issues and lag (e.g. the slider progress test).

The reason I didn't notice it with the new code is that sliders for some reason don't cause it, even when clicking a single value after a long time.

So with that, I just decided to revert to the old animation code, which can also be simplified since it no longer needs the target field. It just caps the time delta to one 60 fps frame, which fixes the issue, while also not causing lag that was present before (and it's more understandable and does less stuff).