### PR TITLE
fix: keep content's overlays visible while showing toaster

### DIFF
--- a/src/widget/toaster/widget.rs
+++ b/src/widget/toaster/widget.rs
@@ -142,23 +142,26 @@ where
         viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        //TODO: this hides the overlay of the content during the toast
+        let (content_state, toasts_state) = state.children.split_at_mut(1);
+        let content = self.content.as_widget_mut().overlay(
+            &mut content_state[0],
+            layout,
+            renderer,
+            viewport,
+            translation,
+        );
         if self.is_empty {
-            self.content.as_widget_mut().overlay(
-                &mut state.children[0],
-                layout,
-                renderer,
-                viewport,
-                translation,
-            )
-        } else {
-            let bounds = layout.bounds();
-
-            Some(overlay::Element::new(Box::new(ToasterOverlay::new(
-                &mut state.children[1],
-                &mut self.toasts,
-            ))))
+            return content;
         }
+        // keep the content's overlays (e.g. popovers, menus) visible while a toast is shown
+        let toaster = overlay::Element::new(Box::new(ToasterOverlay::new(
+            &mut toasts_state[0],
+            &mut self.toasts,
+        )));
+        Some(match content {
+            Some(content) => overlay::Group::with_children(vec![content, toaster]).overlay(),
+            None => toaster,
+        })
     }
 
     fn drag_destinations(


### PR DESCRIPTION
Needed for https://github.com/pop-os/cosmic-viewer/issues/35.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

