### PR TITLE
feat(widget): add fixed-height VirtualList for O(visible) lists

### DIFF
--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -276,6 +276,10 @@ pub use rectangle_tracker::{RectangleTracker, rectangle_tracking_container};
 pub mod scrollable;
 #[doc(inline)]
 pub use scrollable::scrollable;
+
+/// Virtualized vertical lists (only visible rows become widgets).
+pub mod virtual_list;
+
 pub mod segmented_button;
 pub mod segmented_control;
 

--- a/src/widget/virtual_list.rs
+++ b/src/widget/virtual_list.rs
@@ -1,0 +1,193 @@
+// Copyright 2026 System76 / local COSMIC performance work
+// SPDX-License-Identifier: MPL-2.0
+
+//! Virtualized vertical lists for large item counts.
+//!
+//! Immediate-mode UIs (iced) rebuild widget trees every frame. Materializing
+//! hundreds of complex rows (buttons, icons, text) inside a [`scrollable`] makes
+//! keyboard navigation and scrolling lag. Browsers avoid this with virtual
+//! lists: only rows near the viewport exist as real widgets; spacers preserve
+//! total content height so scrollbar math stays correct.
+//!
+//! # Pattern
+//!
+//! 1. Keep scroll offset in app state (`on_scroll` and/or before `snap_to`).
+//! 2. Build content with [`content`] / [`content_with_overscan`].
+//! 3. Wrap in [`crate::widget::scrollable`].
+//!
+//! For short lists that fit the viewport, all items are built (no spacers).
+
+use crate::widget::{column, space};
+use crate::{Element, Renderer};
+use iced::Length;
+use iced::widget;
+
+/// Default extra rows above/below the viewport to reduce pop-in while scrolling.
+pub const DEFAULT_OVERSCAN: usize = 2;
+
+/// Visible item index range `[start, end)` for a vertical virtual list.
+///
+/// `end` is exclusive. When the list fits in the viewport, returns `(0, item_count)`.
+#[must_use]
+pub fn visible_range(
+    item_count: usize,
+    item_height: f32,
+    scroll_offset_y: f32,
+    viewport_height: f32,
+    overscan: usize,
+) -> (usize, usize) {
+    if item_count == 0 || item_height <= 0.0 {
+        return (0, 0);
+    }
+
+    let content_height = item_count as f32 * item_height;
+    if content_height <= viewport_height {
+        return (0, item_count);
+    }
+
+    let scroll = scroll_offset_y.max(0.0);
+    let mut start = (scroll / item_height).floor() as usize;
+    start = start.saturating_sub(overscan);
+
+    let visible = (viewport_height / item_height).ceil() as usize;
+    let mut end = (start + visible + overscan * 2).min(item_count);
+    if end <= start {
+        end = (start + 1).min(item_count);
+    }
+    (start, end)
+}
+
+/// Total content height for `item_count` fixed-height rows.
+#[must_use]
+pub fn content_height(item_count: usize, item_height: f32) -> f32 {
+    item_count as f32 * item_height.max(0.0)
+}
+
+/// Build a virtualized column: top spacer + visible rows + bottom spacer.
+///
+/// Put the result inside a [`scrollable`](crate::widget::scrollable). Keep
+/// `scroll_offset_y` in sync with the scrollable (via `on_scroll` and when
+/// issuing `snap_to` / `scroll_to` from the app).
+///
+/// `item_height` must match the laid-out height of each row (including any
+/// spacing you bake into the row). Variable-height rows are not supported in v1.
+pub fn content<'a, Message: 'a>(
+    item_count: usize,
+    item_height: f32,
+    scroll_offset_y: f32,
+    viewport_height: f32,
+    item: impl Fn(usize) -> Element<'a, Message> + 'a,
+) -> Element<'a, Message> {
+    content_with_overscan(
+        item_count,
+        item_height,
+        scroll_offset_y,
+        viewport_height,
+        DEFAULT_OVERSCAN,
+        item,
+    )
+}
+
+/// Same as [`content`] with a custom overscan row count.
+pub fn content_with_overscan<'a, Message: 'a>(
+    item_count: usize,
+    item_height: f32,
+    scroll_offset_y: f32,
+    viewport_height: f32,
+    overscan: usize,
+    item: impl Fn(usize) -> Element<'a, Message> + 'a,
+) -> Element<'a, Message> {
+    let item_height = item_height.max(0.0);
+    if item_count == 0 || item_height == 0.0 {
+        return space::vertical().height(0).into();
+    }
+
+    let (start, end) = visible_range(
+        item_count,
+        item_height,
+        scroll_offset_y,
+        viewport_height,
+        overscan,
+    );
+
+    let top = start as f32 * item_height;
+    let mid = (end - start) as f32 * item_height;
+    let total = content_height(item_count, item_height);
+    let bottom = (total - top - mid).max(0.0);
+
+    // Capacity: optional spacers + visible items
+    let mut col = column::with_capacity((end - start) + 2).width(Length::Fill);
+
+    if top > 0.0 {
+        col = col.push(space::vertical().height(Length::Fixed(top)));
+    }
+
+    for i in start..end {
+        col = col.push(
+            widget::container(item(i))
+                .width(Length::Fill)
+                .height(Length::Fixed(item_height)),
+        );
+    }
+
+    if bottom > 0.0 {
+        col = col.push(space::vertical().height(Length::Fixed(bottom)));
+    }
+
+    col.into()
+}
+
+/// Convenience: virtual content inside a themed vertical scrollable.
+///
+/// The returned scrollable does **not** auto-track offset; use
+/// [`.on_scroll(...)`](iced::widget::Scrollable::on_scroll) on the result (or
+/// set scroll state when snapping) so the next `view` passes the right
+/// `scroll_offset_y` into this builder.
+pub fn scrollable<'a, Message: 'a>(
+    item_count: usize,
+    item_height: f32,
+    scroll_offset_y: f32,
+    viewport_height: f32,
+    item: impl Fn(usize) -> Element<'a, Message> + 'a,
+) -> widget::Scrollable<'a, Message, crate::Theme, Renderer> {
+    let body = content(
+        item_count,
+        item_height,
+        scroll_offset_y,
+        viewport_height,
+        item,
+    );
+    crate::widget::scrollable(body).height(Length::Fixed(viewport_height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{content_height, visible_range};
+
+    #[test]
+    fn visible_range_full_when_content_fits() {
+        assert_eq!(visible_range(10, 40.0, 0.0, 500.0, 2), (0, 10));
+    }
+
+    #[test]
+    fn visible_range_window_for_long_list() {
+        let (s, e) = visible_range(100, 50.0, 0.0, 200.0, 2);
+        assert_eq!(s, 0);
+        // 200/50 = 4 visible + 2*2 overscan = 8
+        assert!(e <= 10);
+        assert!(e - s < 100);
+    }
+
+    #[test]
+    fn visible_range_scrolls() {
+        let (s, e) = visible_range(100, 50.0, 500.0, 200.0, 2);
+        assert!(s >= 8); // 500/50 = 10, minus overscan 2
+        assert!(e > s);
+        assert!(e <= 100);
+    }
+
+    #[test]
+    fn content_height_scales() {
+        assert_eq!(content_height(20, 49.0), 980.0);
+    }
+}

--- a/src/widget/virtual_list.rs
+++ b/src/widget/virtual_list.rs
@@ -3,33 +3,15 @@
 
 //! Virtualized vertical lists — browser-style list performance for iced/COSMIC.
 //!
-//! # Root issue
+//! # Cost model (keyboard nav)
 //!
-//! Browsers keep list DOM nodes and only change selection / `scrollTop` on each
-//! keypress. iced apps that rebuild and re-layout every row on every
-//! `focused += 1` pay tens of milliseconds per key — rapid arrows feel laggy.
+//! | Frame type | Rebuild row widgets | Remeasure text/layout | Work |
+//! |------------|---------------------|------------------------|------|
+//! | Focus only (range stable) | No | No | paint selection + reposition if scroll changed |
+//! | Scroll, same window | No | No | reposition cached layout nodes |
+//! | Range / content change | Yes (visible only) | Yes (visible only) | O(visible) |
 //!
-//! # What this widget does
-//!
-//! 1. Only **creates** row widgets for the visible window (+ overscan).
-//! 2. **Reuses** those widgets when items/range are unchanged (selection-only).
-//! 3. **Caches** child layout measurements; on scroll/selection only **repositions**
-//!    (no text remeasure).
-//! 4. In **viewport mode** (default for the stateful list), scroll offset is a
-//!    prop (like `scrollTop`) — no `operation::snap_to` tree walk per key.
-//!
-//! # App pattern
-//!
-//! ```ignore
-//! // scroll_y updated on keyboard (proportional formula) and on_scroll from wheel
-//! virtual_list(n)
-//!     .item_height(49.0)
-//!     .viewport_height(504.0)
-//!     .scroll_offset_y(scroll_y)
-//!     .focused(Some(focused))
-//!     .on_scroll(Message::Scrolled) // wheel
-//!     .item(|i| row_without_selection_style(i))
-//! ```
+//! Always runs `tree.diff_children` so iced Button state stays valid.
 
 use crate::widget::{column, space};
 use crate::{Element, Renderer};
@@ -162,11 +144,13 @@ pub fn virtual_list<'a, Message: 'static>(item_count: usize) -> VirtualList<'a, 
         scroll_offset_y: 0.0,
         viewport_height: 504.0,
         overscan: DEFAULT_OVERSCAN,
+        content_revision: 0,
         focused: None,
         selection_fill: None,
         width: Length::Fill,
         on_scroll: None,
         item: Box::new(|_| space::vertical().height(0).into()),
+        range: (0, 0),
         _marker: std::marker::PhantomData,
     }
 }
@@ -177,11 +161,14 @@ pub struct VirtualList<'a, Message: 'static> {
     scroll_offset_y: f32,
     viewport_height: f32,
     overscan: usize,
+    /// Bump when item *data* changes (search results), even if count is same.
+    content_revision: u64,
     focused: Option<usize>,
     selection_fill: Option<Color>,
     width: Length,
     on_scroll: Option<Box<dyn Fn(f32) -> Message + 'a>>,
     item: Box<dyn Fn(usize) -> Element<'static, Message> + 'a>,
+    range: (usize, usize),
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
@@ -210,6 +197,13 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
         self
     }
 
+    /// Bump when item *contents* change even if `item_count` is unchanged.
+    #[must_use]
+    pub fn content_revision(mut self, revision: u64) -> Self {
+        self.content_revision = revision;
+        self
+    }
+
     #[must_use]
     pub fn focused(mut self, focused: Option<usize>) -> Self {
         self.focused = focused;
@@ -228,8 +222,6 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
         self
     }
 
-    /// Mouse-wheel scroll. Keyboard/app should set `scroll_offset_y` itself
-    /// (proportional formula) — no `snap_to` required.
     #[must_use]
     pub fn on_scroll(mut self, f: impl Fn(f32) -> Message + 'a) -> Self {
         self.on_scroll = Some(Box::new(f));
@@ -243,7 +235,7 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
         self
     }
 
-    fn range(&self) -> (usize, usize) {
+    fn compute_range(&self) -> (usize, usize) {
         visible_range(
             self.item_count,
             self.item_height,
@@ -264,10 +256,11 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
 struct State<Message: 'static> {
     item_count: usize,
     item_height: f32,
+    content_revision: u64,
     range: (usize, usize),
     rows: Vec<Element<'static, Message>>,
-    /// Child layouts at local origin (0,0) size — repositioned per scroll cheaply.
-    child_sizes: Vec<Size>,
+    /// Nested layout for each row; repositioned on scroll without remeasure.
+    child_nodes: Vec<Node>,
     layout_width: f32,
 }
 
@@ -276,10 +269,58 @@ impl<Message: 'static> Default for State<Message> {
         Self {
             item_count: 0,
             item_height: 0.0,
+            content_revision: u64::MAX,
             range: (0, 0),
             rows: Vec::new(),
-            child_sizes: Vec::new(),
+            child_nodes: Vec::new(),
             layout_width: 0.0,
+        }
+    }
+}
+
+impl<'a, Message: 'static + Clone> VirtualList<'a, Message> {
+    fn ensure_rows(&mut self, tree: &mut Tree) {
+        let range = self.compute_range();
+        self.range = range;
+
+        let (need_rebuild, rows_len) = {
+            let state = tree.state.downcast_mut::<State<Message>>();
+            let structure = state.item_count != self.item_count
+                || (state.item_height - self.item_height).abs() > f32::EPSILON
+                || state.content_revision != self.content_revision
+                || state.range != range;
+            // If tree children were dropped (e.g. parent recreated tree), rebuild.
+            let orphaned = !state.rows.is_empty() && tree.children.len() != state.rows.len();
+            (structure || orphaned || (state.rows.is_empty() && self.item_count > 0 && range.0 < range.1), state.rows.len())
+        };
+        let _ = rows_len;
+
+        if need_rebuild {
+            let (start, end) = range;
+            let mut rows: Vec<Element<'static, Message>> = (start..end)
+                .map(|i| {
+                    widget::container((self.item)(i))
+                        .width(Length::Fill)
+                        .height(Length::Fixed(self.item_height))
+                        .into()
+                })
+                .collect();
+
+            tree.diff_children(rows.as_mut_slice());
+
+            let state = tree.state.downcast_mut::<State<Message>>();
+            state.item_count = self.item_count;
+            state.item_height = self.item_height;
+            state.content_revision = self.content_revision;
+            state.range = range;
+            state.child_nodes.clear();
+            state.rows = rows;
+        } else {
+            // Keep Element widgets (no item() rebuild) but always re-diff Tree.
+            // Skipping diff_children caused Button "Downcast on stateless state".
+            let mut rows = std::mem::take(&mut tree.state.downcast_mut::<State<Message>>().rows);
+            tree.diff_children(rows.as_mut_slice());
+            tree.state.downcast_mut::<State<Message>>().rows = rows;
         }
     }
 }
@@ -300,38 +341,10 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
     }
 
     fn diff(&mut self, tree: &mut Tree) {
-        let range = self.range();
-        let state = tree.state.downcast_mut::<State<Message>>();
-
-        let structure_changed = state.item_count != self.item_count
-            || (state.item_height - self.item_height).abs() > f32::EPSILON
-            || state.range != range;
-
-        if structure_changed {
-            state.item_count = self.item_count;
-            state.item_height = self.item_height;
-            state.range = range;
-            state.child_sizes.clear();
-
-            let (start, end) = range;
-            let mut rows: Vec<Element<'static, Message>> = (start..end)
-                .map(|i| {
-                    widget::container((self.item)(i))
-                        .width(Length::Fill)
-                        .height(Length::Fixed(self.item_height))
-                        .into()
-                })
-                .collect();
-
-            let _ = state;
-            tree.diff_children(rows.as_mut_slice());
-            tree.state.downcast_mut::<State<Message>>().rows = rows;
-        }
-        // else: selection/scroll-only — keep rows (browser keeps DOM nodes)
+        self.ensure_rows(tree);
     }
 
     fn size(&self) -> Size<Length> {
-        // Viewport-sized (like a scrollport), not full content height.
         Size {
             width: self.width,
             height: Length::Fixed(self.viewport_height),
@@ -344,9 +357,10 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         renderer: &Renderer,
         limits: &Limits,
     ) -> Node {
-        self.diff(tree);
+        // Diff may have run already; ensure_rows is cheap when structure is stable
+        // (reuses Elements, only re-diffs Tree children).
+        self.ensure_rows(tree);
 
-        let state = tree.state.downcast_mut::<State<Message>>();
         let max_width = limits.max().width;
         let width = match self.width {
             Length::Fixed(w) => w.min(max_width),
@@ -355,32 +369,35 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         };
         let viewport_h = self.viewport_height;
         let scroll = self.clamp_scroll(self.scroll_offset_y);
-        let (start, _end) = state.range;
-
+        let (start, _end) = self.range;
         let child_limits = Limits::new(Size::ZERO, Size::new(width, self.item_height));
 
-        // Measure children only when missing sizes (structure change).
-        if state.child_sizes.len() != state.rows.len()
-            || (state.layout_width - width).abs() > 0.5
-        {
-            state.child_sizes.clear();
-            state.layout_width = width;
-            for (row, child_tree) in state.rows.iter_mut().zip(tree.children.iter_mut()) {
-                let node = row
-                    .as_widget_mut()
-                    .layout(child_tree, renderer, &child_limits);
-                state.child_sizes.push(node.size());
+        // 1.0 px tolerance — autosize can jitter subpixel widths.
+        let need_remeasure = {
+            let state = tree.state.downcast_ref::<State<Message>>();
+            state.child_nodes.len() != state.rows.len()
+                || (state.layout_width - width).abs() > 1.0
+        };
+
+        if need_remeasure {
+            let mut rows = std::mem::take(&mut tree.state.downcast_mut::<State<Message>>().rows);
+            let mut child_nodes = Vec::with_capacity(rows.len());
+            for (row, child_tree) in rows.iter_mut().zip(tree.children.iter_mut()) {
+                child_nodes.push(row.as_widget_mut().layout(child_tree, renderer, &child_limits));
             }
+            let state = tree.state.downcast_mut::<State<Message>>();
+            state.rows = rows;
+            state.child_nodes = child_nodes;
+            state.layout_width = width;
         }
 
-        // Reposition only (O(visible)) — no text remeasure. Like scrollTop.
-        let mut nodes = Vec::with_capacity(state.rows.len());
-        for (j, size) in state.child_sizes.iter().enumerate() {
+        // Reposition only (O(visible)) when structure stable.
+        let state = tree.state.downcast_ref::<State<Message>>();
+        let mut nodes = Vec::with_capacity(state.child_nodes.len());
+        for (j, base) in state.child_nodes.iter().enumerate() {
             let content_y = (start + j) as f32 * self.item_height;
             let y = content_y - scroll;
-            let mut node = Node::new(*size);
-            node = node.move_to(Point::new(0.0, y));
-            nodes.push(node);
+            nodes.push(base.clone().move_to(Point::new(0.0, y)));
         }
 
         Node::with_children(Size::new(width, viewport_h), nodes)
@@ -395,9 +412,8 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
     ) {
         operation.container(None, layout.bounds());
         let vo = layout.virtual_offset();
-        let state = tree.state.downcast_mut::<State<Message>>();
-        for ((child, child_tree), child_layout) in state
-            .rows
+        let mut rows = std::mem::take(&mut tree.state.downcast_mut::<State<Message>>().rows);
+        for ((child, child_tree), child_layout) in rows
             .iter_mut()
             .zip(tree.children.iter_mut())
             .zip(layout.children())
@@ -409,6 +425,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                 operation,
             );
         }
+        tree.state.downcast_mut::<State<Message>>().rows = rows;
     }
 
     fn update(
@@ -422,7 +439,6 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
-        // Wheel scroll → app state (like scrollTop).
         if let Event::Mouse(mouse::Event::WheelScrolled { delta }) = event {
             if cursor.is_over(layout.bounds()) {
                 if let Some(on_scroll) = &self.on_scroll {
@@ -441,9 +457,8 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         }
 
         let vo = layout.virtual_offset();
-        let state = tree.state.downcast_mut::<State<Message>>();
-        for ((child, child_tree), child_layout) in state
-            .rows
+        let mut rows = std::mem::take(&mut tree.state.downcast_mut::<State<Message>>().rows);
+        for ((child, child_tree), child_layout) in rows
             .iter_mut()
             .zip(tree.children.iter_mut())
             .zip(layout.children())
@@ -459,6 +474,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                 viewport,
             );
         }
+        tree.state.downcast_mut::<State<Message>>().rows = rows;
     }
 
     fn mouse_interaction(
@@ -500,9 +516,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         viewport: &Rectangle,
     ) {
         let bounds = layout.bounds();
-        let clip = viewport
-            .intersection(&bounds)
-            .unwrap_or(bounds);
+        let clip = viewport.intersection(&bounds).unwrap_or(bounds);
 
         renderer.with_layer(clip, |renderer| {
             let state = tree.state.downcast_ref::<State<Message>>();
@@ -510,7 +524,6 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             let scroll = self.clamp_scroll(self.scroll_offset_y);
             let vo = layout.virtual_offset();
 
-            // Selection highlight (paint only — no row rebuild).
             if let Some(focused) = self.focused {
                 if focused >= start && focused < end {
                     let y = bounds.y + focused as f32 * self.item_height - scroll;
@@ -553,8 +566,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                 .zip(&tree.children)
                 .zip(layout.children())
             {
-                let child_bounds = child_layout.bounds();
-                if !child_bounds.intersects(&clip) {
+                if !child_layout.bounds().intersects(&clip) {
                     continue;
                 }
                 child.as_widget().draw(
@@ -568,7 +580,6 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                 );
             }
 
-            // Minimal scrollbar thumb (optional visual; no iced scrollable).
             let content_h = content_height(self.item_count, self.item_height);
             if content_h > self.viewport_height + 1.0 {
                 let track = Rectangle {
@@ -600,10 +611,10 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                         snap: true,
                     },
                     Background::Color(Color {
-                        r: 0.5,
-                        g: 0.5,
-                        b: 0.5,
-                        a: 0.45,
+                        r: 1.0,
+                        g: 1.0,
+                        b: 1.0,
+                        a: 0.25,
                     }),
                 );
             }
@@ -618,6 +629,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         _viewport: &Rectangle,
         _translation: Vector,
     ) -> Option<overlay::Element<'b, Message, crate::Theme, Renderer>> {
+        // Row overlays unused by launcher; skip to avoid complex State borrows.
         None
     }
 }
@@ -630,37 +642,23 @@ impl<'a, Message: 'static + Clone> From<VirtualList<'a, Message>> for Element<'a
 
 #[cfg(test)]
 mod tests {
-    use super::{content_height, max_scroll, visible_range};
+    use super::*;
 
     #[test]
-    fn visible_range_full_when_content_fits() {
-        assert_eq!(visible_range(10, 40.0, 0.0, 500.0, 2), (0, 10));
+    fn visible_range_empty() {
+        assert_eq!(visible_range(0, 48.0, 0.0, 500.0, 2), (0, 0));
     }
 
     #[test]
-    fn visible_range_window_for_long_list() {
-        let (s, e) = visible_range(100, 50.0, 0.0, 200.0, 2);
-        assert_eq!(s, 0);
-        assert!(e <= 10);
-        assert!(e - s < 100);
+    fn visible_range_fits() {
+        assert_eq!(visible_range(5, 48.0, 0.0, 500.0, 2), (0, 5));
     }
 
     #[test]
-    fn visible_range_scrolls() {
-        let (s, e) = visible_range(100, 50.0, 500.0, 200.0, 2);
-        assert!(s >= 8);
+    fn visible_range_scrolled() {
+        let (s, e) = visible_range(100, 50.0, 200.0, 100.0, 1);
+        assert!(s <= 4);
         assert!(e > s);
         assert!(e <= 100);
-    }
-
-    #[test]
-    fn content_height_scales() {
-        assert_eq!(content_height(20, 49.0), 980.0);
-    }
-
-    #[test]
-    fn max_scroll_zero_when_fits() {
-        assert_eq!(max_scroll(5, 40.0, 500.0), 0.0);
-        assert!((max_scroll(20, 49.0, 504.0) - (980.0 - 504.0)).abs() < 0.1);
     }
 }

--- a/src/widget/virtual_list.rs
+++ b/src/widget/virtual_list.rs
@@ -1,33 +1,56 @@
 // Copyright 2026 System76 / local COSMIC performance work
 // SPDX-License-Identifier: MPL-2.0
 
-//! Virtualized vertical lists for large item counts.
+//! Virtualized vertical lists — browser-style recycling for iced/COSMIC.
 //!
-//! Immediate-mode UIs (iced) rebuild widget trees every frame. Materializing
-//! hundreds of complex rows (buttons, icons, text) inside a [`scrollable`] makes
-//! keyboard navigation and scrolling lag. Browsers avoid this with virtual
-//! lists: only rows near the viewport exist as real widgets; spacers preserve
-//! total content height so scrollbar math stays correct.
+//! # Why this exists
+//!
+//! In the browser, a list of ~100 rows stays as DOM nodes; changing the
+//! selected row only updates classes / `scrollTop`. In iced, `view()` builds a
+//! new `Element` tree every frame. If each keypress rebuilds and re-lays-out
+//! every row, navigation feels laggy even for 20 items.
+//!
+//! This widget:
+//! 1. Only **creates** row widgets for the visible window (+ overscan).
+//! 2. **Reuses** those row widgets when only the selection index changes
+//!    (no child rebuild, cached layout).
+//! 3. Keeps full content height so proportional `snap_to` / scrollbars work.
 //!
 //! # Pattern
 //!
-//! 1. Keep scroll offset in app state (`on_scroll` and/or before `snap_to`).
-//! 2. Build content with [`content`] / [`content_with_overscan`].
-//! 3. Wrap in [`crate::widget::scrollable`].
+//! ```ignore
+//! scrollable(
+//!     virtual_list(items.len())
+//!         .item_height(48.0)
+//!         .viewport_height(504.0)
+//!         .scroll_offset_y(scroll_y)
+//!         .focused(Some(focused))
+//!         .item(|i| row_ui(i)) // must not depend on selection styling
+//! )
+//! .id(LIST_ID)
+//! .on_scroll(|vp| Message::Scrolled(vp.absolute_offset().y))
+//! ```
 //!
-//! For short lists that fit the viewport, all items are built (no spacers).
+//! Keep `scroll_offset_y` in app state (from `on_scroll` and when issuing
+//! `snap_to` / `scroll_to`). Put **selection chrome** via `.focused(Some(i))`
+//! so row bodies stay cacheable.
 
 use crate::widget::{column, space};
 use crate::{Element, Renderer};
 use iced::Length;
 use iced::widget;
+use iced_core::layout::{Layout, Limits, Node};
+use iced_core::widget::tree::{self, Tree};
+use iced_core::widget::{Operation, Widget};
+use iced_core::{
+    Background, Border, Clipboard, Color, Event, Point, Rectangle, Shell, Size, Vector, mouse,
+    overlay, renderer, Renderer as _,
+};
 
-/// Default extra rows above/below the viewport to reduce pop-in while scrolling.
+/// Default extra rows above/below the viewport.
 pub const DEFAULT_OVERSCAN: usize = 2;
 
 /// Visible item index range `[start, end)` for a vertical virtual list.
-///
-/// `end` is exclusive. When the list fits in the viewport, returns `(0, item_count)`.
 #[must_use]
 pub fn visible_range(
     item_count: usize,
@@ -63,14 +86,10 @@ pub fn content_height(item_count: usize, item_height: f32) -> f32 {
     item_count as f32 * item_height.max(0.0)
 }
 
-/// Build a virtualized column: top spacer + visible rows + bottom spacer.
-///
-/// Put the result inside a [`scrollable`](crate::widget::scrollable). Keep
-/// `scroll_offset_y` in sync with the scrollable (via `on_scroll` and when
-/// issuing `snap_to` / `scroll_to` from the app).
-///
-/// `item_height` must match the laid-out height of each row (including any
-/// spacing you bake into the row). Variable-height rows are not supported in v1.
+// --- Stateless helper (always rebuilds; fine for tiny lists / tests) ---------
+
+/// Build a virtualized column (spacers + visible rows). Prefer [`VirtualList`]
+/// when selection changes often — it reuses row widgets across frames.
 pub fn content<'a, Message: 'a>(
     item_count: usize,
     item_height: f32,
@@ -115,7 +134,6 @@ pub fn content_with_overscan<'a, Message: 'a>(
     let total = content_height(item_count, item_height);
     let bottom = (total - top - mid).max(0.0);
 
-    // Capacity: optional spacers + visible items
     let mut col = column::with_capacity((end - start) + 2).width(Length::Fill);
 
     if top > 0.0 {
@@ -137,12 +155,7 @@ pub fn content_with_overscan<'a, Message: 'a>(
     col.into()
 }
 
-/// Convenience: virtual content inside a themed vertical scrollable.
-///
-/// The returned scrollable does **not** auto-track offset; use
-/// [`.on_scroll(...)`](iced::widget::Scrollable::on_scroll) on the result (or
-/// set scroll state when snapping) so the next `view` passes the right
-/// `scroll_offset_y` into this builder.
+/// Convenience scrollable wrapper around [`content`].
 pub fn scrollable<'a, Message: 'a>(
     item_count: usize,
     item_height: f32,
@@ -160,6 +173,420 @@ pub fn scrollable<'a, Message: 'a>(
     crate::widget::scrollable(body).height(Length::Fixed(viewport_height))
 }
 
+// --- Stateful virtual list (cache rows across selection-only updates) --------
+
+/// Create a [`VirtualList`] with `item_count` fixed-height rows.
+#[must_use]
+pub fn virtual_list<'a, Message: 'static>(
+    item_count: usize,
+) -> VirtualList<'a, Message> {
+    VirtualList {
+        item_count,
+        item_height: 48.0,
+        scroll_offset_y: 0.0,
+        viewport_height: 504.0,
+        overscan: DEFAULT_OVERSCAN,
+        focused: None,
+        selection_fill: None,
+        width: Length::Fill,
+        item: Box::new(|_| space::vertical().height(0).into()),
+        _marker: std::marker::PhantomData,
+    }
+}
+
+/// A virtualized list that **reuses row widgets** when only the focused index
+/// changes (browser-like selection updates).
+pub struct VirtualList<'a, Message: 'static> {
+    item_count: usize,
+    item_height: f32,
+    scroll_offset_y: f32,
+    viewport_height: f32,
+    overscan: usize,
+    focused: Option<usize>,
+    /// Optional selection background (RGBA). Defaults to a soft accent-like fill.
+    selection_fill: Option<Color>,
+    width: Length,
+    item: Box<dyn Fn(usize) -> Element<'static, Message> + 'a>,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, Message: 'static> VirtualList<'a, Message> {
+    #[must_use]
+    pub fn item_height(mut self, height: f32) -> Self {
+        self.item_height = height.max(0.0);
+        self
+    }
+
+    #[must_use]
+    pub fn scroll_offset_y(mut self, y: f32) -> Self {
+        self.scroll_offset_y = y.max(0.0);
+        self
+    }
+
+    #[must_use]
+    pub fn viewport_height(mut self, height: f32) -> Self {
+        self.viewport_height = height.max(0.0);
+        self
+    }
+
+    #[must_use]
+    pub fn overscan(mut self, rows: usize) -> Self {
+        self.overscan = rows;
+        self
+    }
+
+    /// Keyboard / app selection index. Drawn as a background behind that row;
+    /// keep this **out** of [`Self::item`] so rows stay cacheable.
+    #[must_use]
+    pub fn focused(mut self, focused: Option<usize>) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    #[must_use]
+    pub fn selection_fill(mut self, color: Color) -> Self {
+        self.selection_fill = Some(color);
+        self
+    }
+
+    #[must_use]
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Row builder. Must produce `'static` elements (own your strings/handles).
+    /// **Do not** bake selection into the row — use [`Self::focused`].
+    #[must_use]
+    pub fn item(
+        mut self,
+        f: impl Fn(usize) -> Element<'static, Message> + 'a,
+    ) -> Self {
+        self.item = Box::new(f);
+        self
+    }
+
+    fn range(&self) -> (usize, usize) {
+        visible_range(
+            self.item_count,
+            self.item_height,
+            self.scroll_offset_y,
+            self.viewport_height,
+            self.overscan,
+        )
+    }
+}
+
+struct State<Message: 'static> {
+    item_count: usize,
+    item_height: f32,
+    range: (usize, usize),
+    /// Owned row elements for the current range (reused across selection-only frames).
+    rows: Vec<Element<'static, Message>>,
+    layout_cache: Option<Node>,
+    layout_width: f32,
+}
+
+impl<Message: 'static> Default for State<Message> {
+    fn default() -> Self {
+        Self {
+            item_count: 0,
+            item_height: 0.0,
+            range: (0, 0),
+            rows: Vec::new(),
+            layout_cache: None,
+            layout_width: 0.0,
+        }
+    }
+}
+
+impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
+    for VirtualList<'a, Message>
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State<Message>>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::<Message>::default())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        // Initial mount: empty until layout/diff fills state.rows
+        Vec::new()
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        let range = self.range();
+        let state = tree.state.downcast_mut::<State<Message>>();
+
+        let structure_changed = state.item_count != self.item_count
+            || (state.item_height - self.item_height).abs() > f32::EPSILON
+            || state.range != range;
+
+        if structure_changed {
+            state.item_count = self.item_count;
+            state.item_height = self.item_height;
+            state.range = range;
+            state.layout_cache = None;
+
+            let (start, end) = range;
+            let mut rows: Vec<Element<'static, Message>> = (start..end)
+                .map(|i| {
+                    widget::container((self.item)(i))
+                        .width(Length::Fill)
+                        .height(Length::Fixed(self.item_height))
+                        .into()
+                })
+                .collect();
+
+            // Drop borrow of state before diff_children.
+            let _ = state;
+            tree.diff_children(rows.as_mut_slice());
+            tree.state.downcast_mut::<State<Message>>().rows = rows;
+        } else {
+            // Selection-only (or pure redraw): keep row widgets + trees.
+            let mut rows = std::mem::take(&mut state.rows);
+            let _ = state;
+            tree.diff_children(rows.as_mut_slice());
+            tree.state.downcast_mut::<State<Message>>().rows = rows;
+        }
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Fixed(content_height(self.item_count, self.item_height)),
+        }
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &Limits,
+    ) -> Node {
+        // Ensure rows exist (first frame / structure change).
+        self.diff(tree);
+
+        let state = tree.state.downcast_mut::<State<Message>>();
+        let max_width = limits.max().width;
+        let content_h = content_height(self.item_count, self.item_height);
+        let width = match self.width {
+            Length::Fixed(w) => w.min(max_width),
+            Length::Fill | Length::FillPortion(_) => max_width,
+            Length::Shrink => max_width,
+        };
+
+        // Layout cache: when only selection changed, reuse geometry.
+        if let Some(cache) = &state.layout_cache {
+            if (state.layout_width - width).abs() < 0.5 {
+                return cache.clone();
+            }
+        }
+
+        let (start, end) = state.range;
+        let top = start as f32 * self.item_height;
+
+        let child_limits = Limits::new(Size::ZERO, Size::new(width, self.item_height));
+
+        let mut nodes = Vec::with_capacity(state.rows.len());
+        for (row, child_tree) in state.rows.iter_mut().zip(tree.children.iter_mut()) {
+            let mut node = row
+                .as_widget_mut()
+                .layout(child_tree, renderer, &child_limits);
+            let y = top + nodes.len() as f32 * self.item_height;
+            node = node.move_to(Point::new(0.0, y));
+            nodes.push(node);
+        }
+
+        // Full content height (spacers are implicit empty space for hit-testing).
+        let root = Node::with_children(Size::new(width, content_h), nodes);
+        // Note: top/bottom gaps have no children — scrollable still uses content size.
+
+        let _ = end; // range end used via state.rows len
+        state.layout_width = width;
+        state.layout_cache = Some(root.clone());
+        root
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<()>,
+    ) {
+        operation.container(None, layout.bounds());
+        let virtual_offset = layout.virtual_offset();
+        let state = tree.state.downcast_mut::<State<Message>>();
+        for ((child, child_tree), child_layout) in state
+            .rows
+            .iter_mut()
+            .zip(tree.children.iter_mut())
+            .zip(layout.children())
+        {
+            child.as_widget_mut().operate(
+                child_tree,
+                child_layout.with_virtual_offset(virtual_offset),
+                renderer,
+                operation,
+            );
+        }
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_mut::<State<Message>>();
+        for ((child, child_tree), child_layout) in state
+            .rows
+            .iter_mut()
+            .zip(tree.children.iter_mut())
+            .zip(layout.children())
+        {
+            child.as_widget_mut().update(
+                child_tree,
+                event,
+                child_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                renderer,
+                clipboard,
+                shell,
+                viewport,
+            );
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        let state = tree.state.downcast_ref::<State<Message>>();
+        state
+            .rows
+            .iter()
+            .zip(&tree.children)
+            .zip(layout.children())
+            .map(|((child, child_tree), child_layout)| {
+                child.as_widget().mouse_interaction(
+                    child_tree,
+                    child_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
+                )
+            })
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &crate::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<State<Message>>();
+        let (start, _) = state.range;
+        let bounds = layout.bounds();
+
+        // Selection background (does not require rebuilding row widgets).
+        if let Some(focused) = self.focused {
+            if focused >= start && focused < state.range.1 {
+                let y = bounds.y + focused as f32 * self.item_height;
+                let sel = Rectangle {
+                    x: bounds.x,
+                    y,
+                    width: bounds.width,
+                    height: self.item_height,
+                };
+                if let Some(clipped) = sel.intersection(viewport) {
+                    let fill = self.selection_fill.unwrap_or_else(|| {
+                        let a = theme.cosmic().accent_color();
+                        Color {
+                            r: a.red,
+                            g: a.green,
+                            b: a.blue,
+                            a: 0.18,
+                        }
+                    });
+                    renderer.fill_quad(
+                        renderer::Quad {
+                            bounds: clipped,
+                            border: Border {
+                                radius: theme.cosmic().corner_radii.radius_s.into(),
+                                width: 0.0,
+                                color: Color::TRANSPARENT,
+                            },
+                            shadow: Default::default(),
+                            snap: true,
+                        },
+                        Background::Color(fill),
+                    );
+                }
+            }
+        }
+
+        for ((child, child_tree), child_layout) in state
+            .rows
+            .iter()
+            .zip(&tree.children)
+            .zip(layout.children())
+        {
+            let child_bounds = child_layout.bounds();
+            if !child_bounds.intersects(viewport) {
+                continue;
+            }
+            child.as_widget().draw(
+                child_tree,
+                renderer,
+                theme,
+                style,
+                child_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                viewport,
+            );
+        }
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, crate::Theme, Renderer>> {
+        let state = tree.state.downcast_mut::<State<Message>>();
+        // No nested overlays aggregation for simplicity.
+        let _ = (state, layout, renderer, viewport, translation);
+        None
+    }
+}
+
+impl<'a, Message: 'static + Clone> From<VirtualList<'a, Message>> for Element<'a, Message> {
+    fn from(list: VirtualList<'a, Message>) -> Self {
+        Element::new(list)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{content_height, visible_range};
@@ -173,7 +600,6 @@ mod tests {
     fn visible_range_window_for_long_list() {
         let (s, e) = visible_range(100, 50.0, 0.0, 200.0, 2);
         assert_eq!(s, 0);
-        // 200/50 = 4 visible + 2*2 overscan = 8
         assert!(e <= 10);
         assert!(e - s < 100);
     }
@@ -181,7 +607,7 @@ mod tests {
     #[test]
     fn visible_range_scrolls() {
         let (s, e) = visible_range(100, 50.0, 500.0, 200.0, 2);
-        assert!(s >= 8); // 500/50 = 10, minus overscan 2
+        assert!(s >= 8);
         assert!(e > s);
         assert!(e <= 100);
     }

--- a/src/widget/virtual_list.rs
+++ b/src/widget/virtual_list.rs
@@ -1,39 +1,35 @@
 // Copyright 2026 System76 / local COSMIC performance work
 // SPDX-License-Identifier: MPL-2.0
 
-//! Virtualized vertical lists — browser-style recycling for iced/COSMIC.
+//! Virtualized vertical lists — browser-style list performance for iced/COSMIC.
 //!
-//! # Why this exists
+//! # Root issue
 //!
-//! In the browser, a list of ~100 rows stays as DOM nodes; changing the
-//! selected row only updates classes / `scrollTop`. In iced, `view()` builds a
-//! new `Element` tree every frame. If each keypress rebuilds and re-lays-out
-//! every row, navigation feels laggy even for 20 items.
+//! Browsers keep list DOM nodes and only change selection / `scrollTop` on each
+//! keypress. iced apps that rebuild and re-layout every row on every
+//! `focused += 1` pay tens of milliseconds per key — rapid arrows feel laggy.
 //!
-//! This widget:
+//! # What this widget does
+//!
 //! 1. Only **creates** row widgets for the visible window (+ overscan).
-//! 2. **Reuses** those row widgets when only the selection index changes
-//!    (no child rebuild, cached layout).
-//! 3. Keeps full content height so proportional `snap_to` / scrollbars work.
+//! 2. **Reuses** those widgets when items/range are unchanged (selection-only).
+//! 3. **Caches** child layout measurements; on scroll/selection only **repositions**
+//!    (no text remeasure).
+//! 4. In **viewport mode** (default for the stateful list), scroll offset is a
+//!    prop (like `scrollTop`) — no `operation::snap_to` tree walk per key.
 //!
-//! # Pattern
+//! # App pattern
 //!
 //! ```ignore
-//! scrollable(
-//!     virtual_list(items.len())
-//!         .item_height(48.0)
-//!         .viewport_height(504.0)
-//!         .scroll_offset_y(scroll_y)
-//!         .focused(Some(focused))
-//!         .item(|i| row_ui(i)) // must not depend on selection styling
-//! )
-//! .id(LIST_ID)
-//! .on_scroll(|vp| Message::Scrolled(vp.absolute_offset().y))
+//! // scroll_y updated on keyboard (proportional formula) and on_scroll from wheel
+//! virtual_list(n)
+//!     .item_height(49.0)
+//!     .viewport_height(504.0)
+//!     .scroll_offset_y(scroll_y)
+//!     .focused(Some(focused))
+//!     .on_scroll(Message::Scrolled) // wheel
+//!     .item(|i| row_without_selection_style(i))
 //! ```
-//!
-//! Keep `scroll_offset_y` in app state (from `on_scroll` and when issuing
-//! `snap_to` / `scroll_to`). Put **selection chrome** via `.focused(Some(i))`
-//! so row bodies stay cacheable.
 
 use crate::widget::{column, space};
 use crate::{Element, Renderer};
@@ -50,7 +46,7 @@ use iced_core::{
 /// Default extra rows above/below the viewport.
 pub const DEFAULT_OVERSCAN: usize = 2;
 
-/// Visible item index range `[start, end)` for a vertical virtual list.
+/// Visible item index range `[start, end)`.
 #[must_use]
 pub fn visible_range(
     item_count: usize,
@@ -80,16 +76,18 @@ pub fn visible_range(
     (start, end)
 }
 
-/// Total content height for `item_count` fixed-height rows.
 #[must_use]
 pub fn content_height(item_count: usize, item_height: f32) -> f32 {
     item_count as f32 * item_height.max(0.0)
 }
 
-// --- Stateless helper (always rebuilds; fine for tiny lists / tests) ---------
+#[must_use]
+pub fn max_scroll(item_count: usize, item_height: f32, viewport_height: f32) -> f32 {
+    (content_height(item_count, item_height) - viewport_height).max(0.0)
+}
 
-/// Build a virtualized column (spacers + visible rows). Prefer [`VirtualList`]
-/// when selection changes often — it reuses row widgets across frames.
+// --- Simple stateless helper -------------------------------------------------
+
 pub fn content<'a, Message: 'a>(
     item_count: usize,
     item_height: f32,
@@ -107,7 +105,6 @@ pub fn content<'a, Message: 'a>(
     )
 }
 
-/// Same as [`content`] with a custom overscan row count.
 pub fn content_with_overscan<'a, Message: 'a>(
     item_count: usize,
     item_height: f32,
@@ -155,31 +152,10 @@ pub fn content_with_overscan<'a, Message: 'a>(
     col.into()
 }
 
-/// Convenience scrollable wrapper around [`content`].
-pub fn scrollable<'a, Message: 'a>(
-    item_count: usize,
-    item_height: f32,
-    scroll_offset_y: f32,
-    viewport_height: f32,
-    item: impl Fn(usize) -> Element<'a, Message> + 'a,
-) -> widget::Scrollable<'a, Message, crate::Theme, Renderer> {
-    let body = content(
-        item_count,
-        item_height,
-        scroll_offset_y,
-        viewport_height,
-        item,
-    );
-    crate::widget::scrollable(body).height(Length::Fixed(viewport_height))
-}
+// --- Stateful viewport virtual list ------------------------------------------
 
-// --- Stateful virtual list (cache rows across selection-only updates) --------
-
-/// Create a [`VirtualList`] with `item_count` fixed-height rows.
 #[must_use]
-pub fn virtual_list<'a, Message: 'static>(
-    item_count: usize,
-) -> VirtualList<'a, Message> {
+pub fn virtual_list<'a, Message: 'static>(item_count: usize) -> VirtualList<'a, Message> {
     VirtualList {
         item_count,
         item_height: 48.0,
@@ -189,13 +165,12 @@ pub fn virtual_list<'a, Message: 'static>(
         focused: None,
         selection_fill: None,
         width: Length::Fill,
+        on_scroll: None,
         item: Box::new(|_| space::vertical().height(0).into()),
         _marker: std::marker::PhantomData,
     }
 }
 
-/// A virtualized list that **reuses row widgets** when only the focused index
-/// changes (browser-like selection updates).
 pub struct VirtualList<'a, Message: 'static> {
     item_count: usize,
     item_height: f32,
@@ -203,9 +178,9 @@ pub struct VirtualList<'a, Message: 'static> {
     viewport_height: f32,
     overscan: usize,
     focused: Option<usize>,
-    /// Optional selection background (RGBA). Defaults to a soft accent-like fill.
     selection_fill: Option<Color>,
     width: Length,
+    on_scroll: Option<Box<dyn Fn(f32) -> Message + 'a>>,
     item: Box<dyn Fn(usize) -> Element<'static, Message> + 'a>,
     _marker: std::marker::PhantomData<&'a ()>,
 }
@@ -235,8 +210,6 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
         self
     }
 
-    /// Keyboard / app selection index. Drawn as a background behind that row;
-    /// keep this **out** of [`Self::item`] so rows stay cacheable.
     #[must_use]
     pub fn focused(mut self, focused: Option<usize>) -> Self {
         self.focused = focused;
@@ -255,13 +228,17 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
         self
     }
 
-    /// Row builder. Must produce `'static` elements (own your strings/handles).
-    /// **Do not** bake selection into the row — use [`Self::focused`].
+    /// Mouse-wheel scroll. Keyboard/app should set `scroll_offset_y` itself
+    /// (proportional formula) — no `snap_to` required.
     #[must_use]
-    pub fn item(
-        mut self,
-        f: impl Fn(usize) -> Element<'static, Message> + 'a,
-    ) -> Self {
+    pub fn on_scroll(mut self, f: impl Fn(f32) -> Message + 'a) -> Self {
+        self.on_scroll = Some(Box::new(f));
+        self
+    }
+
+    /// Row body without selection styling (`focused` paints the highlight).
+    #[must_use]
+    pub fn item(mut self, f: impl Fn(usize) -> Element<'static, Message> + 'a) -> Self {
         self.item = Box::new(f);
         self
     }
@@ -275,15 +252,22 @@ impl<'a, Message: 'static> VirtualList<'a, Message> {
             self.overscan,
         )
     }
+
+    fn clamp_scroll(&self, y: f32) -> f32 {
+        y.clamp(
+            0.0,
+            max_scroll(self.item_count, self.item_height, self.viewport_height),
+        )
+    }
 }
 
 struct State<Message: 'static> {
     item_count: usize,
     item_height: f32,
     range: (usize, usize),
-    /// Owned row elements for the current range (reused across selection-only frames).
     rows: Vec<Element<'static, Message>>,
-    layout_cache: Option<Node>,
+    /// Child layouts at local origin (0,0) size — repositioned per scroll cheaply.
+    child_sizes: Vec<Size>,
     layout_width: f32,
 }
 
@@ -294,7 +278,7 @@ impl<Message: 'static> Default for State<Message> {
             item_height: 0.0,
             range: (0, 0),
             rows: Vec::new(),
-            layout_cache: None,
+            child_sizes: Vec::new(),
             layout_width: 0.0,
         }
     }
@@ -312,7 +296,6 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
     }
 
     fn children(&self) -> Vec<Tree> {
-        // Initial mount: empty until layout/diff fills state.rows
         Vec::new()
     }
 
@@ -328,7 +311,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             state.item_count = self.item_count;
             state.item_height = self.item_height;
             state.range = range;
-            state.layout_cache = None;
+            state.child_sizes.clear();
 
             let (start, end) = range;
             let mut rows: Vec<Element<'static, Message>> = (start..end)
@@ -340,23 +323,18 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
                 })
                 .collect();
 
-            // Drop borrow of state before diff_children.
-            let _ = state;
-            tree.diff_children(rows.as_mut_slice());
-            tree.state.downcast_mut::<State<Message>>().rows = rows;
-        } else {
-            // Selection-only (or pure redraw): keep row widgets + trees.
-            let mut rows = std::mem::take(&mut state.rows);
             let _ = state;
             tree.diff_children(rows.as_mut_slice());
             tree.state.downcast_mut::<State<Message>>().rows = rows;
         }
+        // else: selection/scroll-only — keep rows (browser keeps DOM nodes)
     }
 
     fn size(&self) -> Size<Length> {
+        // Viewport-sized (like a scrollport), not full content height.
         Size {
             width: self.width,
-            height: Length::Fixed(content_height(self.item_count, self.item_height)),
+            height: Length::Fixed(self.viewport_height),
         }
     }
 
@@ -366,48 +344,46 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         renderer: &Renderer,
         limits: &Limits,
     ) -> Node {
-        // Ensure rows exist (first frame / structure change).
         self.diff(tree);
 
         let state = tree.state.downcast_mut::<State<Message>>();
         let max_width = limits.max().width;
-        let content_h = content_height(self.item_count, self.item_height);
         let width = match self.width {
             Length::Fixed(w) => w.min(max_width),
             Length::Fill | Length::FillPortion(_) => max_width,
             Length::Shrink => max_width,
         };
-
-        // Layout cache: when only selection changed, reuse geometry.
-        if let Some(cache) = &state.layout_cache {
-            if (state.layout_width - width).abs() < 0.5 {
-                return cache.clone();
-            }
-        }
-
-        let (start, end) = state.range;
-        let top = start as f32 * self.item_height;
+        let viewport_h = self.viewport_height;
+        let scroll = self.clamp_scroll(self.scroll_offset_y);
+        let (start, _end) = state.range;
 
         let child_limits = Limits::new(Size::ZERO, Size::new(width, self.item_height));
 
+        // Measure children only when missing sizes (structure change).
+        if state.child_sizes.len() != state.rows.len()
+            || (state.layout_width - width).abs() > 0.5
+        {
+            state.child_sizes.clear();
+            state.layout_width = width;
+            for (row, child_tree) in state.rows.iter_mut().zip(tree.children.iter_mut()) {
+                let node = row
+                    .as_widget_mut()
+                    .layout(child_tree, renderer, &child_limits);
+                state.child_sizes.push(node.size());
+            }
+        }
+
+        // Reposition only (O(visible)) — no text remeasure. Like scrollTop.
         let mut nodes = Vec::with_capacity(state.rows.len());
-        for (row, child_tree) in state.rows.iter_mut().zip(tree.children.iter_mut()) {
-            let mut node = row
-                .as_widget_mut()
-                .layout(child_tree, renderer, &child_limits);
-            let y = top + nodes.len() as f32 * self.item_height;
+        for (j, size) in state.child_sizes.iter().enumerate() {
+            let content_y = (start + j) as f32 * self.item_height;
+            let y = content_y - scroll;
+            let mut node = Node::new(*size);
             node = node.move_to(Point::new(0.0, y));
             nodes.push(node);
         }
 
-        // Full content height (spacers are implicit empty space for hit-testing).
-        let root = Node::with_children(Size::new(width, content_h), nodes);
-        // Note: top/bottom gaps have no children — scrollable still uses content size.
-
-        let _ = end; // range end used via state.rows len
-        state.layout_width = width;
-        state.layout_cache = Some(root.clone());
-        root
+        Node::with_children(Size::new(width, viewport_h), nodes)
     }
 
     fn operate(
@@ -418,7 +394,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         operation: &mut dyn Operation<()>,
     ) {
         operation.container(None, layout.bounds());
-        let virtual_offset = layout.virtual_offset();
+        let vo = layout.virtual_offset();
         let state = tree.state.downcast_mut::<State<Message>>();
         for ((child, child_tree), child_layout) in state
             .rows
@@ -428,7 +404,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         {
             child.as_widget_mut().operate(
                 child_tree,
-                child_layout.with_virtual_offset(virtual_offset),
+                child_layout.with_virtual_offset(vo),
                 renderer,
                 operation,
             );
@@ -446,6 +422,25 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
+        // Wheel scroll → app state (like scrollTop).
+        if let Event::Mouse(mouse::Event::WheelScrolled { delta }) = event {
+            if cursor.is_over(layout.bounds()) {
+                if let Some(on_scroll) = &self.on_scroll {
+                    let dy = match delta {
+                        mouse::ScrollDelta::Lines { y, .. } => -y * self.item_height,
+                        mouse::ScrollDelta::Pixels { y, .. } => -y,
+                    };
+                    let new_y = self.clamp_scroll(self.scroll_offset_y + dy);
+                    if (new_y - self.scroll_offset_y).abs() > 0.1 {
+                        shell.publish(on_scroll(new_y));
+                        shell.capture_event();
+                        return;
+                    }
+                }
+            }
+        }
+
+        let vo = layout.virtual_offset();
         let state = tree.state.downcast_mut::<State<Message>>();
         for ((child, child_tree), child_layout) in state
             .rows
@@ -456,7 +451,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             child.as_widget_mut().update(
                 child_tree,
                 event,
-                child_layout.with_virtual_offset(layout.virtual_offset()),
+                child_layout.with_virtual_offset(vo),
                 cursor,
                 renderer,
                 clipboard,
@@ -475,6 +470,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         renderer: &Renderer,
     ) -> mouse::Interaction {
         let state = tree.state.downcast_ref::<State<Message>>();
+        let vo = layout.virtual_offset();
         state
             .rows
             .iter()
@@ -483,7 +479,7 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
             .map(|((child, child_tree), child_layout)| {
                 child.as_widget().mouse_interaction(
                     child_tree,
-                    child_layout.with_virtual_offset(layout.virtual_offset()),
+                    child_layout.with_virtual_offset(vo),
                     cursor,
                     viewport,
                     renderer,
@@ -503,80 +499,125 @@ impl<'a, Message: 'static + Clone> Widget<Message, crate::Theme, Renderer>
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        let state = tree.state.downcast_ref::<State<Message>>();
-        let (start, _) = state.range;
         let bounds = layout.bounds();
+        let clip = viewport
+            .intersection(&bounds)
+            .unwrap_or(bounds);
 
-        // Selection background (does not require rebuilding row widgets).
-        if let Some(focused) = self.focused {
-            if focused >= start && focused < state.range.1 {
-                let y = bounds.y + focused as f32 * self.item_height;
-                let sel = Rectangle {
-                    x: bounds.x,
-                    y,
-                    width: bounds.width,
-                    height: self.item_height,
-                };
-                if let Some(clipped) = sel.intersection(viewport) {
-                    let fill = self.selection_fill.unwrap_or_else(|| {
-                        let a = theme.cosmic().accent_color();
-                        Color {
-                            r: a.red,
-                            g: a.green,
-                            b: a.blue,
-                            a: 0.18,
-                        }
-                    });
-                    renderer.fill_quad(
-                        renderer::Quad {
-                            bounds: clipped,
-                            border: Border {
-                                radius: theme.cosmic().corner_radii.radius_s.into(),
-                                width: 0.0,
-                                color: Color::TRANSPARENT,
+        renderer.with_layer(clip, |renderer| {
+            let state = tree.state.downcast_ref::<State<Message>>();
+            let (start, end) = state.range;
+            let scroll = self.clamp_scroll(self.scroll_offset_y);
+            let vo = layout.virtual_offset();
+
+            // Selection highlight (paint only — no row rebuild).
+            if let Some(focused) = self.focused {
+                if focused >= start && focused < end {
+                    let y = bounds.y + focused as f32 * self.item_height - scroll;
+                    let sel = Rectangle {
+                        x: bounds.x,
+                        y,
+                        width: bounds.width,
+                        height: self.item_height,
+                    };
+                    if let Some(clipped) = sel.intersection(&clip) {
+                        let fill = self.selection_fill.unwrap_or_else(|| {
+                            let a = theme.cosmic().accent_color();
+                            Color {
+                                r: a.red,
+                                g: a.green,
+                                b: a.blue,
+                                a: 0.18,
+                            }
+                        });
+                        renderer.fill_quad(
+                            renderer::Quad {
+                                bounds: clipped,
+                                border: Border {
+                                    radius: theme.cosmic().corner_radii.radius_s.into(),
+                                    width: 0.0,
+                                    color: Color::TRANSPARENT,
+                                },
+                                shadow: Default::default(),
+                                snap: true,
                             },
-                            shadow: Default::default(),
-                            snap: true,
-                        },
-                        Background::Color(fill),
-                    );
+                            Background::Color(fill),
+                        );
+                    }
                 }
             }
-        }
 
-        for ((child, child_tree), child_layout) in state
-            .rows
-            .iter()
-            .zip(&tree.children)
-            .zip(layout.children())
-        {
-            let child_bounds = child_layout.bounds();
-            if !child_bounds.intersects(viewport) {
-                continue;
+            for ((child, child_tree), child_layout) in state
+                .rows
+                .iter()
+                .zip(&tree.children)
+                .zip(layout.children())
+            {
+                let child_bounds = child_layout.bounds();
+                if !child_bounds.intersects(&clip) {
+                    continue;
+                }
+                child.as_widget().draw(
+                    child_tree,
+                    renderer,
+                    theme,
+                    style,
+                    child_layout.with_virtual_offset(vo),
+                    cursor,
+                    &clip,
+                );
             }
-            child.as_widget().draw(
-                child_tree,
-                renderer,
-                theme,
-                style,
-                child_layout.with_virtual_offset(layout.virtual_offset()),
-                cursor,
-                viewport,
-            );
-        }
+
+            // Minimal scrollbar thumb (optional visual; no iced scrollable).
+            let content_h = content_height(self.item_count, self.item_height);
+            if content_h > self.viewport_height + 1.0 {
+                let track = Rectangle {
+                    x: bounds.x + bounds.width - 6.0,
+                    y: bounds.y,
+                    width: 4.0,
+                    height: bounds.height,
+                };
+                let ratio = self.viewport_height / content_h;
+                let thumb_h = (track.height * ratio).max(20.0);
+                let max_y = (track.height - thumb_h).max(0.0);
+                let max_s = max_scroll(self.item_count, self.item_height, self.viewport_height);
+                let t = if max_s > 0.0 { scroll / max_s } else { 0.0 };
+                let thumb = Rectangle {
+                    x: track.x,
+                    y: track.y + max_y * t,
+                    width: track.width,
+                    height: thumb_h,
+                };
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds: thumb,
+                        border: Border {
+                            radius: [2.0; 4].into(),
+                            width: 0.0,
+                            color: Color::TRANSPARENT,
+                        },
+                        shadow: Default::default(),
+                        snap: true,
+                    },
+                    Background::Color(Color {
+                        r: 0.5,
+                        g: 0.5,
+                        b: 0.5,
+                        a: 0.45,
+                    }),
+                );
+            }
+        });
     }
 
     fn overlay<'b>(
         &'b mut self,
-        tree: &'b mut Tree,
-        layout: Layout<'b>,
-        renderer: &Renderer,
-        viewport: &Rectangle,
-        translation: Vector,
+        _tree: &'b mut Tree,
+        _layout: Layout<'b>,
+        _renderer: &Renderer,
+        _viewport: &Rectangle,
+        _translation: Vector,
     ) -> Option<overlay::Element<'b, Message, crate::Theme, Renderer>> {
-        let state = tree.state.downcast_mut::<State<Message>>();
-        // No nested overlays aggregation for simplicity.
-        let _ = (state, layout, renderer, viewport, translation);
         None
     }
 }
@@ -589,7 +630,7 @@ impl<'a, Message: 'static + Clone> From<VirtualList<'a, Message>> for Element<'a
 
 #[cfg(test)]
 mod tests {
-    use super::{content_height, visible_range};
+    use super::{content_height, max_scroll, visible_range};
 
     #[test]
     fn visible_range_full_when_content_fits() {
@@ -615,5 +656,11 @@ mod tests {
     #[test]
     fn content_height_scales() {
         assert_eq!(content_height(20, 49.0), 980.0);
+    }
+
+    #[test]
+    fn max_scroll_zero_when_fits() {
+        assert_eq!(max_scroll(5, 40.0, 500.0), 0.0);
+        assert!((max_scroll(20, 49.0, 504.0) - (980.0 - 504.0)).abs() < 0.1);
     }
 }


### PR DESCRIPTION
### Problem

Lists that rebuild and layout **every** child on each keyboard step are too expensive for long result UIs (see [cosmic-launcher#353](https://github.com/pop-os/cosmic-launcher/issues/353)). libcosmic has no shared virtualization helper, so apps either lag or invent one-off spacer tricks.

### Approach

Add `widget::virtual_list`:

- Fixed `item_height`, `viewport_height`, `scroll_offset_y` (app-owned scroll position)
- Only builds widgets for the visible index range (+ overscan)
- `content_revision` to rebuild when data changes without count changes
- Optional focused index + selection fill (paint) so focus can move without restyling every row
- Wheel → `on_scroll` message; keyboard scroll remains the app’s job (e.g. proportional or ensure-visible)

**Invariant:** when row `Element`s are reused across frames, iced `Tree` children are still reconciled (`diff_children`). Skipping that desynchronizes Button state and can panic (`Downcast on stateless state`).

### Non-goals

- Variable-height rows
- Full replacement of `scrollable`
- App-specific launcher or alt-tab behavior
- Cap list lengths as a performance strategy

### Tests

- Unit tests: `visible_range` empty / fits / scrolled

```bash
cargo test virtual_list
```

### How to review

1. Read module rustdoc cost model (rebuild vs remeasure vs paint)
2. Check Tree/state path on structure change vs focus-only
3. Confirm public API is minimal for a first landing

### Measurements (motivation; full consumer numbers in launcher PR)

| Scenario | Order of magnitude |
|----------|--------------------|
| Eager long list + snap_to each arrow (launcher) | ~150–220 ms |
| Virtual window + prop scroll (prototype) | event-loop side ~0.1–1.4 ms on 20 synthetic rows |

### Checklist

- [x] rustdoc on public API
- [x] unit tests for range helpers
- [x] no launcher-specific code
- [x] Tree re-diff invariant documented

### Related

- https://github.com/pop-os/cosmic-launcher/issues/353
- Follow-up: cosmic-launcher consumer PR after this lands
