### PR TITLE
fix: clear paste cache after shift+insert

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -2111,6 +2111,9 @@ pub fn update<'a, Message: Clone + 'static>(
                     keyboard::Key::Character(c) if "v" == c => {
                         state.is_pasting = None;
                     }
+                    keyboard::Key::Named(keyboard::key::Named::Insert) => {
+                        state.is_pasting = None;
+                    }
                     keyboard::Key::Named(keyboard::key::Named::Tab)
                     | keyboard::Key::Named(keyboard::key::Named::ArrowUp)
                     | keyboard::Key::Named(keyboard::key::Named::ArrowDown) => {


### PR DESCRIPTION
This mirrors the same logic from `ctrl+v`. Without this typing non-ascii characters in Rustdesk will keep repeating the first character (Rustdesk doesn't send pressed keys normally if they're not ascii, it sends the text to its engine and uses shift+insert to paste it in the client).
____

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

