### PR TITLE
fix: gate frosted transparency on auto_blur

### DIFF
--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -896,14 +896,7 @@ impl<T: Application> Cosmic<T> {
                     }
                 }
 
-                let new_blur = self.blur_enabled && {
-                    let t = theme.cosmic();
-                    match self.app.core().app_type() {
-                        crate::core::AppType::Window => t.frosted_windows,
-                        crate::core::AppType::System => t.frosted_system_interface,
-                        crate::core::AppType::Applet => t.frosted_applets,
-                    }
-                };
+                let new_blur = self.blur_enabled && self.app.core().frosted(theme.cosmic());
 
                 theme.transparent = new_blur;
                 let mut guard = THEME.lock().unwrap();
@@ -947,14 +940,7 @@ impl<T: Application> Cosmic<T> {
                     return iced::Task::none();
                 }
                 // update transparent
-                let new_blur = self.blur_enabled && {
-                    let t = theme.cosmic();
-                    match self.app.core().app_type() {
-                        crate::core::AppType::Window => t.frosted_windows,
-                        crate::core::AppType::System => t.frosted_system_interface,
-                        crate::core::AppType::Applet => t.frosted_applets,
-                    }
-                };
+                let new_blur = self.blur_enabled && self.app.core().frosted(theme.cosmic());
                 theme.transparent = new_blur;
 
                 let cmd = self.app.system_theme_update(&keys, theme.cosmic());
@@ -1101,14 +1087,7 @@ impl<T: Application> Cosmic<T> {
                     } else {
                         new_theme
                     };
-                    let new_blur = self.blur_enabled && {
-                        let t = new_theme.cosmic();
-                        match core.app_type() {
-                            crate::core::AppType::Window => t.frosted_windows,
-                            crate::core::AppType::System => t.frosted_system_interface,
-                            crate::core::AppType::Applet => t.frosted_applets,
-                        }
-                    };
+                    let new_blur = self.blur_enabled && core.frosted(new_theme.cosmic());
                     new_theme.transparent = new_blur;
 
                     core.system_theme = new_theme.clone();
@@ -1283,14 +1262,7 @@ impl<T: Application> Cosmic<T> {
                         crate::theme::system_light()
                     };
                     if let ThemeType::System { .. } = new_theme.theme_type {
-                        let new_blur = self.blur_enabled && {
-                            let t = new_theme.cosmic();
-                            match core.app_type() {
-                                crate::core::AppType::Window => t.frosted_windows,
-                                crate::core::AppType::System => t.frosted_system_interface,
-                                crate::core::AppType::Applet => t.frosted_applets,
-                            }
-                        };
+                        let new_blur = self.blur_enabled && core.frosted(new_theme.cosmic());
                         new_theme.transparent = new_blur;
                     }
                     core.system_theme = new_theme.clone();
@@ -1441,14 +1413,7 @@ impl<T: Application> Cosmic<T> {
                                     SurfaceIdWrapper::Popup(_) | SurfaceIdWrapper::LayerSurface(_)
                                 )
                             });
-                    let new_blur = self.blur_enabled && {
-                        let t = theme.cosmic();
-                        match self.app.core().app_type() {
-                            crate::core::AppType::Window => t.frosted_windows,
-                            crate::core::AppType::System => t.frosted_system_interface,
-                            crate::core::AppType::Applet => t.frosted_applets,
-                        }
-                    };
+                    let new_blur = self.blur_enabled && self.app.core().frosted(theme.cosmic());
 
                     let wrapper = self.surface_views.get(&id).map(|s| s.1);
 
@@ -1512,14 +1477,7 @@ impl<T: Application> Cosmic<T> {
                 self.blur_enabled = true;
                 let mut t = THEME.lock().unwrap();
 
-                let new_blur = self.blur_enabled && {
-                    let t = t.cosmic();
-                    match self.app.core().app_type() {
-                        crate::core::AppType::Window => t.frosted_windows,
-                        crate::core::AppType::System => t.frosted_system_interface,
-                        crate::core::AppType::Applet => t.frosted_applets,
-                    }
-                };
+                let new_blur = self.blur_enabled && self.app.core().frosted(t.cosmic());
 
                 t.transparent = new_blur;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -538,6 +538,20 @@ impl Core {
         self.auto_blur
     }
 
+    /// Whether the active theme's frosted (blur) styling should apply to this
+    /// app's surfaces.
+    #[must_use]
+    pub fn frosted(&self, theme: &cosmic_theme::Theme) -> bool {
+        if self.auto_blur.is_empty() {
+            return false;
+        }
+        match self.app_type {
+            AppType::Window => theme.frosted_windows,
+            AppType::System => theme.frosted_system_interface,
+            AppType::Applet => theme.frosted_applets,
+        }
+    }
+
     pub fn set_auto_corner_radius(&mut self, auto_corner_radius: BitFlags<Auto>) {
         self.auto_corner_radius = auto_corner_radius;
     }
@@ -570,13 +584,13 @@ impl Core {
             Some(SurfaceIdWrapper::Window(_)) => {
                 theme.frosted_windows && self.auto_blur.contains(Auto::Window)
             }
-            Some(SurfaceIdWrapper::Popup(_))
-                if matches!(self.app_type, AppType::Window | AppType::System) =>
-            {
-                theme.frosted_windows && self.auto_blur.contains(Auto::Popup)
-            }
-            Some(SurfaceIdWrapper::Popup(_)) if matches!(self.app_type, AppType::Applet) => {
-                theme.frosted_applets && self.auto_blur.contains(Auto::Popup)
+            Some(SurfaceIdWrapper::Popup(_)) => {
+                self.auto_blur.contains(Auto::Popup)
+                    && match self.app_type {
+                        AppType::Window => theme.frosted_windows,
+                        AppType::System => theme.frosted_system_interface,
+                        AppType::Applet => theme.frosted_applets,
+                    }
             }
             None => match self.app_type {
                 AppType::Window => theme.frosted_windows && self.auto_blur.contains(Auto::Window),


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-notifications/issues/164

Also I was setting `core.set_auto_blur(Default::default());` to disable blur altogether for my app, but then it would become transparent, if I manually set the background things like the divider in menus would become transparent. With this patch, I can opt out of frosted glass for my app by adding that one line and everything looks normal. 

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

