### PR TITLE
perf(cosmic-config): batch theme write transactions

### DIFF
--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -461,18 +461,73 @@ pub struct ConfigTransaction<'a> {
 
 impl ConfigTransaction<'_> {
     /// Apply all pending changes from ConfigTransaction
-    //TODO: apply all changes at once
     pub fn commit(self) -> Result<(), Error> {
-        let mut updates = self.updates.lock().unwrap();
-        for (key_path, data) in updates.drain(..) {
-            atomicwrites::AtomicFile::new(
-                key_path,
-                atomicwrites::OverwriteBehavior::AllowOverwrite,
-            )
-            .write(|file| file.write_all(data.as_bytes()))?;
-        }
-        Ok(())
+        let updates = self.updates.lock().unwrap().drain(..).collect::<Vec<_>>();
+        write_updates(updates).map_err(Error::Io)
     }
+}
+
+/// Atomically write all updates, using one fsync per staged file and one fsync
+/// per distinct parent directory instead of one transaction per key.
+fn write_updates(updates: Vec<(PathBuf, String)>) -> std::io::Result<()> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    let pid = std::process::id();
+    let mut staged: Vec<(PathBuf, PathBuf)> = Vec::with_capacity(updates.len());
+
+    let staged_result = updates
+        .iter()
+        .enumerate()
+        .try_for_each(|(index, (key_path, data))| {
+            let dir = key_path.parent().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "key path has no parent directory",
+                )
+            })?;
+            let temp_path = dir.join(format!(".cosmic-config-{pid}-{index}.tmp"));
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            file.write_all(data.as_bytes())?;
+            file.sync_all()?;
+            staged.push((temp_path, key_path.clone()));
+            Ok(())
+        });
+
+    if staged_result.is_err() {
+        for (temp_path, _) in staged {
+            let _ = fs::remove_file(temp_path);
+        }
+        return staged_result;
+    }
+
+    let renamed_result = staged
+        .iter()
+        .try_for_each(|(temp_path, key_path)| fs::rename(temp_path, key_path));
+
+    if renamed_result.is_err() {
+        for (temp_path, _) in &staged {
+            let _ = fs::remove_file(temp_path);
+        }
+        return renamed_result;
+    }
+
+    let mut synced_dirs: Vec<PathBuf> = Vec::new();
+    for (_, key_path) in &staged {
+        if let Some(dir) = key_path.parent() {
+            if synced_dirs.iter().any(|synced| synced == dir) {
+                continue;
+            }
+            fs::File::open(dir)?.sync_all()?;
+            synced_dirs.push(dir.to_path_buf());
+        }
+    }
+
+    Ok(())
 }
 
 // Setting any setting in this way will do one transaction for all settings

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -471,59 +471,55 @@ impl ConfigTransaction<'_> {
 /// per distinct parent directory instead of one transaction per key.
 fn write_updates(updates: impl Iterator<Item = (PathBuf, String)>) -> std::io::Result<()> {
     let pid = std::process::id();
-    let mut staged: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut staged: Vec<(fs::File, PathBuf, PathBuf)> = Vec::new();
 
-    let staged_result =
-        updates
-            .enumerate()
-            .try_for_each(|(index, (key_path, data))| {
-                let dir = key_path.parent().ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "key path has no parent directory",
-                    )
-                })?;
-                let temp_path = dir.join(format!(".cosmic-config-{pid}-{index}.tmp"));
-                let mut file = fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(&temp_path)?;
-                file.write_all(data.as_bytes())?;
-                file.sync_all()?;
-                staged.push((temp_path, key_path));
-                Ok(())
-            });
+    let staged_result = updates
+        .enumerate()
+        .try_for_each(|(index, (key_path, data))| {
+            let dir = key_path.parent().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "key path has no parent directory",
+                )
+            })?;
+            let temp_path = dir.join(format!(".cosmic-config-{pid}-{index}.tmp"));
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            file.write_all(data.as_bytes())?;
+            staged.push((file, temp_path, key_path));
+            Ok(())
+        });
 
-    if staged_result.is_err() {
-        for (temp_path, _) in staged {
-            let _ = fs::remove_file(temp_path);
-        }
-        return staged_result;
-    }
+    let result = staged_result.and_then(|()| {
+        staged.iter().try_for_each(|(file, _, _)| file.sync_all())?;
 
-    let renamed_result = staged
-        .iter()
-        .try_for_each(|(temp_path, key_path)| fs::rename(temp_path, key_path));
+        staged
+            .iter()
+            .try_for_each(|(_, temp_path, key_path)| fs::rename(temp_path, key_path))?;
 
-    if renamed_result.is_err() {
-        for (temp_path, _) in &staged {
-            let _ = fs::remove_file(temp_path);
-        }
-        return renamed_result;
-    }
-
-    let mut synced_dirs: Vec<PathBuf> = Vec::new();
-    for (_, key_path) in &staged {
-        if let Some(dir) = key_path.parent() {
-            if synced_dirs.iter().any(|synced| synced == dir) {
-                continue;
+        let mut synced_dirs: Vec<PathBuf> = Vec::new();
+        staged.iter().try_for_each(|(_, _, key_path)| {
+            if let Some(dir) = key_path.parent() {
+                if synced_dirs.iter().any(|synced| synced == dir) {
+                    return Ok(());
+                }
+                fs::File::open(dir)?.sync_all()?;
+                synced_dirs.push(dir.to_path_buf());
             }
-            fs::File::open(dir)?.sync_all()?;
-            synced_dirs.push(dir.to_path_buf());
+            Ok(())
+        })
+    });
+
+    if result.is_err() {
+        for (file, temp_path, _) in staged {
+            drop(file);
+            let _ = fs::remove_file(temp_path);
         }
     }
 
-    Ok(())
+    result
 }
 
 // Setting any setting in this way will do one transaction for all settings

--- a/cosmic-config/src/lib.rs
+++ b/cosmic-config/src/lib.rs
@@ -462,41 +462,37 @@ pub struct ConfigTransaction<'a> {
 impl ConfigTransaction<'_> {
     /// Apply all pending changes from ConfigTransaction
     pub fn commit(self) -> Result<(), Error> {
-        let updates = self.updates.lock().unwrap().drain(..).collect::<Vec<_>>();
-        write_updates(updates).map_err(Error::Io)
+        let mut updates = self.updates.lock().unwrap();
+        write_updates(updates.drain(..)).map_err(Error::Io)
     }
 }
 
 /// Atomically write all updates, using one fsync per staged file and one fsync
 /// per distinct parent directory instead of one transaction per key.
-fn write_updates(updates: Vec<(PathBuf, String)>) -> std::io::Result<()> {
-    if updates.is_empty() {
-        return Ok(());
-    }
-
+fn write_updates(updates: impl Iterator<Item = (PathBuf, String)>) -> std::io::Result<()> {
     let pid = std::process::id();
-    let mut staged: Vec<(PathBuf, PathBuf)> = Vec::with_capacity(updates.len());
+    let mut staged: Vec<(PathBuf, PathBuf)> = Vec::new();
 
-    let staged_result = updates
-        .iter()
-        .enumerate()
-        .try_for_each(|(index, (key_path, data))| {
-            let dir = key_path.parent().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "key path has no parent directory",
-                )
-            })?;
-            let temp_path = dir.join(format!(".cosmic-config-{pid}-{index}.tmp"));
-            let mut file = fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&temp_path)?;
-            file.write_all(data.as_bytes())?;
-            file.sync_all()?;
-            staged.push((temp_path, key_path.clone()));
-            Ok(())
-        });
+    let staged_result =
+        updates
+            .enumerate()
+            .try_for_each(|(index, (key_path, data))| {
+                let dir = key_path.parent().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "key path has no parent directory",
+                    )
+                })?;
+                let temp_path = dir.join(format!(".cosmic-config-{pid}-{index}.tmp"));
+                let mut file = fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&temp_path)?;
+                file.write_all(data.as_bytes())?;
+                file.sync_all()?;
+                staged.push((temp_path, key_path));
+                Ok(())
+            });
 
     if staged_result.is_err() {
         for (temp_path, _) in staged {


### PR DESCRIPTION
## Problem

`ConfigTransaction::commit` performs two fsync operations per file, which is really slow; a single theme change (~60ish keys) takes 183 fsyncs and 630ms.

This was noticed while working on [cosmic-theme-import](https://github.com/ByteAtATime/cosmic-theme-import), which takes ~1 second without this patch and about half a second with it.

## Results

Theme change:

| | master | this patch |
|---|---|---|
| fsync count | 183 | 62 (61 files + 1 dir) |
| commit latency | ~610 ms | ~310 ms |

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.