### PR TITLE
fix(segmented_button): request redraw on tab focus shift

### DIFF
--- a/src/widget/segmented_button/widget.rs
+++ b/src/widget/segmented_button/widget.rs
@@ -1867,6 +1867,7 @@ where
                 ..
             }) = event
             {
+                shell.request_redraw();
                 state.focused_visible = true;
                 return if *modifiers == keyboard::Modifiers::SHIFT {
                     self.focus_previous(state, shell);


### PR DESCRIPTION
At the moment, the keyboard focus selection in the nav bar and other segmented button elements isn't updated until the mouse is moved. This will fix that. I can do a quick update of cosmic-settings 1.7.0 on merge (or at least a followup PR)

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

