### PR TITLE
fix: request redraw if hovered state changes in segmented_button

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -1244,6 +1244,8 @@ where
         let my_bounds = layout.bounds();
         let state = tree.state.downcast_mut::<LocalState>();
 
+        let hovered_before = state.hovered;
+
         let my_id = self.get_drag_id();
 
         if let Event::Dnd(e) = &mut event {
@@ -1915,6 +1917,10 @@ where
 
                 shell.capture_event();
             }
+        }
+
+        if hovered_before != state.hovered {
+            shell.request_redraw();
         }
     }
 
@@ -2764,7 +2770,7 @@ pub struct LocalState {
     drop_hint: Option<DropHint>,
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 enum Item {
     NextButton,
     #[default]


### PR DESCRIPTION
Segmented button was relying on mouse movement to redraw changes in hovered state instead of asking for redraw explicitly.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

