### PR TITLE
fix: request redraw 

### DIFF
--- a/src/widget/button/widget.rs
+++ b/src/widget/button/widget.rs
@@ -868,8 +868,21 @@ pub fn update<'a, Message: Clone>(
                 }
             }
         }
+        Event::Mouse(mouse::Event::CursorMoved { .. })
+        | Event::Touch(touch::Event::FingerMoved { .. }) => {
+            let state = state();
+            let is_hovered = cursor.is_over(layout.bounds());
+            if state.is_hovered != is_hovered {
+                state.is_hovered = is_hovered;
+                shell.request_redraw();
+            }
+        }
         Event::Touch(touch::Event::FingerLost { .. }) | Event::Mouse(mouse::Event::CursorLeft) => {
             let state = state();
+
+            if state.is_hovered || state.is_pressed {
+                shell.request_redraw();
+            }
             state.is_hovered = false;
             state.is_pressed = false;
         }

--- a/src/widget/dropdown/menu/mod.rs
+++ b/src/widget/dropdown/menu/mod.rs
@@ -499,8 +499,10 @@ where
                     let new_hovered_option = (cursor_position.y / option_height) as usize;
                     let mut hovered_guard = self.hovered_option.lock().unwrap();
 
-                    if let Some(on_option_hovered) = self.on_option_hovered {
-                        if *hovered_guard != Some(new_hovered_option) {
+                    if *hovered_guard != Some(new_hovered_option) {
+                        shell.request_redraw();
+
+                        if let Some(on_option_hovered) = self.on_option_hovered {
                             shell.publish(on_option_hovered(new_hovered_option));
                         }
                     }

--- a/src/widget/dropdown/multi/menu.rs
+++ b/src/widget/dropdown/multi/menu.rs
@@ -382,6 +382,8 @@ where
                                 if previous_hover_option.as_ref() == Some(item) {
                                     previous_hover_option
                                 } else {
+                                    shell.request_redraw();
+
                                     if let Some(on_option_hovered) = self.on_option_hovered {
                                         shell.publish(on_option_hovered(item.clone()));
                                     }

--- a/src/widget/menu/menu_bar.rs
+++ b/src/widget/menu/menu_bar.rs
@@ -656,6 +656,7 @@ where
             Mouse(mouse::Event::CursorMoved { .. } | mouse::Event::CursorEntered)
                 if open && view_cursor.is_over(layout.bounds()) =>
             {
+                shell.request_redraw();
                 shell.capture_event();
                 #[cfg(wayland_platform)]
                 if matches!(WINDOWING_SYSTEM.get(), Some(WindowingSystem::Wayland)) {

--- a/src/widget/menu/menu_inner.rs
+++ b/src/widget/menu/menu_inner.rs
@@ -1502,7 +1502,9 @@ where
         // cursor is outside
         {
 
-            last_menu_state.index = None;
+            if last_menu_state.index.take().is_some() {
+                shell.request_redraw();
+            }
             shell.capture_event();
             return new_menu_root;
         }
@@ -1560,6 +1562,10 @@ where
         let item = &active_menu[new_index];
         // set new index
         let old_index = last_menu_state.index.replace(new_index);
+
+        if old_index != Some(new_index) {
+            shell.request_redraw();
+        }
 
         // get new active item
         // * add new menu if the new item is a menu

--- a/src/widget/responsive_container.rs
+++ b/src/widget/responsive_container.rs
@@ -180,13 +180,21 @@ where
         let state = tree.state.downcast_mut::<State>();
 
         if state.needs_update {
-            shell.publish((self.on_action)(
-                crate::surface::Action::ResponsiveMenuBar {
-                    menu_bar: self.id.clone(),
-                    limits: state.limits,
-                    size: state.size,
-                },
-            ));
+            // `needs_update` stays set while the content cannot fit, don't publish messages in a
+            // busy loop
+            let announcement = (state.limits, state.size);
+
+            if state.announced != Some(announcement) {
+                state.announced = Some(announcement);
+                shell.publish((self.on_action)(
+                    crate::surface::Action::ResponsiveMenuBar {
+                        menu_bar: self.id.clone(),
+                        limits: announcement.0,
+                        size: announcement.1,
+                    },
+                ));
+            }
+
             state.needs_update = false;
         }
 
@@ -328,6 +336,8 @@ struct State {
     limits: Limits,
     size: Size,
     needs_update: bool,
+    /// The `(limits, size)` last announced, so an unsatisfiable layout does not announce forever
+    announced: Option<(Limits, Size)>,
 }
 
 impl State {
@@ -336,6 +346,7 @@ impl State {
             limits: Limits::NONE,
             size: Size::new(0., 0.),
             needs_update: false,
+            announced: None,
         }
     }
 }

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -1680,6 +1680,7 @@ pub fn update<'a, Message: Clone + 'static>(
 
                 state.last_click = Some(click);
 
+                shell.request_redraw();
                 shell.capture_event();
                 return;
             } else {
@@ -1746,6 +1747,7 @@ pub fn update<'a, Message: Clone + 'static>(
                     .cursor
                     .select_range(state.cursor.start(value), position);
 
+                shell.request_redraw();
                 shell.capture_event();
                 return;
             }
@@ -2099,6 +2101,7 @@ pub fn update<'a, Message: Clone + 'static>(
                     _ => {}
                 }
 
+                shell.request_redraw();
                 shell.capture_event();
                 return;
             }


### PR DESCRIPTION
Previously iced was requesting redraw on mouse move, so some widgets looked correct without asking for a redraw explicitly. But with https://github.com/pop-os/iced/pull/377, the widgets need to ask for it explicitly. This is more correct and more efficient.

For example Button wasn't telling anybody that it needs a redraw when it would change its hover state, but since we were redrawing as the cursor moves, we would see the hover state change. Now, it asks explicitly. So, instead of getting a redraw per monitor refresh rate as the cursor moves, you only get 2, one when the cursor enters the button and the hover state changes, and one when it leaves the button.


____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

