### PR TITLE
feat: add fixed time for auto switching theme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ apply = "0.3.0"
 async-fs = { version = "2.2", optional = true }
 async-std = { workspace = true, optional = true }
 auto_enums = "0.8.8"
-jiff = "0.2"
+jiff.workspace = true
 cosmic-config = { path = "cosmic-config" }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", optional = true }
 # Internationalization
@@ -251,6 +251,7 @@ dirs = "6.0"
 palette = "0.7"
 ron = "0.12"
 serde = "1.0"
+jiff = "0.2"
 thiserror = "2.0"
 tracing = "0.1"
 tokio = "1.52"

--- a/cosmic-theme/Cargo.toml
+++ b/cosmic-theme/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1.0.149", optional = true, features = [
     "preserve_order",
 ] }
 ron.workspace = true
+jiff = {workspace = true, features = ["serde"]}
 csscolorparser = { version = "0.8.3", features = ["serde"] }
 cosmic-config = { path = "../cosmic-config/", default-features = false, features = [
     "subscription",

--- a/cosmic-theme/src/model/mode.rs
+++ b/cosmic-theme/src/model/mode.rs
@@ -1,4 +1,5 @@
 use cosmic_config::{Config, ConfigGet, CosmicConfigEntry};
+use jiff::civil::Time;
 
 /// ID for the ThemeMode config
 pub const THEME_MODE_ID: &str = "com.system76.CosmicTheme.Mode";
@@ -7,12 +8,16 @@ pub const THEME_MODE_ID: &str = "com.system76.CosmicTheme.Mode";
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, cosmic_config::cosmic_config_derive::CosmicConfigEntry,
 )]
-#[version = 1]
+#[version = 2]
 pub struct ThemeMode {
     /// The theme dark mode setting.
     pub is_dark: bool,
     /// The theme auto-switch dark and light mode setting.
     pub auto_switch: bool,
+    /// The theme will switch based on fixed timestamps.
+    pub auto_switch_fixed_source: bool,
+    pub auto_switch_dark_from: Option<Time>,
+    pub auto_switch_dark_to: Option<Time>,
 }
 
 impl Default for ThemeMode {
@@ -21,6 +26,9 @@ impl Default for ThemeMode {
         Self {
             is_dark: true,
             auto_switch: false,
+            auto_switch_fixed_source: false,
+            auto_switch_dark_from: None,
+            auto_switch_dark_to: None,
         }
     }
 }


### PR DESCRIPTION
Introducing time field to switch dark theme based on them. 

pop-os/cosmic-settings-daemon#189

I’m wondering if it’s right to place these new fields in `ThemeMode`. For me `auto_switch_fixed_source` belong there, but what about the time fields ? 

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

