### PR TITLE
feat(text_context_menu): always show items, but disable them

### DIFF
--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -355,6 +355,8 @@ impl<'a, Message: Clone + 'static> Widget<Message, crate::Theme, Renderer> for S
                         selected_text,
                         false,
                         has_selection,
+                        self.inner.has_text(&tree.children[0]),
+                        self.inner.clipboard_has_text(&tree.children[0]),
                         &menu_bar_state,
                         &pending_action,
                         renderer,

--- a/src/widget/text_context_menu.rs
+++ b/src/widget/text_context_menu.rs
@@ -217,7 +217,12 @@ where
     let selected_text = widget.selected_text(tree);
     let is_editable = widget.is_editable();
 
-    let mut menu_roots = build_menu_roots(is_editable, selected_text.is_some());
+    let mut menu_roots = build_menu_roots(
+        is_editable,
+        selected_text.is_some(),
+        widget.has_text(tree),
+        widget.clipboard_has_text(tree),
+    );
     menu_roots.iter_mut().for_each(menu::Tree::set_index);
 
     let bounds = Rectangle {
@@ -283,28 +288,28 @@ pub(crate) enum TextCtxAction {
     SelectAll,
 }
 
-fn build_menu_roots(is_editable: bool, has_selection: bool) -> Vec<menu::Tree<TextCtxAction>> {
-    let mut items = Vec::with_capacity(4);
+fn build_menu_roots(
+    is_editable: bool,
+    has_selection: bool,
+    has_text: bool,
+    clipboard_has_text: bool,
+) -> Vec<menu::Tree<TextCtxAction>> {
+    let item = |label: &'static str, action: TextCtxAction, enabled: bool| {
+        menu::Tree::from(crate::Element::from(
+            menu::menu_button(vec![widget::text(label).into()])
+                .on_press_maybe(enabled.then_some(action)),
+        ))
+    };
 
-    if is_editable && has_selection {
-        items.push(menu::Tree::from(crate::Element::from(
-            menu::menu_button(vec![widget::text("Cut").into()]).on_press(TextCtxAction::Cut),
-        )));
-    }
-    if has_selection {
-        items.push(menu::Tree::from(crate::Element::from(
-            menu::menu_button(vec![widget::text("Copy").into()]).on_press(TextCtxAction::Copy),
-        )));
-    }
+    let mut items = Vec::with_capacity(4);
     if is_editable {
-        items.push(menu::Tree::from(crate::Element::from(
-            menu::menu_button(vec![widget::text("Paste").into()]).on_press(TextCtxAction::Paste),
-        )));
+        items.push(item("Cut", TextCtxAction::Cut, has_selection));
     }
-    items.push(menu::Tree::from(crate::Element::from(
-        menu::menu_button(vec![widget::text("Select All").into()])
-            .on_press(TextCtxAction::SelectAll),
-    )));
+    items.push(item("Copy", TextCtxAction::Copy, has_selection));
+    if is_editable {
+        items.push(item("Paste", TextCtxAction::Paste, clipboard_has_text));
+    }
+    items.push(item("Select All", TextCtxAction::SelectAll, has_text));
 
     vec![menu::Tree::with_children(
         RcElementWrapper::new(crate::Element::from(widget::Row::new())),
@@ -486,6 +491,8 @@ pub(crate) fn create_text_context_popup(
     selected_text: Option<String>,
     is_editable: bool,
     has_selection: bool,
+    has_text: bool,
+    clipboard_has_text: bool,
     menu_bar_state: &MenuBarState,
     pending_action: &PendingAction,
     renderer: &crate::Renderer,
@@ -499,7 +506,7 @@ pub(crate) fn create_text_context_popup(
         return;
     }
 
-    let mut menu_roots = build_menu_roots(is_editable, has_selection);
+    let mut menu_roots = build_menu_roots(is_editable, has_selection, has_text, clipboard_has_text);
     menu_roots.iter_mut().for_each(menu::Tree::set_index);
 
     let id = menu_bar_state.inner.with_data_mut(|state| {

--- a/src/widget/text_editor.rs
+++ b/src/widget/text_editor.rs
@@ -297,6 +297,8 @@ impl<'a, Message: Clone + 'static> Widget<Message, crate::Theme, crate::Renderer
                         selected_text,
                         self.inner.is_editable(),
                         has_selection,
+                        self.inner.has_text(&tree.children[0]),
+                        self.inner.clipboard_has_text(&tree.children[0]),
                         &menu_bar_state,
                         &pending_action,
                         renderer,

--- a/src/widget/text_input/input.rs
+++ b/src/widget/text_input/input.rs
@@ -1054,6 +1054,8 @@ where
                     .selection(&state.tracked_value)
                     .map(|(start, end)| state.tracked_value.select(start, end).to_string());
                 let has_selection = selected_text.is_some();
+                let has_text = !state.tracked_value.is_empty();
+                let clipboard_has_text = state.clipboard_has_text;
                 let click_position = state.context_menu_position.unwrap();
                 let menu_bar_state = state.menu_bar_state.clone();
                 let pending_action = state.pending_action.clone();
@@ -1063,6 +1065,8 @@ where
                     selected_text,
                     true,
                     has_selection,
+                    has_text,
+                    clipboard_has_text,
                     &menu_bar_state,
                     &pending_action,
                     renderer,
@@ -1617,6 +1621,7 @@ pub fn update<'a, Message: Clone + 'static>(
                     state.focus();
                 }
                 state.context_menu_position = Some(pos);
+                state.clipboard_has_text = iced_core::widget::text::clipboard_has_text(clipboard);
                 shell.capture_event();
                 return;
             }
@@ -3096,6 +3101,7 @@ pub struct State {
     keyboard_modifiers: keyboard::Modifiers,
     scroll_offset: f32,
     context_menu_position: Option<iced_core::Point>,
+    clipboard_has_text: bool,
     pub(crate) menu_bar_state: crate::widget::menu::MenuBarState,
     pub(crate) pending_action: crate::widget::text_context_menu::PendingAction,
 }
@@ -3191,6 +3197,7 @@ impl State {
             scroll_offset: 0.0,
             dirty: false,
             context_menu_position: None,
+            clipboard_has_text: false,
             menu_bar_state: crate::widget::menu::MenuBarState::default(),
             pending_action: crate::widget::text_context_menu::pending_action(),
         }
@@ -3552,6 +3559,14 @@ impl<Message: Clone + 'static> iced_core::widget::text::HasSelectableText
 
     fn is_editable(&self) -> bool {
         true
+    }
+
+    fn has_text(&self, tree: &WidgetTree) -> bool {
+        !tree.state.downcast_ref::<State>().tracked_value.is_empty()
+    }
+
+    fn clipboard_has_text(&self, tree: &WidgetTree) -> bool {
+        tree.state.downcast_ref::<State>().clipboard_has_text
     }
 
     fn is_focused(&self, tree: &WidgetTree) -> bool {


### PR DESCRIPTION
Depends on
- [x] https://github.com/pop-os/iced/pull/391

Currently when you rightclick inside a textbox "paste" always is available, even if nothing is in the clipboard. Select all is always available even if no text is in the input. If we don't show those items, then when you rightclick nothing will be shown if there is no text in the text input and nothing in the clipboard.

Instead I changed the logic to always show all 4 items (copy, cut, paste, select all) in text edit but disable them if they don't apply.

And for selectable text in labels, it will always show copy, and select all, but disables them if it doesn't apply.

fixes https://github.com/pop-os/libcosmic/issues/1423
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

