### PR TITLE
fix: fixed panic on right click submenu

### DIFF
--- a/examples/context-menu/Cargo.toml
+++ b/examples/context-menu/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 tracing-log = "0.2.0"
-log = "0.4"
 
 [dependencies.libcosmic]
 path = "../../"

--- a/examples/context-menu/Cargo.toml
+++ b/examples/context-menu/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 tracing-log = "0.2.0"
+log = "0.4"
 
 [dependencies.libcosmic]
 path = "../../"

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -83,7 +83,7 @@ impl cosmic::Application for App {
 
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
-        log::error!("Clicked {message:?}");
+        tracing::error!("Clicked {message:?}");
         match message {
             Message::Clicked => {
                 self.button_label = format!("Clicked {message:?}");

--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -30,6 +30,7 @@ pub enum Message {
     WindowClose,
     Surface(cosmic::surface::Action),
     ToggleHideContent,
+    ToggleSomeAction,
     WindowNew,
 }
 
@@ -82,6 +83,7 @@ impl cosmic::Application for App {
 
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
+        log::error!("Clicked {message:?}");
         match message {
             Message::Clicked => {
                 self.button_label = format!("Clicked {message:?}");
@@ -91,9 +93,10 @@ impl cosmic::Application for App {
                     cosmic::app::Action::Surface(action),
                 ));
             }
-            Message::WindowClose => {}
-            Message::ToggleHideContent => {}
-            Message::WindowNew => {}
+            Message::WindowClose | 
+            Message::ToggleHideContent | 
+            Message::ToggleSomeAction | 
+            Message::WindowNew=> {}
         }
 
         Task::none()
@@ -102,7 +105,7 @@ impl cosmic::Application for App {
     /// Creates a view after each update.
     fn view(&self) -> Element<'_, Self::Message> {
         let widget = cosmic::widget::context_menu(
-            cosmic::widget::button::text(self.button_label.to_string()).on_press(Message::Clicked),
+            cosmic::widget::button::text(self.button_label.clone()).on_press(Message::Clicked),
             self.context_menu(),
         )
         .on_surface_action(Message::Surface);
@@ -131,7 +134,14 @@ impl App {
                         None,
                         self.hide_content,
                         ContextMenuAction::ToggleHideContent,
-                    )],
+                    ),
+                    menu::Item::CheckBox(
+                        "Test content",
+                        None,
+                        self.hide_content,
+                        ContextMenuAction::ToggleSomeAction,
+                    )
+                    ],
                 ),
                 menu::Item::Divider,
                 menu::Item::Button("Quit", None, ContextMenuAction::WindowClose),
@@ -144,6 +154,7 @@ impl App {
 pub enum ContextMenuAction {
     WindowClose,
     ToggleHideContent,
+    ToggleSomeAction,
     WindowNew,
 }
 
@@ -153,6 +164,7 @@ impl menu::Action for ContextMenuAction {
         match self {
             ContextMenuAction::WindowClose => Message::WindowClose,
             ContextMenuAction::ToggleHideContent => Message::ToggleHideContent,
+            ContextMenuAction::ToggleSomeAction => Message::ToggleSomeAction,
             ContextMenuAction::WindowNew => Message::WindowNew,
         }
     }

--- a/src/widget/menu/menu_inner.rs
+++ b/src/widget/menu/menu_inner.rs
@@ -650,7 +650,7 @@ impl<'b, Message: Clone + 'static> Menu<'b, Message> {
                     state.pressed = false;
 
                     // process close condition
-                    if state
+                    if state.open && state
                         .view_cursor
                         .position()
                         .unwrap_or_default()
@@ -1428,47 +1428,48 @@ where
         state.view_cursor = view_cursor;
 
         // * remove invalid menus
+        if state.open {
+            let mut prev_bounds = std::iter::once(menu.bar_bounds)
+                .chain(
+                    if menu.is_overlay {
+                        state.menu_states[..state.menu_states.len().saturating_sub(1)].iter()
+                    } else {
+                        state.menu_states[..menu.depth].iter()
+                    }
+                    .map(|s| s.menu_bounds.children_bounds),
+                )
+                .collect::<Vec<_>>();
 
-        let mut prev_bounds = std::iter::once(menu.bar_bounds)
-            .chain(
-                if menu.is_overlay {
-                    state.menu_states[..state.menu_states.len().saturating_sub(1)].iter()
-                } else {
-                    state.menu_states[..menu.depth].iter()
+            if menu.is_overlay && menu.close_condition.leave {
+                for i in (0..state.menu_states.len()).rev() {
+                    let mb = &state.menu_states[i].menu_bounds;
+
+                    if mb.parent_bounds.contains(overlay_cursor)
+                        || menu.is_overlay && mb.children_bounds.contains(overlay_cursor)
+                        || mb.offset_bounds.contains(overlay_cursor)
+                        || (mb.check_bounds.contains(overlay_cursor)
+                            && prev_bounds.iter().all(|pvb| !pvb.contains(overlay_cursor)))
+                    {
+                        break;
+                    }
+                    prev_bounds.pop();
+                    state.active_root.pop();
+                    state.menu_states.pop();
                 }
-                .map(|s| s.menu_bounds.children_bounds),
-            )
-            .collect::<Vec<_>>();
+            } else if menu.is_overlay {
+                for i in (0..state.menu_states.len()).rev() {
+                    let mb = &state.menu_states[i].menu_bounds;
 
-        if menu.is_overlay && menu.close_condition.leave {
-            for i in (0..state.menu_states.len()).rev() {
-                let mb = &state.menu_states[i].menu_bounds;
-
-                if mb.parent_bounds.contains(overlay_cursor)
-                    || menu.is_overlay && mb.children_bounds.contains(overlay_cursor)
-                    || mb.offset_bounds.contains(overlay_cursor)
-                    || (mb.check_bounds.contains(overlay_cursor)
-                        && prev_bounds.iter().all(|pvb| !pvb.contains(overlay_cursor)))
-                {
-                    break;
+                    if mb.parent_bounds.contains(overlay_cursor)
+                        || mb.children_bounds.contains(overlay_cursor)
+                        || prev_bounds.iter().all(|pvb| !pvb.contains(overlay_cursor))
+                    {
+                        break;
+                    }
+                    prev_bounds.pop();
+                    state.active_root.pop();
+                    state.menu_states.pop();
                 }
-                prev_bounds.pop();
-                state.active_root.pop();
-                state.menu_states.pop();
-            }
-        } else if menu.is_overlay {
-            for i in (0..state.menu_states.len()).rev() {
-                let mb = &state.menu_states[i].menu_bounds;
-
-                if mb.parent_bounds.contains(overlay_cursor)
-                    || mb.children_bounds.contains(overlay_cursor)
-                    || prev_bounds.iter().all(|pvb| !pvb.contains(overlay_cursor))
-                {
-                    break;
-                }
-                prev_bounds.pop();
-                state.active_root.pop();
-                state.menu_states.pop();
             }
         }
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
----
1. The essence of the problem: when right‑clicking, the menu is reset and marked as not open. 
```
                    // close all menus when clicking inside the menu bar
                    if self.bar_bounds.contains(overlay_cursor) {
                        state.reset();
                    }
```
Accordingly, with any subsequent mouse or keyboard event, which is inevitable, an attempt is made via the depth property to access an element of the menu_states array that no longer exists. I suggest if the menu is "!open", do not handle “dangerous events” related to the mouse and keyboard.

2. Removed some linter warnings in example application "context-menu"
3. Added  in example application "context-menu" new menu item and log on menu click event.

PS related issue may be https://github.com/pop-os/libcosmic/issues/1360
