### PR TITLE
Request redraw for drop down widget

### DIFF
--- a/src/widget/dropdown/menu/mod.rs
+++ b/src/widget/dropdown/menu/mod.rs
@@ -508,6 +508,21 @@ where
                     }
 
                     *hovered_guard = Some(new_hovered_option);
+                } else {
+                    let mut hovered_guard = self.hovered_option.lock().unwrap();
+
+                    if hovered_guard.is_some() {
+                        *hovered_guard = None;
+                        shell.request_redraw();
+                    }
+                }
+            }
+            Event::Mouse(mouse::Event::CursorLeft) => {
+                let mut hovered_guard = self.hovered_option.lock().unwrap();
+
+                if hovered_guard.is_some() {
+                    *hovered_guard = None;
+                    shell.request_redraw();
                 }
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {

--- a/src/widget/dropdown/multi/menu.rs
+++ b/src/widget/dropdown/multi/menu.rs
@@ -395,6 +395,15 @@ where
                     if *self.hovered_option != previous_hover_option {
                         shell.request_redraw();
                     }
+                } else if self.hovered_option.is_some() {
+                    *self.hovered_option = None;
+                    shell.request_redraw();
+                }
+            }
+            Event::Mouse(mouse::Event::CursorLeft) => {
+                if self.hovered_option.is_some() {
+                    *self.hovered_option = None;
+                    shell.request_redraw();
                 }
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {

--- a/src/widget/dropdown/widget.rs
+++ b/src/widget/dropdown/widget.rs
@@ -567,6 +567,7 @@ pub fn update<
                 state: &mut State,
                 on_selected: Arc<dyn Fn(usize) -> Message + Send + Sync + 'static>| {
         state.is_open.store(true, Ordering::Relaxed);
+        shell.request_redraw();
         let mut hovered_guard = state.hovered_option.lock().unwrap();
         *hovered_guard = selected;
         let id = window::Id::unique();

--- a/src/widget/dropdown/widget.rs
+++ b/src/widget/dropdown/widget.rs
@@ -661,6 +661,7 @@ pub fn update<
         state.close_operation = false;
         state.is_open.store(false, Ordering::SeqCst);
         if is_open {
+            shell.request_redraw();
             #[cfg(wayland_platform)]
             if let Some(ref on_close) = on_surface_action {
                 shell.publish(on_close(surface::action::destroy_popup(state.popup_id)));
@@ -684,6 +685,7 @@ pub fn update<
                 // Event wasn't processed by overlay, so cursor was clicked either outside it's
                 // bounds or on the drop-down, either way we close the overlay.
                 state.is_open.store(false, Ordering::Relaxed);
+                shell.request_redraw();
                 #[cfg(wayland_platform)]
                 if let Some(on_close) = on_surface_action {
                     shell.publish(on_close(surface::action::destroy_popup(state.popup_id)));


### PR DESCRIPTION
This supersedes https://github.com/pop-os/libcosmic/pull/1396.

Adds another missing request_redraw, and also handles hover state on the menu items.

I didn't notice this because the dropdown widgets in the settings pane in `cosmic-edit` or `term` work fine without this fix. But if your UI doesn't have other message subscriptions then this issue becomes visible.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

