### PR TITLE
Revert "feat(cosmic-config): add `new_data` method."

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -56,22 +56,6 @@ fn get_state_dir() -> Option<PathBuf> {
     Some(home_dir.join(".local").join(".state"))
 }
 
-/// Get the data directory, with Flatpak sandbox support.
-fn get_data_dir() -> Option<PathBuf> {
-    // Check if we're running in Flatpak
-    if env::var_os("FLATPAK_ID").is_some() {
-        // Try HOST_XDG_DATA_HOME first
-        if let Some(host_data) = env::var_os("HOST_XDG_DATA_HOME") {
-            return Some(PathBuf::from(host_data));
-        }
-        // Fallback: try to construct from HOME
-        if let Some(home) = env::var_os("HOME") {
-            return Some(PathBuf::from(home).join(".local").join("share"));
-        }
-    }
-    dirs::data_dir()
-}
-
 #[cfg(feature = "subscription")]
 mod subscription;
 #[cfg(feature = "subscription")]
@@ -324,40 +308,6 @@ impl Config {
             user_path: Some(user_path),
             previous: if version > 1 && look_for_previous {
                 Self::new_state_inner(name, version - 1, false)
-                    .ok()
-                    .map(Box::new)
-            } else {
-                None
-            },
-        })
-    }
-
-    /// Get data for the given application name and config version.
-    ///     pub fn new_state(name: &str, version: u64) -> Result<Self, Error> {
-    pub fn new_data(name: &str, version: u64) -> Result<Self, Error> {
-        Self::new_data_inner(name, version, true)
-    }
-
-    pub fn new_data_inner(
-        name: &str,
-        version: u64,
-        look_for_previous: bool,
-    ) -> Result<Self, Error> {
-        // Look for [name]/v[version]
-        let path = sanitize_name(name)?.join(format!("v{}", version));
-
-        // Get libcosmic user data directory
-        let mut user_path = get_data_dir().ok_or(Error::NoConfigDirectory)?;
-        user_path.push("cosmic");
-        user_path.push(path);
-        // Create new data directory if not found.
-        fs::create_dir_all(&user_path)?;
-
-        Ok(Self {
-            system_path: None,
-            user_path: Some(user_path),
-            previous: if version > 1 && look_for_previous {
-                Self::new_data_inner(name, version - 1, false)
                     .ok()
                     .map(Box::new)
             } else {

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -88,7 +88,4 @@ pub fn main() {
 
     println!("Testing state");
     test_config(Config::new_state("com.system76.Example", 1).unwrap());
-
-    println!("Testing data");
-    test_config(Config::new_data("com.system76.Example", 1).unwrap());
 }


### PR DESCRIPTION
It was found that dirs::data_dir conflicts with dirs::config_dir on macOS and Windows.

This reverts commit 631c81b170b792fa57898161b73a5a673ad79b48 from https://github.com/pop-os/libcosmic/pull/1172

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

