### PR TITLE
Fix menu example not working 

### DIFF
--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -9,7 +9,7 @@ use std::{env, process};
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::alignment::{Horizontal, Vertical};
 use cosmic::iced::keyboard::Key;
-use cosmic::iced::{window, Length, Size};
+use cosmic::iced::{event, keyboard, window, Event, Length, Size, Subscription};
 use cosmic::widget::menu::action::MenuAction;
 use cosmic::widget::menu::key_bind::{KeyBind, Modifier};
 use cosmic::widget::menu::{self, ItemHeight, ItemWidth};
@@ -110,6 +110,26 @@ impl cosmic::Application for App {
 
     fn header_start(&self) -> Vec<Element<'_, Self::Message>> {
         vec![menu_bar(&self.config, &self.key_binds)]
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        event::listen_with(|event, _status, _window_id| {
+            let Event::Keyboard(keyboard::Event::KeyPressed {
+                key,
+                modifiers,
+                physical_key,
+                ..
+            }) = event
+            else {
+                return None;
+            };
+
+            let key_binds = key_binds();
+            key_binds
+                .iter()
+                .find(|(key_bind, _)| key_bind.matches(modifiers, &key, Some(&physical_key)))
+                .map(|(_, action)| action.message())
+        })
     }
 
     /// Handle application events here.

--- a/src/widget/menu/menu_bar.rs
+++ b/src/widget/menu/menu_bar.rs
@@ -648,6 +648,7 @@ where
                     return;
                 }
                 shell.capture_event();
+                shell.request_redraw();
                 #[cfg(wayland_platform)]
                 if matches!(WINDOWING_SYSTEM.get(), Some(WindowingSystem::Wayland)) {
                     self.create_popup(layout, view_cursor, renderer, shell, viewport, my_state);


### PR DESCRIPTION
When trying to develop an application with a menu bar (following the example in `examples/menu`) with default features disabled and "about", "wgpu", "winit" enabled , I've found that :

- the menu items were not clickable: they disappeared as soon as I tried to click on them.
- the key binds were not working in the example (which is confusing for an example).

The tests were done under Fedora 44 GNOME and Wine (cross-compilation as x86_64-pc-windows-gnu).

It turns out that:

-  the menu items being not clickable was due to redrawing not being requested.
-  having the key binds not working was due to missing events subscription (as done in `cosmic-term`). 

So this patch set addresses these two issues:

- one commit updates `src/widget/menu/menu_bar.rs` to force a redraw (may be there is more clever way to do it).
- another commit updates  `examples/menu/src/main.rs` to implement `App::subscription()` so the key binds are handled.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

