### PR TITLE
fix(segmented_button): crash when enumerating context menu buttons

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -970,11 +970,12 @@ where
 
             let Some((mut bounds, i)) = self
                 .variant_bounds(state, layout.bounds())
-                .enumerate()
-                .find_map(|(i, item)| match item {
-                    ItemBounds::Button(e, bounds) if e == entity => Some((bounds, i)),
+                .filter_map(|item| match item {
+                    ItemBounds::Button(entity, bounds) => Some((bounds, entity)),
                     _ => None,
                 })
+                .enumerate()
+                .find_map(|(i, (bounds, e))| if e == entity { Some((bounds, i)) } else { None })
             else {
                 return;
             };
@@ -2529,11 +2530,12 @@ where
 
         let (mut bounds, i) = self
             .variant_bounds(state, layout.bounds())
-            .enumerate()
-            .find_map(|(i, item)| match item {
-                ItemBounds::Button(e, bounds) if e == entity => Some((bounds, i)),
+            .filter_map(|item| match item {
+                ItemBounds::Button(entity, bounds) => Some((bounds, entity)),
                 _ => None,
-            })?;
+            })
+            .enumerate()
+            .find_map(|(i, (bounds, e))| if e == entity { Some((bounds, i)) } else { None })?;
 
         assert!(
             self.context_menu


### PR DESCRIPTION
Fix crash in applications when using popover context menus on a nav bar with dividers, such as a mounted path in COSMIC Files. Enumerating before filtering buttons will cause the index to exceed the actual number of children.

Closes #1349 

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

