### PR TITLE
fix: config watcher hash & blur

### DIFF
--- a/cosmic-config/src/dbus.rs
+++ b/cosmic-config/src/dbus.rs
@@ -67,6 +67,8 @@ struct Wrapper(
 impl std::hash::Hash for Wrapper {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
+        self.2.hash(state);
+        self.3.hash(state);
     }
 }
 

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -941,7 +941,7 @@ impl<T: Application> Cosmic<T> {
             }
 
             Action::SystemThemeChange(keys, mut theme) => {
-                let cur_is_dark = THEME.lock().unwrap().theme_type.is_dark();
+                let cur_is_dark = self.app.core().system_theme_mode.is_dark;
                 // Ignore updates if the current theme mode does not match.
                 if cur_is_dark != theme.cosmic().is_dark {
                     return iced::Task::none();
@@ -1026,14 +1026,14 @@ impl<T: Application> Cosmic<T> {
                             } else {
                                 iced::window::disable_blur
                             };
-                            if self.app.core().blur(&cosmic_theme, None) {
-                                cmds.push(blur(
-                                    self.app
-                                        .core()
-                                        .main_window_id()
-                                        .unwrap_or(window::Id::RESERVED),
-                                ));
-                            }
+
+                            cmds.push(blur(
+                                self.app
+                                    .core()
+                                    .main_window_id()
+                                    .unwrap_or(window::Id::RESERVED),
+                            ));
+
                             for (id, wrapper, ..) in &self.surface_views {
                                 let overriden = wrapper.2(&self.app);
                                 if self.app.core().blur(&cosmic_theme, Some(wrapper.1))


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

