### PR TITLE
widget/icon: add Icon::opacity()

### DIFF
--- a/src/widget/icon/mod.rs
+++ b/src/widget/icon/mod.rs
@@ -26,6 +26,7 @@ pub fn icon(handle: Handle) -> Icon {
         height: None,
         size: 16,
         class: crate::theme::Svg::default(),
+        opacity: 1.0,
         rotation: None,
         width: None,
     }
@@ -46,6 +47,9 @@ pub struct Icon {
     #[setters(skip)]
     pub(super) size: u16,
     content_fit: ContentFit,
+    /// Opacity of the rendered icon (1.0 = opaque). Lets callers dim an icon,
+    /// e.g. to signal an online-only / not-downloaded file in a sync folder.
+    opacity: f32,
     #[setters(strip_option)]
     width: Option<Length>,
     #[setters(strip_option)]
@@ -85,6 +89,7 @@ impl Icon {
                 )
                 .rotation(self.rotation.unwrap_or_default())
                 .content_fit(self.content_fit)
+                .opacity(self.opacity)
                 .into()
         };
 
@@ -101,6 +106,7 @@ impl Icon {
                 )
                 .rotation(self.rotation.unwrap_or_default())
                 .content_fit(self.content_fit)
+                .opacity(self.opacity)
                 .symbolic(self.handle.symbolic)
                 .into()
         };


### PR DESCRIPTION
Let callers set the opacity of an `Icon`. The underlying iced `Image` and `Svg`
widgets already support `.opacity()`; `Icon` hardcoded it to `1.0` and exposed
no setter, so there was no way to dim an icon.

This adds an `opacity: f32` field (default `1.0`, so existing behaviour is
unchanged — the `#[derive(Setters)]` gives the `.opacity()` builder) and passes
it through to the `Image`/`Svg` widgets in `view()`.

**Motivation:** a file manager / sync client wants to render an "online-only"
(not-downloaded) file's icon dimmed, the way OneDrive/Dropbox do. More
generally, any caller that wants a faded/disabled icon can now do so without
pre-processing the image. Companion use in a cosmic-files sync-status RFC.
