### PR TITLE
Addition of choice of window controls to the left or to the right

### DIFF
--- a/cosmic-theme/src/model/theme.rs
+++ b/cosmic-theme/src/model/theme.rs
@@ -99,6 +99,8 @@ pub struct Theme {
     pub is_dark: bool,
     /// is high contrast
     pub is_high_contrast: bool,
+    /// are standard window controls on the left
+    pub window_controls_left: bool,
     /// cosmic-comp window gaps size (outer, inner)
     pub gaps: (u32, u32),
     /// cosmic-comp active hint window outline width
@@ -891,6 +893,8 @@ pub struct ThemeBuilder {
     #[serde(default)]
     /// enabled blurred transparency
     pub frosted: BlurStrength,
+    /// standard window controls are set left
+    pub window_controls_left: bool,
     /// cosmic-comp window gaps size (outer, inner)
     pub gaps: (u32, u32),
     /// cosmic-comp active hint window outline width
@@ -935,6 +939,7 @@ impl Default for ThemeBuilder {
             warning: Default::default(),
             destructive: Default::default(),
             frosted: BlurStrength::default(),
+            window_controls_left: Default::default(),
             // cosmic-comp theme settings
             gaps: (0, 8),
             active_hint: 3,
@@ -1087,6 +1092,7 @@ impl ThemeBuilder {
             active_hint,
             window_hint,
             frosted,
+            window_controls_left,
             frosted_windows,
             frosted_system_interface,
             frosted_panel,
@@ -1553,6 +1559,7 @@ impl ThemeBuilder {
             corner_radii,
             is_dark,
             is_high_contrast,
+            window_controls_left,
             gaps,
             active_hint,
             window_hint,

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -85,6 +85,13 @@ pub fn is_high_contrast() -> bool {
     active_type().is_high_contrast()
 }
 
+/// Whether the active theme has a preference for window buttons on the left.
+#[inline]
+#[must_use]
+pub fn has_window_controls_on_left() -> bool {
+    active().cosmic().window_controls_left
+}
+
 pub fn system_dark() -> Theme {
     let Ok(helper) = crate::cosmic_theme::Theme::dark_config() else {
         return Theme::dark();

--- a/src/widget/header_bar.rs
+++ b/src/widget/header_bar.rs
@@ -370,12 +370,22 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
         let is_ssd = self.is_ssd;
 
         // Take ownership of the regions to be packed.
-        let start = std::mem::take(&mut self.start);
+        let mut start = std::mem::take(&mut self.start);
         let center = std::mem::take(&mut self.center);
         let mut end = std::mem::take(&mut self.end);
 
-        // Also packs the window controls at the very end.
-        end.push(self.window_controls(space_xxs));
+        // Pack the window controls
+        let controls_left = theme::has_window_controls_on_left();
+        let window_controls = self.window_controls(space_xxs, controls_left);
+
+        if controls_left
+        {
+            start.insert(0, window_controls);
+        }
+        else
+        {
+            end.push(window_controls);
+        }
 
         let padding = if is_ssd {
             [2, 8, 2, 8]
@@ -445,7 +455,7 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
     }
 
     /// Creates the widget for window controls.
-    fn window_controls(&mut self, spacing: u16) -> Element<'a, Message> {
+    fn window_controls(&mut self, spacing: u16, buttons_left: bool) -> Element<'a, Message> {
         macro_rules! icon {
             ($name:expr, $size:expr, $on_press:expr) => {{
                 widget::icon::from_name($name)
@@ -458,24 +468,22 @@ impl<'a, Message: Clone + 'static> HeaderBar<'a, Message> {
             }};
         }
 
+        let close = self.on_close.take().map(|m| icon!("window-close-symbolic", 16, m));
+        let min = self.on_minimize.take().map(|m| icon!("window-minimize-symbolic", 16, m));
+        let max = self.on_maximize.take().map(|m| {
+            if self.maximized {
+                icon!("window-restore-symbolic", 16, m)
+            } else {
+                icon!("window-maximize-symbolic", 16, m)
+            }
+        });
+
+        let mut row = if buttons_left {[close, min, max]} else {[min, max, close]}.into_iter();
+
         widget::row::with_capacity(3)
-            .push_maybe(
-                self.on_minimize
-                    .take()
-                    .map(|m| icon!("window-minimize-symbolic", 16, m)),
-            )
-            .push_maybe(self.on_maximize.take().map(|m| {
-                if self.maximized {
-                    icon!("window-restore-symbolic", 16, m)
-                } else {
-                    icon!("window-maximize-symbolic", 16, m)
-                }
-            }))
-            .push_maybe(
-                self.on_close
-                    .take()
-                    .map(|m| icon!("window-close-symbolic", 16, m)),
-            )
+            .push_maybe(row.next())
+            .push_maybe(row.next())
+            .push_maybe(row.next())
             .spacing(spacing)
             .align_y(iced::Alignment::Center)
             .into()


### PR DESCRIPTION
This PR adds the apparatus for declaring in a COSMIC theme whether standard window controls should appear on the left or the right of the header bar:
- A boolean field in the `cosmic_theme::Theme` and `cosmic::ThemeBuilder` structs
- Initialisation code in the implementations of same
- A getter for the active theme in `theme`
- Determination of whether to add the controls left or right in the HeaderBar widget's `view()` function

If the controls are configured left, the order is `[close][min][max]` and if right then `[min][max][close]`.

## Checklist
- There is no AI-generated code
- I believe I understand what I have done
- My commit messages are accurate
- I have tested my contribution using the template application and I have run `just check` on my branch
- I have read and certify my contribution under the [Developer Certificate of Origin](https://developercertificate.org/)