### PR TITLE
fix: disabled menu buttons don't need to be transparent

### DIFF
--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -218,7 +218,12 @@ impl Catalog for crate::Theme {
 
         appearance(self, false, false, true, style, |component| {
             let mut background = Color::from(component.base);
-            background.a *= 0.5;
+            if !matches!(
+                style,
+                Button::MenuFolder | Button::MenuItem | Button::MenuRoot
+            ) {
+                background.a *= 0.5;
+            }
             (
                 background,
                 Some(component.on_disabled.into()),


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

