### PR TITLE
feat: add focus mark for menu item

### DIFF
--- a/examples/context-menu/src/main.rs
+++ b/examples/context-menu/src/main.rs
@@ -142,6 +142,12 @@ impl App {
                             self.hide_content,
                             ContextMenuAction::ToggleSomeAction,
                         ),
+                        menu::Item::CheckBox(
+                            "Test content2",
+                            None,
+                            self.hide_content,
+                            ContextMenuAction::ToggleSomeAction,
+                        ),
                     ],
                 ),
                 menu::Item::Divider,

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -44,6 +44,8 @@ pub static TRANSPARENT_COMPONENT: LazyLock<Component> = LazyLock::new(|| Compone
     disabled_border: CosmicColor::new(0.0, 0.0, 0.0, 0.0),
 });
 
+pub const FOCUSED_BORDER_WIDTH: f32 = 1.00;
+
 pub(crate) static THEME: Mutex<Theme> = Mutex::new(Theme {
     theme_type: ThemeType::Dark,
     layer: cosmic_theme::Layer::Background,

--- a/src/theme/style/button.rs
+++ b/src/theme/style/button.rs
@@ -37,6 +37,7 @@ pub enum Button {
     Transparent,
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn appearance(
     theme: &crate::Theme,
     focused: bool,
@@ -179,7 +180,7 @@ pub fn appearance(
     appearance.border_radius = (*corner_radii).into();
 
     if focused {
-        appearance.outline_width = 1.0;
+        appearance.outline_width = crate::theme::FOCUSED_BORDER_WIDTH;
         appearance.outline_color = cosmic.accent.base.into();
         appearance.border_width = 2.0;
         appearance.border_color = Color::TRANSPARENT;

--- a/src/widget/button/widget.rs
+++ b/src/widget/button/widget.rs
@@ -10,7 +10,7 @@ use iced::Alignment;
 use iced_runtime::core::widget::Id;
 use iced_runtime::{Action, Task, keyboard, task};
 
-use iced_core::event::{self, Event};
+use iced_core::event::Event;
 use iced_core::renderer::{self, Quad, Renderer};
 use iced_core::widget::Operation;
 use iced_core::widget::tree::{self, Tree};
@@ -418,7 +418,7 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
             self.on_press.as_deref(),
             self.on_press_down.as_deref(),
             || tree.state.downcast_mut::<State>(),
-        )
+        );
     }
 
     #[allow(clippy::too_many_lines)]
@@ -463,7 +463,11 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
                 if !self.selected && matches!(self.style, crate::theme::Button::HeaderBar) {
                     headerbar_alpha = Some(0.8);
                 }
-                theme.hovered(state.is_focused, self.selected, &self.style)
+                let is_focused = matches!(
+                    self.style,
+                    crate::theme::Button::MenuItem | crate::theme::Button::MenuFolder
+                ) | state.is_focused;
+                theme.hovered(is_focused, self.selected, &self.style)
             }
         } else {
             if !self.selected && matches!(self.style, crate::theme::Button::HeaderBar) {
@@ -472,6 +476,15 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
 
             theme.active(state.is_focused, self.selected, &self.style)
         };
+        let draw_bounds = if matches!(
+            self.style,
+            crate::theme::Button::MenuItem | crate::theme::Button::MenuFolder
+        ) {
+            bounds.shrink(Padding::new(4.0))
+        } else {
+            bounds
+        };
+
         if matches!(
             self.style,
             crate::theme::Button::MenuItem | crate::theme::Button::MenuFolder
@@ -507,11 +520,12 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
 
         draw::<_, crate::Theme>(
             renderer,
-            bounds,
+            draw_bounds,
             *viewport,
             &styling,
             |renderer, _styling| {
-                self.content.as_widget().draw(
+                let widget = self.content.as_widget();
+                widget.draw(
                     &tree.children[0],
                     renderer,
                     theme,
@@ -522,7 +536,7 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
                     },
                     content_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
-                    &viewport.intersection(&bounds).unwrap_or_default(),
+                    &viewport.intersection(&draw_bounds).unwrap_or_default(),
                 );
             },
             matches!(self.variant, Variant::Image { .. }),
@@ -681,7 +695,6 @@ impl<'a, Message: 'a + Clone> Widget<Message, crate::Theme, crate::Renderer>
             height,
         } = layout.bounds();
         let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
-        let is_hovered = state.state.downcast_ref::<State>().is_hovered;
 
         let mut node = Node::new(Role::Button);
         node.add_action(Action::Focus);

--- a/src/widget/menu/menu_inner.rs
+++ b/src/widget/menu/menu_inner.rs
@@ -825,14 +825,17 @@ impl<'b, Message: Clone + 'static> Menu<'b, Message> {
                                         rad = rad_0;
                                     }
                                 }
+                                let cosmic = theme.cosmic();
                                 let path_quad = renderer::Quad {
                                     bounds: active_layout
                                         .bounds()
+                                        .shrink(Padding::new(1.0))
                                         .intersection(&viewport)
                                         .unwrap_or_default(),
                                     border: Border {
                                         radius: rad.into(),
-                                        ..Default::default()
+                                        width: crate::theme::FOCUSED_BORDER_WIDTH,
+                                        color: cosmic.accent.base.into(),
                                     },
                                     shadow: Shadow::default(),
                                     snap: true,

--- a/src/widget/wrapper.rs
+++ b/src/widget/wrapper.rs
@@ -158,8 +158,8 @@ impl<M> Widget<M, crate::Theme, crate::Renderer> for RcElementWrapper<M> {
         self.element.with_data_mut(|e| {
             e.as_widget_mut().update(
                 state, event, layout, cursor, renderer, clipboard, shell, viewport,
-            )
-        })
+            );
+        });
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

1. A menu item doesn't have any mark when it is focused, which is very inconvenient. I suggest adding a border as a mark. I have reused the behavior of the border from the file "src/theme/style/button.rs", function "appearance", which is already used to style the menu item. 
BEFORE:
<img width="649" height="265" alt="image" src="https://github.com/user-attachments/assets/5dca6978-ffdd-4a03-87e8-bf92cfea84a9" />

AFTER:
<img width="610" height="250" alt="image" src="https://github.com/user-attachments/assets/0de379d0-06b4-47d6-bf25-5310e56f1f57" />

2. Fixed some linter's warnings in files which are used in "1".