### PR TITLE
Fix text selection color

### DIFF
--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -2920,27 +2920,39 @@ pub fn draw<'a, Message>(
             text_color
         };
 
-        renderer.fill_text(
-            Text {
-                content: if text.is_empty() {
-                    placeholder.to_string()
-                } else {
-                    text.clone()
-                },
-                font,
-                bounds: bounds.size(),
-                size: iced::Pixels(size),
-                align_x: text::Alignment::Default,
-                align_y: alignment::Vertical::Center,
-                line_height: text::LineHeight::default(),
-                shaping: text::Shaping::Advanced,
-                wrapping: text::Wrapping::None,
-                ellipsize: text::Ellipsize::None,
+        let text = Text {
+            content: if text.is_empty() {
+                placeholder.to_string()
+            } else {
+                text.clone()
             },
-            bounds.position(),
-            color,
-            text_bounds,
-        );
+            font,
+            bounds: bounds.size(),
+            size: iced::Pixels(size),
+            align_x: text::Alignment::Default,
+            align_y: alignment::Vertical::Center,
+            line_height: text::LineHeight::default(),
+            shaping: text::Shaping::Advanced,
+            wrapping: text::Wrapping::None,
+            ellipsize: text::Ellipsize::None,
+        };
+        renderer.fill_text(text.clone(), bounds.position(), color, text_bounds);
+
+        // Redraw the same text in the selected color, clipped to the selection quads,
+        // so glyph shaping and positioning stay identical to the unselected pass.
+        if is_selecting {
+            let shift = Vector::new(alignment_offset - offset, 0.0);
+            for (quad, _) in &cursors {
+                renderer.with_layer(quad.bounds + shift, |renderer| {
+                    renderer.fill_text(
+                        text.clone(),
+                        bounds.position(),
+                        appearance.selected_text_color,
+                        text_bounds,
+                    );
+                });
+            }
+        }
     };
 
     // FIXME: we always must clip with a layer because of what appears to be a tiny-skia text clipping issue.

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -7,7 +7,6 @@
 //! A [`TextInput`] has some local [`State`].
 use std::borrow::Cow;
 use std::cell::{Cell, LazyCell};
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::ext::ColorExt;
 use crate::theme::THEME;
@@ -2562,63 +2561,6 @@ fn input_method<'b>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn render_graphemes(
-    value: &Value,
-    state: &State,
-    left: usize,
-    right: usize,
-    text: &str,
-    text_color: Color,
-    bounds: Rectangle,
-    size: f32,
-    renderer: &mut crate::Renderer,
-    font: iced_core::Font,
-) {
-    let lo_byte = value.byte_index_at_grapheme(left);
-    let hi_byte = value.byte_index_at_grapheme(right);
-
-    let rects = state.value.raw().highlight(
-        0,
-        (lo_byte, text::Affinity::After),
-        (hi_byte, text::Affinity::Before),
-    );
-
-    if !rects.is_empty() {
-        let grapheme_range = text[lo_byte..hi_byte].to_string();
-        let origin = bounds.position();
-
-        let start_pos = origin + (rects.first().unwrap().position() - Point::ORIGIN);
-
-        for rect in rects {
-            let absolute_rect = Rectangle {
-                x: rect.x + origin.x,
-                y: rect.y + origin.y,
-                width: rect.width,
-                height: rect.height,
-            };
-
-            renderer.fill_text(
-                Text {
-                    content: grapheme_range.clone(),
-                    font,
-                    bounds: bounds.size(),
-                    size: iced::Pixels(size),
-                    align_x: text::Alignment::Default,
-                    align_y: alignment::Vertical::Center,
-                    line_height: text::LineHeight::default(),
-                    shaping: text::Shaping::Advanced,
-                    wrapping: text::Wrapping::None,
-                    ellipsize: text::Ellipsize::None,
-                },
-                start_pos,
-                text_color,
-                absolute_rect,
-            );
-        }
-    }
-}
-
 /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
 /// [`Value`] if provided.
 ///
@@ -2827,7 +2769,7 @@ pub fn draw<'a, Message>(
     let handling_dnd_offer = !matches!(state.dnd_offer, DndOfferState::None);
     #[cfg(not(wayland_platform))]
     let handling_dnd_offer = false;
-    let (cursors, offset, _) = if let Some(focus) =
+    let (cursors, offset, is_selecting) = if let Some(focus) =
         state.is_focused.filter(|f| f.focused).or_else(|| {
             let now = Instant::now();
             handling_dnd_offer.then_some(Focus {
@@ -2901,6 +2843,7 @@ pub fn draw<'a, Message>(
                         (lo_byte, text::Affinity::After),
                         (hi_byte, text::Affinity::Before),
                     );
+
                     let cursors: Vec<(renderer::Quad, Color)> = rects
                         .into_iter()
                         .map(|r| {
@@ -2954,6 +2897,7 @@ pub fn draw<'a, Message>(
             state.value.raw().min_width(),
             effective_alignment(state.value.raw()),
         );
+
         if cursors.is_empty() {
             renderer.with_translation(Vector::ZERO, |_| {});
         } else {
@@ -2970,77 +2914,33 @@ pub fn draw<'a, Message>(
             width: actual_width,
             ..text_bounds
         };
-        let tcolor = if text.is_empty() {
+        let color = if text.is_empty() {
             appearance.placeholder_color
         } else {
             text_color
         };
 
-        if let cursor::State::Selection { start, end } = state.cursor.state(value)
-            && state.is_focused()
-        {
-            let left = start.min(end);
-            let right = end.max(start);
-            let grapheme_len = text.graphemes(true).count();
-
-            if left > 0 {
-                render_graphemes(
-                    value, state, 0, left, &text, tcolor, bounds, size, renderer, font,
-                );
-            }
-
-            if grapheme_len >= right {
-                render_graphemes(
-                    value,
-                    state,
-                    left,
-                    right,
-                    &text,
-                    appearance.selected_text_color,
-                    bounds,
-                    size,
-                    renderer,
-                    font,
-                );
-            }
-
-            if left < grapheme_len {
-                render_graphemes(
-                    value,
-                    state,
-                    right,
-                    grapheme_len,
-                    &text,
-                    tcolor,
-                    bounds,
-                    size,
-                    renderer,
-                    font,
-                );
-            }
-        } else {
-            renderer.fill_text(
-                Text {
-                    content: if text.is_empty() {
-                        placeholder.to_string()
-                    } else {
-                        text.clone()
-                    },
-                    font,
-                    bounds: bounds.size(),
-                    size: iced::Pixels(size),
-                    align_x: text::Alignment::Default,
-                    align_y: alignment::Vertical::Center,
-                    line_height: text::LineHeight::default(),
-                    shaping: text::Shaping::Advanced,
-                    wrapping: text::Wrapping::None,
-                    ellipsize: text::Ellipsize::None,
+        renderer.fill_text(
+            Text {
+                content: if text.is_empty() {
+                    placeholder.to_string()
+                } else {
+                    text.clone()
                 },
-                bounds.position(),
-                tcolor,
-                text_bounds,
-            );
-        }
+                font,
+                bounds: bounds.size(),
+                size: iced::Pixels(size),
+                align_x: text::Alignment::Default,
+                align_y: alignment::Vertical::Center,
+                line_height: text::LineHeight::default(),
+                shaping: text::Shaping::Advanced,
+                wrapping: text::Wrapping::None,
+                ellipsize: text::Ellipsize::None,
+            },
+            bounds.position(),
+            color,
+            text_bounds,
+        );
     };
 
     // FIXME: we always must clip with a layer because of what appears to be a tiny-skia text clipping issue.


### PR DESCRIPTION
Looks like https://github.com/pop-os/libcosmic/pull/1409 is dividing the text into 3 chunks of not-selected, selected, and not-selected and redrawing the graphemes, that doesn't work for mixed bidi-text. Also another bug is causing the text to be drawn with the wrong y.

This fixes the issue, by redrawing the selected text over the original text and clipping it to the selection quads.


Before:
<img width="553" height="204" alt="Screenshot_2026-09-10_11-05-14" src="https://github.com/user-attachments/assets/bc47bbe4-e64e-4a8f-87b7-57a076e39651" />

<img width="663" height="282" alt="Screenshot_2026-09-10_11-58-14" src="https://github.com/user-attachments/assets/add5e41f-1c44-4f40-a3db-2c08e27f3c51" />


After:

<img width="575" height="238" alt="Screenshot_2026-09-10_11-59-15" src="https://github.com/user-attachments/assets/4ae92aa0-0526-4a2f-9056-bd5b435755c9" />


Alternative approach is to set the color of the text span and let cosmic-text handle it, but that means everything should become rich-text and that's more expensive than redrawing the text over the original one.


____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

