### PR TITLE
fix: avoid blurring subsurfaces on creation

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -1683,7 +1683,7 @@ impl<App: Application> Cosmic<App> {
         let live_settings_task = self.apply_live_settings(
             SurfaceIdWrapper::Subsurface(settings.id),
             &LiveSettings {
-                blur: Some(self.blur_enabled),
+                blur: None,
                 corners: None,
                 padding: None,
             },


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

