### PR TITLE
fix: don't pass keyboard events to content if popover modal is open

### DIFF
--- a/src/widget/popover.rs
+++ b/src/widget/popover.rs
@@ -157,9 +157,17 @@ where
     ) {
         if self.popup.is_some() {
             if self.modal {
-                if matches!(event, Event::Mouse(_) | Event::Touch(_)) {
-                    shell.capture_event();
-                    return;
+                match event {
+                    Event::Mouse(_) | Event::Touch(_) => {
+                        shell.capture_event();
+                        return;
+                    }
+                    // app-level keyboard navigation (Tab focus cycling, Escape)
+                    // still receives keyboard events
+                    Event::Keyboard(_) => {
+                        return;
+                    }
+                    _ => {}
                 }
             } else if let Some(on_close) = self.on_close.as_ref() {
                 if matches!(

--- a/src/widget/popover.rs
+++ b/src/widget/popover.rs
@@ -156,9 +156,17 @@ where
     ) {
         if self.popup.is_some() {
             if self.modal {
-                if matches!(event, Event::Mouse(_) | Event::Touch(_)) {
-                    shell.capture_event();
-                    return;
+                match event {
+                    Event::Mouse(_) | Event::Touch(_) => {
+                        shell.capture_event();
+                        return;
+                    }
+                    // app-level keyboard navigation (Tab focus cycling, Escape)
+                    // still receives keyboard events
+                    Event::Keyboard(_) => {
+                        return;
+                    }
+                    _ => {}
                 }
             } else if let Some(on_close) = self.on_close.as_ref() {
                 if matches!(


### PR DESCRIPTION
This fixes tab key in "Save changes before closing?" dialog in cosmic-edit.
If you open cosmic-edit type something press super+q to close it, the popover opens asking if you wanna save it, but if you press tab, it types it in the editor!

This fixes that issue, if popover is a modal, it doesn't allow the keyboard events to get to the content, however it does allow navigation keys to get to the app.

I have tested it with cosmic-edit, and only cosmic-greeter and cosmic-settings use it as modal, just need to test them to make sure it doesn't introduce any side effects.

- [ ] in cosmic-edit ctrl+a is going to the app when the dialog is open.
  - Could not fix this.
- [ ] escape doesn't work.
  - Could not fix this either.
- [ ] probably we want pressing "space" on a button to activate it, no?
  - no!
 
EDIT:
This could help with the pop up in cosmic-edit, but I think the proper solution is an actual dialog. I'll keep an eye on the dialog support in cosmic-comp and proper dialog support in libcosmic.

But until then this could partially help. `tab` and `enter` work properly, so when closing cosmic-edit, you can tab to the proper button and press it. But keyboard shortcut (such as `ctrl+a`) is still sent to the app, and `esc` needs to be handled inside the app.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

