### PR TITLE
fix: rendering  font color for text_input widget in "selected" mode

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -2976,95 +2976,70 @@ pub fn draw<'a, Message>(
             text_color
         };
 
-        match state.cursor.state(value) {
-            cursor::State::Index(..) => {
-                renderer.fill_text(
-                    Text {
-                        content: if text.is_empty() {
-                            placeholder.to_string()
-                        } else {
-                            text.clone()
-                        },
-                        font,
-                        bounds: bounds.size(),
-                        size: iced::Pixels(size),
-                        align_x: text::Alignment::Default,
-                        align_y: alignment::Vertical::Center,
-                        line_height: text::LineHeight::default(),
-                        shaping: text::Shaping::Advanced,
-                        wrapping: text::Wrapping::None,
-                        ellipsize: text::Ellipsize::None,
-                    },
-                    bounds.position(),
-                    tcolor,
-                    text_bounds,
+        if let cursor::State::Selection { start, end } = state.cursor.state(value)
+            && state.is_focused()
+        {
+            let left = start.min(end);
+            let right = end.max(start);
+            let grapheme_len = text.graphemes(true).count();
+
+            if left > 0 {
+                render_graphemes(
+                    value, state, 0, left, &text, tcolor, bounds, size, renderer, font,
                 );
             }
-            cursor::State::Selection { start, end } => {
-                if state.is_focused() {
-                    let left = start.min(end);
-                    let right = end.max(start);
-                    let grapheme_len = text.graphemes(true).count();
 
-                    if left > 0 {
-                        render_graphemes(
-                            value, state, 0, left, &text, tcolor, bounds, size, renderer, font,
-                        );
-                    }
-
-                    if grapheme_len >= right {
-                        render_graphemes(
-                            value,
-                            state,
-                            left,
-                            right,
-                            &text,
-                            appearance.selected_text_color,
-                            bounds,
-                            size,
-                            renderer,
-                            font,
-                        );
-                    }
-
-                    if left < grapheme_len {
-                        render_graphemes(
-                            value,
-                            state,
-                            right,
-                            grapheme_len,
-                            &text,
-                            tcolor,
-                            bounds,
-                            size,
-                            renderer,
-                            font,
-                        );
-                    }
-                } else {
-                    renderer.fill_text(
-                        Text {
-                            content: if text.is_empty() {
-                                placeholder.to_string()
-                            } else {
-                                text.clone()
-                            },
-                            font,
-                            bounds: bounds.size(),
-                            size: iced::Pixels(size),
-                            align_x: text::Alignment::Default,
-                            align_y: alignment::Vertical::Center,
-                            line_height: text::LineHeight::default(),
-                            shaping: text::Shaping::Advanced,
-                            wrapping: text::Wrapping::None,
-                            ellipsize: text::Ellipsize::None,
-                        },
-                        bounds.position(),
-                        tcolor,
-                        text_bounds,
-                    );
-                }
+            if grapheme_len >= right {
+                render_graphemes(
+                    value,
+                    state,
+                    left,
+                    right,
+                    &text,
+                    appearance.selected_text_color,
+                    bounds,
+                    size,
+                    renderer,
+                    font,
+                );
             }
+
+            if left < grapheme_len {
+                render_graphemes(
+                    value,
+                    state,
+                    right,
+                    grapheme_len,
+                    &text,
+                    tcolor,
+                    bounds,
+                    size,
+                    renderer,
+                    font,
+                );
+            }
+        } else {
+            renderer.fill_text(
+                Text {
+                    content: if text.is_empty() {
+                        placeholder.to_string()
+                    } else {
+                        text.clone()
+                    },
+                    font,
+                    bounds: bounds.size(),
+                    size: iced::Pixels(size),
+                    align_x: text::Alignment::Default,
+                    align_y: alignment::Vertical::Center,
+                    line_height: text::LineHeight::default(),
+                    shaping: text::Shaping::Advanced,
+                    wrapping: text::Wrapping::None,
+                    ellipsize: text::Ellipsize::None,
+                },
+                bounds.position(),
+                tcolor,
+                text_bounds,
+            );
         }
     };
 

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -2566,8 +2566,8 @@ fn input_method<'b>(
 fn render_graphemes(
     value: &Value,
     state: &State,
-    left: usize, 
-    right: usize, 
+    left: usize,
+    right: usize,
     text: &str,
     text_color: Color,
     bounds: Rectangle,
@@ -2602,7 +2602,7 @@ fn render_graphemes(
                 Text {
                     content: grapheme_range.clone(),
                     font,
-                    bounds: bounds.size(), 
+                    bounds: bounds.size(),
                     size: iced::Pixels(size),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,
@@ -2954,7 +2954,6 @@ pub fn draw<'a, Message>(
             state.value.raw().min_width(),
             effective_alignment(state.value.raw()),
         );
- 
         if cursors.is_empty() {
             renderer.with_translation(Vector::ZERO, |_| {});
         } else {
@@ -2999,7 +2998,6 @@ pub fn draw<'a, Message>(
                     bounds.position(),
                     tcolor,
                     text_bounds,
-                    
                 );
             }
             cursor::State::Selection { start, end } => {
@@ -3009,15 +3007,39 @@ pub fn draw<'a, Message>(
                     let grapheme_len = text.graphemes(true).count();
 
                     if left > 0 {
-                        render_graphemes(value, state,0,left, &text, tcolor, bounds, size, renderer, font);
+                        render_graphemes(
+                            value, state, 0, left, &text, tcolor, bounds, size, renderer, font,
+                        );
                     }
 
                     if grapheme_len >= right {
-                        render_graphemes(value, state,left,right, &text, appearance.selected_text_color, bounds, size, renderer, font);
+                        render_graphemes(
+                            value,
+                            state,
+                            left,
+                            right,
+                            &text,
+                            appearance.selected_text_color,
+                            bounds,
+                            size,
+                            renderer,
+                            font,
+                        );
                     }
 
                     if left < grapheme_len {
-                        render_graphemes(value, state,right,grapheme_len, &text, tcolor, bounds, size, renderer, font);
+                        render_graphemes(
+                            value,
+                            state,
+                            right,
+                            grapheme_len,
+                            &text,
+                            tcolor,
+                            bounds,
+                            size,
+                            renderer,
+                            font,
+                        );
                     }
                 } else {
                     renderer.fill_text(
@@ -3040,7 +3062,6 @@ pub fn draw<'a, Message>(
                         bounds.position(),
                         tcolor,
                         text_bounds,
-                        
                     );
                 }
             }

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -7,6 +7,7 @@
 //! A [`TextInput`] has some local [`State`].
 use std::borrow::Cow;
 use std::cell::{Cell, LazyCell};
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::ext::ColorExt;
 use crate::theme::THEME;
@@ -2561,6 +2562,63 @@ fn input_method<'b>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn render_graphemes(
+    value: &Value,
+    state: &State,
+    left: usize, 
+    right: usize, 
+    text: &str,
+    text_color: Color,
+    bounds: Rectangle,
+    size: f32,
+    renderer: &mut crate::Renderer,
+    font: iced_core::Font,
+) {
+    let lo_byte = value.byte_index_at_grapheme(left);
+    let hi_byte = value.byte_index_at_grapheme(right);
+
+    let rects = state.value.raw().highlight(
+        0,
+        (lo_byte, text::Affinity::After),
+        (hi_byte, text::Affinity::Before),
+    );
+
+    if !rects.is_empty() {
+        let grapheme_range = text[lo_byte..hi_byte].to_string();
+        let origin = bounds.position();
+
+        let start_pos = origin + (rects.first().unwrap().position() - Point::ORIGIN);
+
+        for rect in rects {
+            let absolute_rect = Rectangle {
+                x: rect.x + origin.x,
+                y: rect.y + origin.y,
+                width: rect.width,
+                height: rect.height,
+            };
+
+            renderer.fill_text(
+                Text {
+                    content: grapheme_range.clone(),
+                    font,
+                    bounds: bounds.size(), 
+                    size: iced::Pixels(size),
+                    align_x: text::Alignment::Default,
+                    align_y: alignment::Vertical::Center,
+                    line_height: text::LineHeight::default(),
+                    shaping: text::Shaping::Advanced,
+                    wrapping: text::Wrapping::None,
+                    ellipsize: text::Ellipsize::None,
+                },
+                start_pos,
+                text_color,
+                absolute_rect,
+            );
+        }
+    }
+}
+
 /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
 /// [`Value`] if provided.
 ///
@@ -2769,7 +2827,7 @@ pub fn draw<'a, Message>(
     let handling_dnd_offer = !matches!(state.dnd_offer, DndOfferState::None);
     #[cfg(not(wayland_platform))]
     let handling_dnd_offer = false;
-    let (cursors, offset, is_selecting) = if let Some(focus) =
+    let (cursors, offset, _) = if let Some(focus) =
         state.is_focused.filter(|f| f.focused).or_else(|| {
             let now = Instant::now();
             handling_dnd_offer.then_some(Focus {
@@ -2843,7 +2901,6 @@ pub fn draw<'a, Message>(
                         (lo_byte, text::Affinity::After),
                         (hi_byte, text::Affinity::Before),
                     );
-
                     let cursors: Vec<(renderer::Quad, Color)> = rects
                         .into_iter()
                         .map(|r| {
@@ -2897,7 +2954,7 @@ pub fn draw<'a, Message>(
             state.value.raw().min_width(),
             effective_alignment(state.value.raw()),
         );
-
+ 
         if cursors.is_empty() {
             renderer.with_translation(Vector::ZERO, |_| {});
         } else {
@@ -2914,33 +2971,80 @@ pub fn draw<'a, Message>(
             width: actual_width,
             ..text_bounds
         };
-        let color = if text.is_empty() {
+        let tcolor = if text.is_empty() {
             appearance.placeholder_color
         } else {
             text_color
         };
 
-        renderer.fill_text(
-            Text {
-                content: if text.is_empty() {
-                    placeholder.to_string()
+        match state.cursor.state(value) {
+            cursor::State::Index(..) => {
+                renderer.fill_text(
+                    Text {
+                        content: if text.is_empty() {
+                            placeholder.to_string()
+                        } else {
+                            text.clone()
+                        },
+                        font,
+                        bounds: bounds.size(),
+                        size: iced::Pixels(size),
+                        align_x: text::Alignment::Default,
+                        align_y: alignment::Vertical::Center,
+                        line_height: text::LineHeight::default(),
+                        shaping: text::Shaping::Advanced,
+                        wrapping: text::Wrapping::None,
+                        ellipsize: text::Ellipsize::None,
+                    },
+                    bounds.position(),
+                    tcolor,
+                    text_bounds,
+                    
+                );
+            }
+            cursor::State::Selection { start, end } => {
+                if state.is_focused() {
+                    let left = start.min(end);
+                    let right = end.max(start);
+                    let grapheme_len = text.graphemes(true).count();
+
+                    if left > 0 {
+                        render_graphemes(value, state,0,left, &text, tcolor, bounds, size, renderer, font);
+                    }
+
+                    if grapheme_len >= right {
+                        render_graphemes(value, state,left,right, &text, appearance.selected_text_color, bounds, size, renderer, font);
+                    }
+
+                    if left < grapheme_len {
+                        render_graphemes(value, state,right,grapheme_len, &text, tcolor, bounds, size, renderer, font);
+                    }
                 } else {
-                    text.clone()
-                },
-                font,
-                bounds: bounds.size(),
-                size: iced::Pixels(size),
-                align_x: text::Alignment::Default,
-                align_y: alignment::Vertical::Center,
-                line_height: text::LineHeight::default(),
-                shaping: text::Shaping::Advanced,
-                wrapping: text::Wrapping::None,
-                ellipsize: text::Ellipsize::None,
-            },
-            bounds.position(),
-            color,
-            text_bounds,
-        );
+                    renderer.fill_text(
+                        Text {
+                            content: if text.is_empty() {
+                                placeholder.to_string()
+                            } else {
+                                text.clone()
+                            },
+                            font,
+                            bounds: bounds.size(),
+                            size: iced::Pixels(size),
+                            align_x: text::Alignment::Default,
+                            align_y: alignment::Vertical::Center,
+                            line_height: text::LineHeight::default(),
+                            shaping: text::Shaping::Advanced,
+                            wrapping: text::Wrapping::None,
+                            ellipsize: text::Ellipsize::None,
+                        },
+                        bounds.position(),
+                        tcolor,
+                        text_bounds,
+                        
+                    );
+                }
+            }
+        }
     };
 
     // FIXME: we always must clip with a layer because of what appears to be a tiny-skia text clipping issue.


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Fixed rendering  font color for text_input widget in "selected" mode

before:
<img width="276" height="162" alt="image" src="https://github.com/user-attachments/assets/68d971d3-757e-4ae9-8f62-131452870382" />

after:
<img width="236" height="140" alt="image" src="https://github.com/user-attachments/assets/4667e9ff-ba4b-4085-8c19-a3dc6abb939e" />

tested:
- selection at begin
<img width="212" height="106" alt="image" src="https://github.com/user-attachments/assets/06ecdfd6-7955-4128-b062-1c766f9d9db3" />

- selection at the end
<img width="267" height="164" alt="image" src="https://github.com/user-attachments/assets/2113769d-221b-4b8e-8cee-6be2a0c453eb" />

- selection in the middle
<img width="281" height="136" alt="image" src="https://github.com/user-attachments/assets/a5c6adf6-0ddc-4d55-b349-526695917175" />


