### PR TITLE
On platforms without state_dir, fall back to ~/.local/state

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -48,7 +48,12 @@ fn get_state_dir() -> Option<PathBuf> {
             return Some(PathBuf::from(home).join(".local").join("state"));
         }
     }
-    dirs::state_dir()
+    if let Some(state_dir) = dirs::state_dir() {
+        return Some(state_dir);
+    }
+    // On platforms without state_dir, fall back to ~/.local/state
+    let home_dir = dirs::home_dir()?;
+    Some(home_dir.join(".local").join(".state"))
 }
 
 /// Get the data directory, with Flatpak sandbox support.


### PR DESCRIPTION
This works around issues with state config on macOS and Windows, where there is no defined application state directory

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

