### PR TITLE
[Circular] Dynamic bar height

### DIFF
--- a/src/widget/progress_bar/circular.rs
+++ b/src/widget/progress_bar/circular.rs
@@ -18,7 +18,7 @@ where
     Theme: StyleSheet,
 {
     size: f32,
-    bar_height: f32,
+    bar_height: Option<f32>,
     style: Theme::Style,
     cycle_duration: Duration,
     period: Duration,
@@ -32,8 +32,8 @@ where
     /// Creates a new [`Circular`] with the given content.
     pub fn new() -> Self {
         Circular {
-            size: 40.0,
-            bar_height: 4.0,
+            size: 48.0,
+            bar_height: None,
             style: Theme::Style::default(),
             cycle_duration: Duration::from_millis(1500),
             period: Duration::from_secs(2),
@@ -48,8 +48,9 @@ where
     }
 
     /// Sets the bar height of the [`Circular`].
+    /// By default, the height is based on the size of the [`Circular`].
     pub fn bar_height(mut self, bar_height: f32) -> Self {
-        self.bar_height = bar_height;
+        self.bar_height = Some(bar_height);
         self
     }
 
@@ -172,41 +173,41 @@ where
         let custom_style = Theme::appearance(theme, &self.style, self.progress.is_some(), true);
 
         let geometry = state.cache.draw(renderer, bounds.size(), |frame| {
-            let track_radius = frame.width() / 2.0 - self.bar_height;
+            let bar_height = self.bar_height.unwrap_or((frame.width() / 12.0).max(2.0));
+            let track_radius = (frame.width() - bar_height) / 2.0;
             if track_radius <= 0.0 {
                 return;
             }
-            let track_path = canvas::Path::circle(frame.center(), track_radius);
 
+            let track_path = canvas::Path::circle(frame.center(), track_radius);
             frame.stroke(
                 &track_path,
                 canvas::Stroke::default()
                     .with_color(custom_style.track_color)
-                    .with_width(self.bar_height),
+                    .with_width(bar_height),
             );
 
-            // Converts a track fraction to an angle in radians, with 0 being top of circle
-            let to_angle = |t: f32| t * 2.0 * PI - PI / 2.0;
             let draw_bar = |frame: &mut canvas::Frame, start: f32, end: f32| {
                 let mut builder = canvas::path::Builder::new();
                 builder.arc(canvas::path::Arc {
                     center: frame.center(),
                     radius: track_radius,
-                    start_angle: Radians(to_angle(start)),
-                    end_angle: Radians(to_angle(end)),
+                    start_angle: Radians(2.0 * PI * start - PI / 2.0),
+                    end_angle: Radians(2.0 * PI * end - PI / 2.0),
                 });
                 frame.stroke(
                     &builder.build(),
                     canvas::Stroke::default()
                         .with_color(custom_style.bar_color)
-                        .with_width(self.bar_height)
+                        .with_width(bar_height)
                         .with_line_cap(canvas::LineCap::Round),
                 );
             };
 
             if self.progress.is_some() {
                 if let Some(border_color) = custom_style.border_color {
-                    for radius_offset in [self.bar_height / 2.0, -(self.bar_height / 2.0)] {
+                    // - 0.5 ensures the border is inside the track
+                    for radius_offset in [bar_height / 2.0 - 0.5, -(bar_height / 2.0 - 0.5)] {
                         let border_path =
                             canvas::Path::circle(frame.center(), track_radius + radius_offset);
                         frame.stroke(


### PR DESCRIPTION
This calculates the `bar_height` based on the size of the Circular by default, so that ones with a small size don't have visual issues caused by a fixed height (unless users manually change it). Effectively makes the widget scale up and down with size while preserving ratios (down to 24, since the min automatic bar size is 2).
I changed the default size to 48 (and the division by 12 because of the default 4 height), since [the designs](https://www.figma.com/design/SkAtS5qlVOGQC0n895AHzX/Design-System--WIP-?node-id=13487-20487&t=YaQRQRdnHztfkz1M-0) seem to be like that, though I'm not sure if that's up to date. Let me know if it should stay at 40.

Also fixes the `track_radius` calculation, which caused the widget to appear smaller than it should be (it substracted the entire bar_height instead of just ½). This also matches designs, by having the border be a part of the track width (and prevents clipping issues when the border extends past the track).

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

